### PR TITLE
Feature: Copy Helm certs playbook from CEH branch

### DIFF
--- a/code/provision/playbooks/maintenance/regenerate-helm-certificates.yml
+++ b/code/provision/playbooks/maintenance/regenerate-helm-certificates.yml
@@ -1,0 +1,94 @@
+# This is a playbook to regenerate the certificates for Tiller & Helm
+# Unfortunately currently this doesn't update the Tiller secret for tls.crt
+# Hence there is a workaround to inject the new secret as well
+# https://github.com/helm/helm/issues/4691
+#
+---
+- hosts: k8s-master
+  tasks:
+    - set_fact:
+        ca_certs_dir='/home/ubuntu/helm'
+        k8s_cert_dir='/etc/kubernetes/pki'
+        tmp_dir='/tmp/helm-certs/'
+
+    - name: Create Temp Directory
+      file:
+        path: "{{ tmp_dir }}"
+        state: directory
+
+    - name: Create new Keys
+      shell: "openssl genrsa -out {{ tmp_dir }}/{{ item }}.key.pem"
+      with_items:
+        - helm
+        - tiller
+
+    - name: Create CSRs
+      shell: "openssl req -new -key {{ tmp_dir }}/{{ item }}.key.pem -out {{ tmp_dir }}/{{ item }}.csr.pem -subj \"/C=UK/O=Datalabs/CN={{ item }}\""
+      with_items:
+        - helm
+        - tiller
+
+    - name: Sign Helm/Tiller Certs
+      shell: "openssl x509 -req -CA {{ k8s_cert_dir }}/ca.crt -CAkey {{ k8s_cert_dir }}/ca.key -CAcreateserial -in {{ tmp_dir }}/{{ item }}.csr.pem -out {{ item }}.cert.pem -days 365"
+      args:
+        chdir: "{{ tmp_dir }}"
+      become: yes
+      become_method: sudo
+      with_items:
+        - helm
+        - tiller
+
+    - name: Remove current Helm/Tiller Keys
+      file:
+        state: absent
+        path: "{{ ca_certs_dir }}/{{ item }}.key.pem"
+      with_items:
+        - helm
+        - tiller
+
+    - name: Remove current Helm/Tiller certificates
+      file:
+        state: absent
+        path: "{{ ca_certs_dir }}/{{ item }}.cert.pem"
+      with_items:
+        - helm
+        - tiller
+
+    - name: Implement newly generated keys
+      copy:
+        src: "{{ tmp_dir }}/{{ item }}.key.pem"
+        dest: "{{ ca_certs_dir }}/{{ item }}.key.pem"
+        remote_src: yes
+        owner: ubuntu
+        group: docker
+        mode: 0640
+      with_items:
+        - helm
+        - tiller
+
+    - name: Implement newly generated certs
+      copy:
+        src: "{{ tmp_dir }}/{{ item }}.cert.pem"
+        dest: "{{ ca_certs_dir }}/{{ item }}.cert.pem"
+        remote_src: yes
+        owner: ubuntu
+        group: docker
+        mode: 0640
+      with_items:
+        - helm
+        - tiller
+
+    - name: Update Tiller Key Secre
+      shell: "kubectl get secret tiller-secret -n kube-system -o json | jq --arg cert \"$(cat {{ ca_certs_dir }}/tiller.cert.pem | base64 -w 0)\" '.data[\"tls.crt\"]=$cert' | kubectl apply -f -"
+      args:
+        chdir: "{{ ca_certs_dir }}"
+
+    - name: Update Tiller CRT Secret
+      shell: "kubectl get secret tiller-secret -n kube-system -o json | jq --arg cert \"$(cat {{ ca_certs_dir }}/tiller.key.pem | base64 -w 0)\" '.data[\"tls.key\"]=$cert' | kubectl apply -f -"
+      args:
+        chdir: "{{ ca_certs_dir }}"
+
+    - name: Remove tmp directory
+      file:
+        path: "{{ tmp_dir }}"
+        state: absent

--- a/code/provision/playbooks/roles/helm/tasks/create-signed-certs.yml
+++ b/code/provision/playbooks/roles/helm/tasks/create-signed-certs.yml
@@ -29,7 +29,7 @@
     dest: "{{ ca_certs_dir }}/{{ item }}.key.pem"
 
 - name: Sign Helm Certs
-  shell: "openssl x509 -req -CA {{ k8s_cert_dir }}/ca.crt -CAkey {{ k8s_cert_dir }}/ca.key -CAcreateserial -in {{ item }}.csr.pem -out {{ item }}.cert.pem"
+  shell: "openssl x509 -req -CA {{ k8s_cert_dir }}/ca.crt -CAkey {{ k8s_cert_dir }}/ca.key -CAcreateserial -in {{ item }}.csr.pem -out {{ item }}.cert.pem -days 365"
   args:
     chdir: "{{ ca_certs_dir }}"
   become: yes


### PR DESCRIPTION
Direct copy from existing script and hasn't been tested as Helm 3 is due out soon which makes it redundant.
If it doesn't work it can be fixed when used. 