### PR TITLE
Pin session data to RStudio notebook name to make unique

### DIFF
--- a/code/workspaces/infrastructure-api/manifests/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/manifests/rstudio.deployment.template.yml
@@ -20,7 +20,7 @@ spec:
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "mkdir -p /data/notebooks/rstudio"]
+          args: ["-c", "mkdir -p /data/notebooks/{{ name }}"]
           volumeMounts:
             - mountPath: /data
               name: glusterfsvol
@@ -29,7 +29,7 @@ spec:
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "chown 1000:100 /data/notebooks && chown 1000:100 /data/notebooks/rstudio"]
+          args: ["-c", "chown 1000:100 /data/notebooks && chown 1000:100 /data/notebooks/{{ name }}"]
           volumeMounts:
             - mountPath: /data
               name: glusterfsvol
@@ -37,7 +37,7 @@ spec:
         - name: create-datalab-symlink
           image: busybox
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "ln -s /data/notebooks/rstudio/ /home/datalab"]
+          command: ["sh", "-c", "ln -s /data/notebooks/{{ name }}/ /home/datalab"]
           volumeMounts:
             - mountPath: /home
               name: homedir


### PR DESCRIPTION
Suggest implementing this now unless there are any better suggestions - to be clear {{ name }} resolves to something like "rstudio-notebook" as it uses the deployment name itself so it should be unique to notebook type and name as well.

