### PR TITLE
Add liveness checks for kubernetes deployment

### DIFF
--- a/code/datalab-app/app.Dockerfile
+++ b/code/datalab-app/app.Dockerfile
@@ -2,4 +2,6 @@ FROM nginx:1.13.0
 
 LABEL maintainer "joshua.foster@stfc.ac.uk"
 
+COPY ./app.nginx.config /etc/nginx/conf.d/default.conf
+
 COPY ./dist/app /usr/share/nginx/html

--- a/code/datalab-app/app.nginx.config
+++ b/code/datalab-app/app.nginx.config
@@ -4,9 +4,6 @@ server {
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;
-    expires -1;
-    add_header Pragma "no-cache";
-    add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
-    try_files $uri$args $uri$args/ $uri $uri/ /index.html =404;
+    try_files $uri /index.html;
   }
 }

--- a/code/datalab-app/app.nginx.config
+++ b/code/datalab-app/app.nginx.config
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  server_name localhost;
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    expires -1;
+    add_header Pragma "no-cache";
+    add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
+    try_files $uri$args $uri$args/ $uri $uri/ /index.html =404;
+  }
+}

--- a/code/datalab-app/src/api/api.js
+++ b/code/datalab-app/src/api/api.js
@@ -4,6 +4,7 @@ import { graphqlExpress, graphiqlExpress } from 'graphql-server-express';
 import configureCorsHeaders from './corsConfig';
 import schema from './schema/index';
 import config from './config';
+import status from './status';
 
 const port = config.get('apiPort');
 
@@ -16,6 +17,7 @@ configureCorsHeaders(app);
 app.use(bodyParser.json());
 
 app.use('/api', api);
+app.get('/status', status.get);
 
 if (process.env.NODE_ENV !== 'production') {
   app.use('/graphiql', graphiql);

--- a/code/datalab-app/src/api/status.js
+++ b/code/datalab-app/src/api/status.js
@@ -1,0 +1,10 @@
+import version from './version';
+
+function get(req, res) {
+  res.json({
+    message: 'I am alive!',
+    version,
+  });
+}
+
+export default { get };

--- a/code/datalab-app/src/api/status.js
+++ b/code/datalab-app/src/api/status.js
@@ -2,7 +2,7 @@ import version from './version';
 
 function get(req, res) {
   res.json({
-    message: 'I am alive!',
+    message: 'OK',
     version,
   });
 }

--- a/code/provision/kubernetes/datalab-api-deployment.yml
+++ b/code/provision/kubernetes/datalab-api-deployment.yml
@@ -12,8 +12,15 @@ spec:
       containers:
         - name: datalab-api
           image: nerc/datalab-api
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/code/provision/kubernetes/datalab-app-deployment.yml
+++ b/code/provision/kubernetes/datalab-app-deployment.yml
@@ -12,8 +12,15 @@ spec:
       containers:
         - name: datalab-app
           image: nerc/datalab-app
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/code/provision/kubernetes/docs-deployment.yml
+++ b/code/provision/kubernetes/docs-deployment.yml
@@ -12,8 +12,15 @@ spec:
       containers:
         - name: docs
           image: nerc/docs
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR adds an api status route for use with Kubernetes liveness probes. The api container will need to be rebuild pushed before deploying onto the K8s cluster, otherwise api pod deployment will fail.