### PR TITLE
Fix: Increase auth0 user API call to max value

### DIFF
--- a/code/auth-service/src/userManagement/authZeroUserManagement.js
+++ b/code/auth-service/src/userManagement/authZeroUserManagement.js
@@ -24,6 +24,7 @@ export function asyncGetUsers() {
       axios.get(`${authZeroManagementApi}/users`, {
         params: {
           fields: 'name,user_id',
+          per_page: '100',
         },
         headers: {
           Authorization: `Bearer ${bearer}`,


### PR DESCRIPTION
Workaround so users > 50, < 100 still appear in the UI to add to datastores until this is permanently fixed/made redundant

docs: https://auth0.com/docs/api/management/v2/#!/Users/get_users