### PR TITLE
feat: enable Auth0 signup through the UI

### DIFF
--- a/code/datalab-app/src/app/auth/auth.js
+++ b/code/datalab-app/src/app/auth/auth.js
@@ -4,6 +4,7 @@ import auth0 from 'auth0-js';
 import { pick } from 'lodash';
 import cookies from './cookies';
 import { setSession, clearSession, getSession } from '../core/sessionUtil';
+import loginScreens from './auth0UniversalLoginScreens';
 
 class Auth {
   constructor(authZeroInit, promisifyAuthZeroInit, authConfig) {
@@ -11,6 +12,7 @@ class Auth {
     this.authZeroAsync = promisifyAuthZeroInit;
     this.authZeroInit = authZeroInit;
     this.login = this.login.bind(this);
+    this.signUp = this.signUp.bind(this);
     this.logout = this.logout.bind(this);
     this.handleAuthentication = this.handleAuthentication.bind(this);
     this.renewSession = this.renewSession.bind(this);
@@ -23,6 +25,13 @@ class Auth {
     // User redirected to Auth0 login page
     const state = JSON.stringify({ appRedirect: window.location.pathname });
     this.authZeroInit.authorize({ state });
+  }
+
+  signUp() {
+    // Auth0 universal login configured to open on Sign Up page
+    // Note: This required customization of Auth0 Universal Login widget (see auth0)
+    const state = JSON.stringify({ appRedirect: window.location.pathname });
+    this.authZeroInit.authorize({ state, initial_screen: loginScreens.SIGN_UP });
   }
 
   logout() {

--- a/code/datalab-app/src/app/auth/auth0UniversalLoginScreens.js
+++ b/code/datalab-app/src/app/auth/auth0UniversalLoginScreens.js
@@ -1,0 +1,7 @@
+// Possible values for the intial screen for the Auth0 Universal login page
+// https://auth0.com/docs/libraries/lock/v11/configuration#initialscreen-string-
+export default Object.freeze({
+  LOGIN: 'login',
+  SIGN_UP: 'signUp',
+  FORGOT_PASSWORD: 'forgotPassword',
+});

--- a/code/datalab-app/src/app/components/welcome/HeroBar.js
+++ b/code/datalab-app/src/app/components/welcome/HeroBar.js
@@ -31,7 +31,7 @@ const HeroBar = ({ classes }) => (
   <div className={classes.bar}>
     <img className={classes.logo} src={datalabsLogo} alt="DataLabs-Logo" />
     <Typography className={classes.tagLine} variant="h6">{tagLine}</Typography>
-    <Button className={classes.button} color="primary" disabled>Sign Up</Button>
+    <Button className={classes.button} color="primary" onClick={getAuth().signUp}>Sign Up</Button>
     <Button className={classes.button} color="primary" onClick={getAuth().login}> Log In</Button>
   </div>
 );

--- a/code/datalab-app/src/app/components/welcome/HeroBar.spec.js
+++ b/code/datalab-app/src/app/components/welcome/HeroBar.spec.js
@@ -6,6 +6,7 @@ import getAuth from '../../auth/auth';
 jest.mock('../../auth/auth');
 getAuth.mockImplementation(() => ({
   login: jest.fn(),
+  signUp: jest.fn(),
 }));
 
 describe('HeroBar', () => {

--- a/code/datalab-app/src/app/components/welcome/__snapshots__/HeroBar.spec.js.snap
+++ b/code/datalab-app/src/app/components/welcome/__snapshots__/HeroBar.spec.js.snap
@@ -18,7 +18,7 @@ exports[`HeroBar renders correct snapshot 1`] = `
   <WithStyles(Button)
     className="HeroBar-button-4"
     color="primary"
-    disabled={true}
+    onClick={[MockFunction]}
   >
     Sign Up
   </WithStyles(Button)>


### PR DESCRIPTION
* Enable the sign-up button in the UI.
* Clicking button takes user to Auth0 Universal Login with the `Sign Up` tab selected (rather than default of `Login`.
* Required changing code in the Universal Login page. This can be viewed in the `Universal Login -> Login` section when logged into Auth0.

>**Note:** The way the parameter used to tell the Universal Login what screen to open on is passed causes a warning to be logged in the browser console.