### PR TITLE
fix: correct path for deleting volume key

### DIFF
--- a/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
@@ -26,7 +26,7 @@ function createVolume(params) {
 
 function deleteVolume(params) {
   // Deletion of PVC is blocked to prevent breaking pods.
-  const { datalabInfo, name } = params;
+  const { datalabInfo, projectKey, name } = params;
   const k8sName = `${type}-${name}`;
 
   return ingressApi.deleteIngress(k8sName, datalabInfo)
@@ -34,7 +34,7 @@ function deleteVolume(params) {
     .then(() => deploymentApi.deleteDeployment(k8sName))
     // .then(() => volumeApi.deletePersistentVolumeClaim(`${name}-claim`))
     .then(() => k8sSecretApi.deleteSecret(k8sName))
-    .then(() => secretManager.deleteMinioCredentials(datalabInfo.name, name));
+    .then(() => secretManager.deleteMinioCredentials(projectKey, name));
 }
 
 function queryVolume(params) {


### PR DESCRIPTION
Vault secret deletion for volumes hadn't been updated to the new path