### PR TITLE
chore: upgrade node container version used in travis

### DIFF
--- a/code/datalab-app/api.Dockerfile
+++ b/code/datalab-app/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2.1-alpine
+FROM node:8.16.0-alpine
 
 LABEL maintainer "joshua.foster@stfc.ac.uk"
 


### PR DESCRIPTION
Travis build on master is failing when trying to build into a container as the version of eslint isn't compatible with the version of Node in the container (v8.2.1). This isn't picked up on the branches as there is no container build and the travis build node is using version 8.16.0 of Node (which is compatible with the version of eslint being used). 