### PR TITLE
create userRoles record for users without one to allow login

### DIFF
--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -111,6 +111,21 @@ describe('userRolesRepository', () => {
         ],
       });
     });
+
+    it('should add an empty record for a user that does not have one when retrieving roles', async () => {
+      await userRoleRepository.getRoles('uid999');
+      expect(mockDatabase().query()).toEqual({
+        userId: 'uid999',
+      });
+
+      expect(mockDatabase().invocation().entity).toEqual({
+        $setOnInsert: {
+          userId: 'uid999',
+          instanceAdmin: false,
+          projectRoles: [],
+        },
+      });
+    });
   });
 
   describe('delete role', () => {


### PR DESCRIPTION
It would be good to have some feedback on this if possible!

I'm not sure if this is the best way to approach it, but the issue is that a user that doesn't have an entry in the userRoles collection is stuck in an infinite loop logging on after passing auth0 lock. Hence this creates an empty entry.