### PR TITLE
Upgrade infrastructure container Node version 

### DIFF
--- a/code/infrastructure-api/Dockerfile
+++ b/code/infrastructure-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2.1-alpine
+FROM node:8.16.0-alpine
 
 LABEL maintainer "gareth.lloyd@stfc.ac.uk"
 


### PR DESCRIPTION
Fix failing Travis container build for infrastructure-api. See PR #312 for more detail.