### PR TITLE
feat: update GraphQL schema to have project services

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/projectService.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.js
@@ -4,11 +4,52 @@ import config from '../config';
 
 const authServiceUrl = `${config.get('authorisationService')}`;
 
+function listProjects() {
+  return Promise.resolve([
+    {
+      id: 123,
+      name: 'project',
+      key: 'project',
+      tags: ['alpha', 'beta', 'gamma'],
+      collaborationLink: 'https://testlab.test-datalabs.nerc.ac.uk/',
+    },
+  ]);
+}
+
 function getProjectByKey(projectKey) {
   return Promise.resolve({
     id: 123,
     name: 'project',
     key: projectKey,
+  });
+}
+
+function createProject({ projectKey, ...rest }) {
+  logger.debug(`Creating project ${projectKey}`);
+  return Promise.resolve({
+    id: 321,
+    key: projectKey,
+    ...rest,
+  });
+}
+
+function updateProject({ projectKey, ...rest }) {
+  logger.debug(`Updating project ${projectKey}`);
+  return Promise.resolve({
+    id: 321,
+    key: projectKey,
+    ...rest,
+  });
+}
+
+function deleteProject(projectKey) {
+  logger.debug(`Deleting project ${projectKey}`);
+  return Promise.resolve({
+    id: 321,
+    key: projectKey,
+    name: 'notNeeded',
+    tags: [],
+    collaborationLink: undefined,
   });
 }
 
@@ -34,4 +75,12 @@ const generateOptions = token => ({
   },
 });
 
-export default { getProjectByKey, addProjectPermission, removeProjectPermission };
+export default {
+  listProjects,
+  getProjectByKey,
+  createProject,
+  updateProject,
+  deleteProject,
+  addProjectPermission,
+  removeProjectPermission,
+};

--- a/code/workspaces/client-api/src/dataaccess/usersService.js
+++ b/code/workspaces/client-api/src/dataaccess/usersService.js
@@ -31,10 +31,17 @@ async function getUserName(userId, token) {
   }
 }
 
+function isMemberOfProject(projectKey) {
+  logger.debug(`Checking user membership for project ${projectKey}`);
+  // This is a temporary dummy value which will require another route to be
+  // added to the auth-service.
+  return true;
+}
+
 const generateOptions = token => ({
   headers: {
     authorization: token,
   },
 });
 
-export default { getAll, getProjectUsers, getUserName };
+export default { getAll, getProjectUsers, getUserName, isMemberOfProject };

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -35,6 +35,7 @@ const resolvers = {
     userPermissions: (obj, params, { token }) => getUserPermissions(token),
     checkNameUniqueness: (obj, { name }, { user, token }) => permissionChecker([STACKS_CREATE, STORAGE_CREATE], user, () => internalNameChecker({ user, token }, name)),
     users: (obj, args, { user, token }) => permissionChecker(USERS_LIST, user, () => userService.getAll({ token })),
+    projects: (obj, args, { token }) => projectService.listProjects(token),
     project: (obj, { key }, { user, token }) => permissionChecker(SETTINGS_READ, user, () => projectService.getProjectByKey(key, token)),
   },
 
@@ -51,6 +52,9 @@ const resolvers = {
     removeProjectPermission: (obj, { permission: { projectKey, userId } }, { user, token }) => (
       permissionChecker(PERMISSIONS_DELETE, user, () => projectService.removeProjectPermission(projectKey, userId, token))
     ),
+    createProject: (obj, { project }, { token }) => projectService.createProject(project, token),
+    updateProject: (obj, { project }, { token }) => projectService.updateProject(project, token),
+    deleteProject: (obj, { project: { projectKey } }, { token }) => projectService.deleteProject(projectKey, token),
   },
 
   DataStore: {
@@ -66,6 +70,7 @@ const resolvers = {
 
   Project: {
     projectUsers: (obj, args, ctx) => userService.getProjectUsers(obj.key, ctx.token),
+    accessible: (obj, args, ctx) => userService.isMemberOfProject(obj.key, ctx.token),
   },
 
   ProjectUser: {

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -33,6 +33,9 @@ type Query {
     # List of users within the current DataLab
     users: [User]
 
+    # List of projects where the user is a member
+    projects: [Project]
+
     # Details of a single project
     project(key: String!): Project
 }
@@ -56,6 +59,15 @@ type Mutation {
 
     # Remove user access to data store
     removeUserFromDataStore(dataStore: DataStorageUpdateRequest): DataStore
+
+    # Create a new project
+    createProject(project: ProjectCreationRequest): Project
+
+    # Update a project
+    updateProject(project: ProjectUpdateRequest): Project
+
+    # Delete a project
+    deleteProject(project: ProjectDeletionRequest): Project
 
     # Add a user permission to a project
     addProjectPermission(permission: PermissionAddRequest): Permission
@@ -190,7 +202,31 @@ type Project {
     id: ID!
     key: String!
     name: String!
-    projectUsers: [ProjectUser!]!
+    accessible: Boolean!
+    projectUsers: [ProjectUser!]
+}
+
+# Type to describe the mutation for creating a new Project
+input ProjectCreationRequest {
+    projectKey: String!
+    name: String!
+    description: String
+    tags: [String!]
+    collaborationLink: String
+}
+
+# Type to describe the mutation for updating a Project
+input ProjectUpdateRequest {
+    projectKey: String!
+    name: String!
+    description: String
+    tags: [String!]
+    collaborationLink: String
+}
+
+# Type to describe the project for deletion
+input ProjectDeletionRequest {
+    projectKey: String!
 }
 
 type Permission {


### PR DESCRIPTION
Tasks to be cover in another PR:

- Add `isMemberOfProject` route to auth-service
- Add `instance-admin` permissions to project creation/deletion