### PR TITLE
Fix: Configure Swap settings for all Kubernetes servers

### DIFF
--- a/code/provision/playbooks/roles/kubernetes-common/tasks/main.yml
+++ b/code/provision/playbooks/roles/kubernetes-common/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Remove current swaps from fstab
+  lineinfile:
+    dest: /etc/fstab
+    regexp: '^/[\S]+\s+none\s+swap '
+    state: absent
+
+- name: Disable swap
+  command: swapoff --all
+
 - name: Install ca-certificates
   apt:
     name: ca-certificates


### PR DESCRIPTION
This change is to ensure that swap is always turned off for Kubernetes servers otherwise Kubelt fails to start.