### PR TITLE
Kubewatcher error handling

### DIFF
--- a/code/infrastructure-api/src/dataaccess/stacksRepository.js
+++ b/code/infrastructure-api/src/dataaccess/stacksRepository.js
@@ -54,7 +54,7 @@ function updateStatus(stack) {
   const { name, type, status } = stack;
   return Stack()
     .where({ name, type })
-    .update({ status })
+    .updateOne({ status })
     .exec();
 }
 

--- a/code/infrastructure-api/src/kubeWatcher/__snapshots__/kubeWatcher.spec.js.snap
+++ b/code/infrastructure-api/src/kubeWatcher/__snapshots__/kubeWatcher.spec.js.snap
@@ -7,6 +7,11 @@ Array [
     "message": "Pod added: -- name: \\"jupyter-expectedName\\", type: \\"jupyter\\"",
     "metadata": undefined,
   },
+]
+`;
+
+exports[`Kubernetes event watcher podAddedWatcher logs events 2`] = `
+Array [
   Object {
     "data": undefined,
     "message": "Updated status record for \\"jupyter-expectedName\\" to \\"creating\\"",
@@ -32,6 +37,11 @@ Array [
     "message": "Pod ready -- name: \\"jupyter-expectedName\\", type: \\"jupyter\\"",
     "metadata": undefined,
   },
+]
+`;
+
+exports[`Kubernetes event watcher podReadyWatcher logs events 2`] = `
+Array [
   Object {
     "data": undefined,
     "message": "Updated status record for \\"expectedName\\" to \\"ready\\"",

--- a/code/infrastructure-api/src/kubeWatcher/kubeWatcher.spec.js
+++ b/code/infrastructure-api/src/kubeWatcher/kubeWatcher.spec.js
@@ -21,7 +21,10 @@ describe('Kubernetes event watcher', () => {
     const event = generatePodEvent('jupyter-expectedName', 'jupyter');
 
     return podAddedWatcher(event)
-      .then(() => expect(logger.getDebugMessages()).toMatchSnapshot());
+      .then(() => {
+        expect(logger.getDebugMessages()).toMatchSnapshot();
+        expect(logger.getInfoMessages()).toMatchSnapshot();
+      });
   });
 
   it('podAddedWatcher updates pod status', () => {
@@ -59,7 +62,10 @@ describe('Kubernetes event watcher', () => {
     const event = generatePodEvent('jupyter-expectedName', 'jupyter');
 
     return podReadyWatcher(event)
-      .then(() => expect(logger.getDebugMessages()).toMatchSnapshot());
+      .then(() => {
+        expect(logger.getDebugMessages()).toMatchSnapshot();
+        expect(logger.getInfoMessages()).toMatchSnapshot();
+      });
   });
 
   it('podReadyWatcher updates pod status', () => {

--- a/code/infrastructure-api/src/kubeWatcher/stackStatusChecker.spec.js
+++ b/code/infrastructure-api/src/kubeWatcher/stackStatusChecker.spec.js
@@ -27,7 +27,7 @@ const stacks = [
 ];
 
 getStacksMock.mockReturnValue(Promise.resolve(stacks));
-updateStatusMock.mockReturnValue(Promise.resolve());
+updateStatusMock.mockReturnValue(Promise.resolve({ n: 1 }));
 
 describe('Stack Status Checker', () => {
   beforeEach(() => {

--- a/code/infrastructure-api/src/server.js
+++ b/code/infrastructure-api/src/server.js
@@ -22,4 +22,4 @@ function listen() {
 
 database.createConnection()
   .then(listen)
-  .catch(error => logger.error(chalk.red(`Error connecting to the database ${error}`)));
+  .catch(error => logger.error(`Error connecting to the database ${error}`));


### PR DESCRIPTION
* Improve logging in kubewatcher.
* Update mongoose `update` to `updateOne` due to depreciation of `update`. 