### PR TITLE
feat(user permissions table): make user permissions updatable

### DIFF
--- a/code/workspaces/web-app/src/components/settings/RemoveUserDialog.js
+++ b/code/workspaces/web-app/src/components/settings/RemoveUserDialog.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+
+export default function RemoveUserDialog({ classes, state, setState, onRemoveConfirmationFn, project, dispatch }) {
+  if (!state.open) return null;
+
+  const closedState = { user: null, open: false };
+  return (
+    <Dialog open={state.open}>
+      <DialogTitle>Remove User Permissions?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {`Are you sure you want to remove all project permissions for ${state.user.name}?`}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button id="cancel-button" onClick={() => setState(closedState)}>Cancel</Button>
+        <Button
+          id="confirm-button"
+          className={classes.dialogDeleteUserButton}
+          variant="outlined"
+          onClick={() => {
+            onRemoveConfirmationFn(project, state.user, dispatch);
+            setState(closedState);
+          }}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/code/workspaces/web-app/src/components/settings/RemoveUserDialog.spec.js
+++ b/code/workspaces/web-app/src/components/settings/RemoveUserDialog.spec.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import RemoveUserDialog from './RemoveUserDialog';
+
+describe('RemoveUserDialog', () => {
+  const classes = { dialogDeleteUserButton: 'dialogDeleteUserButton' };
+
+  describe('when the dialog state has open equal to false', () => {
+    let shallow;
+
+    beforeEach(() => {
+      shallow = createShallow();
+    });
+
+    it('renders as null', () => {
+      expect(
+        shallow(
+          <RemoveUserDialog
+            classes={classes}
+            state={{ user: null, open: false }}
+            setState={jest.fn()}
+            onRemoveConfirmationFn={jest.fn()}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('when the dialog state has open equal to true and a user set', () => {
+    let shallow;
+
+    beforeEach(() => {
+      shallow = createShallow();
+    });
+
+    const openState = { user: { name: 'User One', userId: 'user-one-id' }, open: true };
+
+    it('renders to match snapshot', () => {
+      expect(
+        shallow(
+          <RemoveUserDialog
+            classes={classes}
+            state={openState}
+            setState={jest.fn()}
+            onRemoveConfirmationFn={jest.fn()}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('closes when the cancel button is pressed and does not call confirmation function', () => {
+      const mockSetState = jest.fn();
+      const mockOnRemoveConfirmationFn = jest.fn();
+      const render = shallow(
+        <RemoveUserDialog
+          classes={classes}
+          state={openState}
+          setState={mockSetState}
+          onRemoveConfirmationFn={mockOnRemoveConfirmationFn}
+          dispatch={jest.fn()}
+        />,
+      );
+      render.find('#cancel-button').simulate('click');
+
+      expect(mockSetState).toHaveBeenCalledTimes(1);
+      expect(mockSetState).toHaveBeenCalledWith({ open: false, user: null });
+      expect(mockOnRemoveConfirmationFn).toHaveBeenCalledTimes(0);
+    });
+
+    it('calls provided function and closes when the confirm button is pressed', () => {
+      const mockSetState = jest.fn();
+      const mockOnRemoveConfirmationFn = jest.fn();
+      const mockDispatch = jest.fn();
+      const projectName = 'project';
+      const render = shallow(
+        <RemoveUserDialog
+          classes={classes}
+          state={openState}
+          setState={mockSetState}
+          onRemoveConfirmationFn={mockOnRemoveConfirmationFn}
+          project={projectName}
+          dispatch={mockDispatch}
+        />,
+      );
+      render.find('#confirm-button').simulate('click');
+
+      expect(mockSetState).toHaveBeenCalledTimes(1);
+      expect(mockSetState).toHaveBeenCalledWith({ open: false, user: null });
+      expect(mockOnRemoveConfirmationFn).toHaveBeenCalledTimes(1);
+      expect(mockOnRemoveConfirmationFn)
+        .toHaveBeenCalledWith(projectName, openState.user, mockDispatch);
+    });
+  });
+});

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
@@ -1,16 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { startCase } from 'lodash';
-import Button from '@material-ui/core/Button';
-import Checkbox from '@material-ui/core/Checkbox';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Icon from '@material-ui/core/Icon';
-import IconButton from '@material-ui/core/IconButton';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableCell from '@material-ui/core/TableCell';
@@ -19,7 +10,9 @@ import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import projectSettingsActions from '../../actions/projectSettingsActions';
-import { PERMISSION_VALUES, SORTED_PERMISSIONS } from '../../constants/permissions';
+import RemoveUserDialog from './RemoveUserDialog';
+import { CheckboxCell, RemoveUserButtonCell } from './UserPermissionsTableActionCells';
+import { SORTED_PERMISSIONS } from '../../constants/permissions';
 
 const styles = theme => ({
   activeSelection: {
@@ -220,87 +213,6 @@ export function UserPermissionsTableRow({ user, isCurrentUser, index, project, c
         setRemoveUserDialogState={setRemoveUserDialogState}
       />
     </TableRow>
-  );
-}
-
-export function CheckboxCell({ user, isCurrentUser, checkboxSpec, project, classes, cellKey, actions, dispatch }) {
-  return (
-    <TableCell
-      className={classes.tableCell}
-      padding="checkbox"
-      align="center"
-      key={cellKey}
-    >
-      <PermissionsCheckbox
-        user={user}
-        isCurrentUser={isCurrentUser}
-        checkboxSpec={checkboxSpec}
-        project={project}
-        classes={classes}
-        actions={actions}
-        dispatch={dispatch}
-      />
-    </TableCell>
-  );
-}
-
-export function PermissionsCheckbox({ user, isCurrentUser, checkboxSpec, project, classes, actions, dispatch }) {
-  const props = { checked: true, color: 'default' };
-  if (user.role === checkboxSpec.name) {
-    props.className = classes.activeSelection;
-  } else if (PERMISSION_VALUES[user.role.toUpperCase()] > checkboxSpec.value) {
-    props.className = classes.implicitSelection;
-  } else {
-    props.checked = false;
-  }
-
-  if (isCurrentUser) props.disabled = true;
-
-  return <Checkbox {...props} onClick={() => actions.addUserPermission(project, user, checkboxSpec.name, dispatch)}/>;
-}
-
-export function RemoveUserButtonCell({ user, isCurrentUser, classes, setRemoveUserDialogState }) {
-  return (
-    <TableCell className={classes.tableCell} padding="checkbox" align="center">
-      <IconButton
-        disabled={isCurrentUser}
-        onClick={() => {
-          setRemoveUserDialogState({ user, open: true });
-        }}
-      >
-        <Icon>{'remove_circle_outline'}</Icon>
-      </IconButton>
-    </TableCell>
-  );
-}
-
-export function RemoveUserDialog({ classes, state, setState, onRemoveConfirmationFn, project, dispatch }) {
-  if (!state.open) return null;
-
-  const closedState = { user: null, open: false };
-  return (
-    <Dialog open={state.open}>
-      <DialogTitle>Remove User Permissions?</DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          {`Are you sure you want to remove all project permissions for ${state.user.name}?`}
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button id="cancel-button" onClick={() => setState(closedState)}>Cancel</Button>
-        <Button
-          id="confirm-button"
-          className={classes.dialogDeleteUserButton}
-          variant="outlined"
-          onClick={() => {
-            onRemoveConfirmationFn(project, state.user, dispatch);
-            setState(closedState);
-          }}
-        >
-          Confirm
-        </Button>
-      </DialogActions>
-    </Dialog>
   );
 }
 

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
@@ -1,22 +1,16 @@
 import React from 'react';
 import { createShallow } from '@material-ui/core/test-utils';
-import IconButton from '@material-ui/core/IconButton';
-import Checkbox from '@material-ui/core/Checkbox';
-import { PERMISSIONS, PERMISSION_VALUES } from '../../constants/permissions';
+import { PERMISSIONS } from '../../constants/permissions';
 import projectSettingsActions from '../../actions/projectSettingsActions';
 import {
   PureUserPermissionsTable,
   FullWidthRow,
   FullWidthTextRow,
   UserPermissionsTableRow,
-  PermissionsCheckbox,
-  CheckboxCell,
   UserPermissionsTableHead,
   UserPermissionsTableBody,
   projectUsersSelector,
   currentUserIdSelector,
-  RemoveUserButtonCell,
-  RemoveUserDialog,
   dispatchRemoveUserPermissions,
   dispatchAddUserPermissions,
   columnHeadings,
@@ -264,157 +258,6 @@ describe('UserPermissionsTableRow', () => {
   });
 });
 
-describe('CheckboxCell', () => {
-  let shallow;
-
-  const classes = {
-    activeSelection: 'active',
-    implicitSelection: 'implicit',
-  };
-
-  beforeEach(() => {
-    shallow = createShallow();
-  });
-
-  it('renders correctly passing props to PermissionsCheckbox in TableCell', () => {
-    const user = { role: PERMISSIONS.ADMIN };
-    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
-
-    expect(
-      shallow(
-        <CheckboxCell
-          user={user}
-          isCurrentUser={false}
-          checkboxSpec={checkboxSpec}
-          project="project"
-          classes={classes}
-          cellKey="key"
-          dispatch={jest.fn()}
-        />,
-      ),
-    ).toMatchSnapshot();
-  });
-});
-
-describe('PermissionsCheckbox', () => {
-  let shallow;
-
-  const classes = {
-    activeSelection: 'active',
-    implicitSelection: 'implicit',
-  };
-
-  beforeEach(() => {
-    shallow = createShallow();
-  });
-
-  describe('when user has rights equal to CheckboxSpec', () => {
-    const user = { role: PERMISSIONS.ADMIN };
-    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
-    it('returns an checked active selection check box', () => {
-      expect(
-        shallow(
-          <PermissionsCheckbox
-            user={user}
-            isCurrentUser={false}
-            checkboxSpec={checkboxSpec}
-            project="project"
-            classes={classes}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('when user has rights greater than CheckboxSpec', () => {
-    const user = { role: PERMISSIONS.ADMIN };
-    const checkboxSpec = { name: PERMISSIONS.USER, value: PERMISSION_VALUES.USER };
-    it('returns an checked implicit selection check box', () => {
-      expect(
-        shallow(
-          <PermissionsCheckbox
-            user={user}
-            isCurrentUser={false}
-            checkboxSpec={checkboxSpec}
-            project="project"
-            classes={classes}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('when user has rights less than CheckboxSpec', () => {
-    const user = { role: PERMISSIONS.VIEWER };
-    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
-    it('returns an unchecked check box', () => {
-      expect(
-        shallow(
-          <PermissionsCheckbox
-            user={user}
-            isCurrentUser={false}
-            checkboxSpec={checkboxSpec}
-            project="project"
-            classes={classes}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('when checkbox user is the current user', () => {
-    const user = { role: PERMISSIONS.ADMIN };
-    const checkboxSpec = { name: PERMISSIONS.USER, value: PERMISSION_VALUES.USER };
-
-    it('renders with correct check status and as disabled', () => {
-      expect(
-        shallow(
-          <PermissionsCheckbox
-            user={user}
-            isCurrentUser={true}
-            checkboxSpec={checkboxSpec}
-            project="project"
-            classes={classes}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('when the checkbox is clicked', () => {
-    const mockActions = {
-      addUserPermission: jest.fn(),
-    };
-    mockActions.addUserPermission.mockReturnValue('expected-result');
-
-    const mockDispatch = jest.fn();
-    const project = 'project';
-    const user = { name: 'User One', userId: 'user-one-id', role: PERMISSIONS.USER };
-    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
-
-    it('dispatches update action with correct user and new permission level', () => {
-      const render = shallow(
-        <PermissionsCheckbox
-          user={user}
-          isCurrentUser={true}
-          checkboxSpec={checkboxSpec}
-          project={project}
-          classes={classes}
-          actions={mockActions}
-          dispatch={mockDispatch}
-        />,
-      );
-      render.find(Checkbox).simulate('click');
-      expect(mockActions.addUserPermission).toHaveBeenCalledTimes(1);
-      expect(mockActions.addUserPermission).toHaveBeenCalledWith(project, user, checkboxSpec.name, mockDispatch);
-    });
-  });
-});
-
 describe('UserPermissionsTableHead', () => {
   const classes = {
     tableCell: 'tableCell',
@@ -445,99 +288,6 @@ describe('UserPermissionsTableHead', () => {
         <UserPermissionsTableHead headings={headings} classes={classes} />,
       ),
     ).toMatchSnapshot();
-  });
-});
-
-describe('RemoveUserDialog', () => {
-  const classes = { dialogDeleteUserButton: 'dialogDeleteUserButton' };
-
-  describe('when the dialog state has open equal to false', () => {
-    let shallow;
-
-    beforeEach(() => {
-      shallow = createShallow();
-    });
-
-    it('renders as null', () => {
-      expect(
-        shallow(
-          <RemoveUserDialog
-            classes={classes}
-            state={{ user: null, open: false }}
-            setState={jest.fn()}
-            onRemoveConfirmationFn={jest.fn()}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-  });
-
-  describe('when the dialog state has open equal to true and a user set', () => {
-    let shallow;
-
-    beforeEach(() => {
-      shallow = createShallow();
-    });
-
-    const openState = { user: { name: 'User One', userId: 'user-one-id' }, open: true };
-
-    it('renders to match snapshot', () => {
-      expect(
-        shallow(
-          <RemoveUserDialog
-            classes={classes}
-            state={openState}
-            setState={jest.fn()}
-            onRemoveConfirmationFn={jest.fn()}
-            dispatch={jest.fn()}
-          />,
-        ),
-      ).toMatchSnapshot();
-    });
-
-    it('closes when the cancel button is pressed and does not call confirmation function', () => {
-      const mockSetState = jest.fn();
-      const mockOnRemoveConfirmationFn = jest.fn();
-      const render = shallow(
-        <RemoveUserDialog
-          classes={classes}
-          state={openState}
-          setState={mockSetState}
-          onRemoveConfirmationFn={mockOnRemoveConfirmationFn}
-          dispatch={jest.fn()}
-        />,
-      );
-      render.find('#cancel-button').simulate('click');
-
-      expect(mockSetState).toHaveBeenCalledTimes(1);
-      expect(mockSetState).toHaveBeenCalledWith({ open: false, user: null });
-      expect(mockOnRemoveConfirmationFn).toHaveBeenCalledTimes(0);
-    });
-
-    it('calls provided function and closes when the confirm button is pressed', () => {
-      const mockSetState = jest.fn();
-      const mockOnRemoveConfirmationFn = jest.fn();
-      const mockDispatch = jest.fn();
-      const projectName = 'project';
-      const render = shallow(
-        <RemoveUserDialog
-          classes={classes}
-          state={openState}
-          setState={mockSetState}
-          onRemoveConfirmationFn={mockOnRemoveConfirmationFn}
-          project={projectName}
-          dispatch={mockDispatch}
-        />,
-      );
-      render.find('#confirm-button').simulate('click');
-
-      expect(mockSetState).toHaveBeenCalledTimes(1);
-      expect(mockSetState).toHaveBeenCalledWith({ open: false, user: null });
-      expect(mockOnRemoveConfirmationFn).toHaveBeenCalledTimes(1);
-      expect(mockOnRemoveConfirmationFn)
-        .toHaveBeenCalledWith(projectName, openState.user, mockDispatch);
-    });
   });
 });
 
@@ -579,45 +329,5 @@ describe('dispatchRemoveUserPermissions', () => {
     expect(projectSettingsActions.removeUserPermission).toHaveBeenCalledTimes(1);
     expect(projectSettingsActions.removeUserPermission)
       .toHaveBeenCalledWith(projectKey, user);
-  });
-});
-
-describe('RemoveUserButtonCell', () => {
-  const classes = { tableCell: 'tableCell' };
-  const user = { name: 'User One', userId: 'user-one-id' };
-
-  let shallow;
-
-  beforeEach(() => {
-    shallow = createShallow();
-  });
-
-  it('renders as disabled when on the row of the current user', () => {
-    expect(
-      shallow(
-        <RemoveUserButtonCell
-          user={user}
-          isCurrentUser={true}
-          classes={classes}
-          setRemoveUserDialogState={jest.fn()}
-        />,
-      ),
-    ).toMatchSnapshot();
-  });
-
-  it('sets the remove user dialog state so it opens when clicked', () => {
-    const mockSetRemoveUserDialogState = jest.fn();
-    const render = shallow(
-      <RemoveUserButtonCell
-        user={user}
-        isCurrentUser={true}
-        classes={classes}
-        setRemoveUserDialogState={mockSetRemoveUserDialogState}
-      />,
-    );
-
-    render.find(IconButton).simulate('click');
-    expect(mockSetRemoveUserDialogState).toHaveBeenCalledTimes(1);
-    expect(mockSetRemoveUserDialogState).toHaveBeenCalledWith({ user, open: true });
   });
 });

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import TableCell from '@material-ui/core/TableCell';
+import Checkbox from '@material-ui/core/Checkbox';
+import IconButton from '@material-ui/core/IconButton';
+import Icon from '@material-ui/core/Icon';
+import { PERMISSION_VALUES } from '../../constants/permissions';
+
+export function CheckboxCell({ user, isCurrentUser, checkboxSpec, project, classes, cellKey, actions, dispatch }) {
+  return (
+    <TableCell
+      className={classes.tableCell}
+      padding="checkbox"
+      align="center"
+      key={cellKey}
+    >
+      <PermissionsCheckbox
+        user={user}
+        isCurrentUser={isCurrentUser}
+        checkboxSpec={checkboxSpec}
+        project={project}
+        classes={classes}
+        actions={actions}
+        dispatch={dispatch}
+      />
+    </TableCell>
+  );
+}
+
+export function PermissionsCheckbox({ user, isCurrentUser, checkboxSpec, project, classes, actions, dispatch }) {
+  const props = { checked: true, color: 'default' };
+  if (user.role === checkboxSpec.name) {
+    props.className = classes.activeSelection;
+  } else if (PERMISSION_VALUES[user.role.toUpperCase()] > checkboxSpec.value) {
+    props.className = classes.implicitSelection;
+  } else {
+    props.checked = false;
+  }
+
+  if (isCurrentUser) props.disabled = true;
+
+  return <Checkbox {...props} onClick={() => actions.addUserPermission(project, user, checkboxSpec.name, dispatch)}/>;
+}
+
+export function RemoveUserButtonCell({ user, isCurrentUser, classes, setRemoveUserDialogState }) {
+  return (
+    <TableCell className={classes.tableCell} padding="checkbox" align="center">
+      <IconButton
+        disabled={isCurrentUser}
+        onClick={() => {
+          setRemoveUserDialogState({ user, open: true });
+        }}
+      >
+        <Icon>{'remove_circle_outline'}</Icon>
+      </IconButton>
+    </TableCell>
+  );
+}

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.spec.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.spec.js
@@ -1,0 +1,197 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import Checkbox from '@material-ui/core/Checkbox';
+import IconButton from '@material-ui/core/IconButton';
+import { PERMISSION_VALUES, PERMISSIONS } from '../../constants/permissions';
+import { CheckboxCell, PermissionsCheckbox, RemoveUserButtonCell } from './UserPermissionsTableActionCells';
+
+describe('CheckboxCell', () => {
+  let shallow;
+
+  const classes = {
+    activeSelection: 'active',
+    implicitSelection: 'implicit',
+  };
+
+  beforeEach(() => {
+    shallow = createShallow();
+  });
+
+  it('renders correctly passing props to PermissionsCheckbox in TableCell', () => {
+    const user = { role: PERMISSIONS.ADMIN };
+    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
+
+    expect(
+      shallow(
+        <CheckboxCell
+          user={user}
+          isCurrentUser={false}
+          checkboxSpec={checkboxSpec}
+          project="project"
+          classes={classes}
+          cellKey="key"
+          dispatch={jest.fn()}
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+});
+
+describe('PermissionsCheckbox', () => {
+  let shallow;
+
+  const classes = {
+    activeSelection: 'active',
+    implicitSelection: 'implicit',
+  };
+
+  beforeEach(() => {
+    shallow = createShallow();
+  });
+
+  describe('when user has rights equal to CheckboxSpec', () => {
+    const user = { role: PERMISSIONS.ADMIN };
+    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
+    it('returns an checked active selection check box', () => {
+      expect(
+        shallow(
+          <PermissionsCheckbox
+            user={user}
+            isCurrentUser={false}
+            checkboxSpec={checkboxSpec}
+            project="project"
+            classes={classes}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('when user has rights greater than CheckboxSpec', () => {
+    const user = { role: PERMISSIONS.ADMIN };
+    const checkboxSpec = { name: PERMISSIONS.USER, value: PERMISSION_VALUES.USER };
+    it('returns an checked implicit selection check box', () => {
+      expect(
+        shallow(
+          <PermissionsCheckbox
+            user={user}
+            isCurrentUser={false}
+            checkboxSpec={checkboxSpec}
+            project="project"
+            classes={classes}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('when user has rights less than CheckboxSpec', () => {
+    const user = { role: PERMISSIONS.VIEWER };
+    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
+    it('returns an unchecked check box', () => {
+      expect(
+        shallow(
+          <PermissionsCheckbox
+            user={user}
+            isCurrentUser={false}
+            checkboxSpec={checkboxSpec}
+            project="project"
+            classes={classes}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('when checkbox user is the current user', () => {
+    const user = { role: PERMISSIONS.ADMIN };
+    const checkboxSpec = { name: PERMISSIONS.USER, value: PERMISSION_VALUES.USER };
+
+    it('renders with correct check status and as disabled', () => {
+      expect(
+        shallow(
+          <PermissionsCheckbox
+            user={user}
+            isCurrentUser={true}
+            checkboxSpec={checkboxSpec}
+            project="project"
+            classes={classes}
+            dispatch={jest.fn()}
+          />,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('when the checkbox is clicked', () => {
+    const mockActions = {
+      addUserPermission: jest.fn(),
+    };
+    mockActions.addUserPermission.mockReturnValue('expected-result');
+
+    const mockDispatch = jest.fn();
+    const project = 'project';
+    const user = { name: 'User One', userId: 'user-one-id', role: PERMISSIONS.USER };
+    const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
+
+    it('dispatches update action with correct user and new permission level', () => {
+      const render = shallow(
+        <PermissionsCheckbox
+          user={user}
+          isCurrentUser={true}
+          checkboxSpec={checkboxSpec}
+          project={project}
+          classes={classes}
+          actions={mockActions}
+          dispatch={mockDispatch}
+        />,
+      );
+      render.find(Checkbox).simulate('click');
+      expect(mockActions.addUserPermission).toHaveBeenCalledTimes(1);
+      expect(mockActions.addUserPermission).toHaveBeenCalledWith(project, user, checkboxSpec.name, mockDispatch);
+    });
+  });
+});
+
+describe('RemoveUserButtonCell', () => {
+  const classes = { tableCell: 'tableCell' };
+  const user = { name: 'User One', userId: 'user-one-id' };
+
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow();
+  });
+
+  it('renders as disabled when on the row of the current user', () => {
+    expect(
+      shallow(
+        <RemoveUserButtonCell
+          user={user}
+          isCurrentUser={true}
+          classes={classes}
+          setRemoveUserDialogState={jest.fn()}
+        />,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('sets the remove user dialog state so it opens when clicked', () => {
+    const mockSetRemoveUserDialogState = jest.fn();
+    const render = shallow(
+      <RemoveUserButtonCell
+        user={user}
+        isCurrentUser={true}
+        classes={classes}
+        setRemoveUserDialogState={mockSetRemoveUserDialogState}
+      />,
+    );
+
+    render.find(IconButton).simulate('click');
+    expect(mockSetRemoveUserDialogState).toHaveBeenCalledTimes(1);
+    expect(mockSetRemoveUserDialogState).toHaveBeenCalledWith({ user, open: true });
+  });
+});

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/RemoveUserDialog.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/RemoveUserDialog.spec.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RemoveUserDialog when the dialog state has open equal to false renders as null 1`] = `""`;
+
+exports[`RemoveUserDialog when the dialog state has open equal to true and a user set renders to match snapshot 1`] = `
+<WithStyles(ForwardRef(Dialog))
+  open={true}
+>
+  <WithStyles(ForwardRef(DialogTitle))>
+    Remove User Permissions?
+  </WithStyles(ForwardRef(DialogTitle))>
+  <WithStyles(ForwardRef(DialogContent))>
+    <WithStyles(ForwardRef(DialogContentText))>
+      Are you sure you want to remove all project permissions for User One?
+    </WithStyles(ForwardRef(DialogContentText))>
+  </WithStyles(ForwardRef(DialogContent))>
+  <WithStyles(ForwardRef(DialogActions))>
+    <WithStyles(ForwardRef(Button))
+      id="cancel-button"
+      onClick={[Function]}
+    >
+      Cancel
+    </WithStyles(ForwardRef(Button))>
+    <WithStyles(ForwardRef(Button))
+      className="dialogDeleteUserButton"
+      id="confirm-button"
+      onClick={[Function]}
+      variant="outlined"
+    >
+      Confirm
+    </WithStyles(ForwardRef(Button))>
+  </WithStyles(ForwardRef(DialogActions))>
+</WithStyles(ForwardRef(Dialog))>
+`;

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckboxCell renders correctly passing props to PermissionsCheckbox in TableCell 1`] = `
-<WithStyles(ForwardRef(TableCell))
-  align="center"
-  key="key"
-  padding="checkbox"
->
-  <PermissionsCheckbox
-    checkboxSpec={
-      Object {
-        "name": "admin",
-        "value": 2,
-      }
-    }
-    classes={
-      Object {
-        "activeSelection": "active",
-        "implicitSelection": "implicit",
-      }
-    }
-    dispatch={[MockFunction]}
-    isCurrentUser={false}
-    project="project"
-    user={
-      Object {
-        "role": "admin",
-      }
-    }
-  />
-</WithStyles(ForwardRef(TableCell))>
-`;
-
 exports[`FullWidthRow returns a table row with correct colSpan and content 1`] = `
 <WithStyles(ForwardRef(TableRow))>
   <WithStyles(ForwardRef(TableCell))
@@ -54,42 +23,6 @@ exports[`FullWidthTextRow returns a table row with correct colSpan and text wrap
     Text to go in row.
   </WithStyles(ForwardRef(Typography))>
 </FullWidthRow>
-`;
-
-exports[`PermissionsCheckbox when checkbox user is the current user renders with correct check status and as disabled 1`] = `
-<WithStyles(ForwardRef(Checkbox))
-  checked={true}
-  className="implicit"
-  color="default"
-  disabled={true}
-  onClick={[Function]}
-/>
-`;
-
-exports[`PermissionsCheckbox when user has rights equal to CheckboxSpec returns an checked active selection check box 1`] = `
-<WithStyles(ForwardRef(Checkbox))
-  checked={true}
-  className="active"
-  color="default"
-  onClick={[Function]}
-/>
-`;
-
-exports[`PermissionsCheckbox when user has rights greater than CheckboxSpec returns an checked implicit selection check box 1`] = `
-<WithStyles(ForwardRef(Checkbox))
-  checked={true}
-  className="implicit"
-  color="default"
-  onClick={[Function]}
-/>
-`;
-
-exports[`PermissionsCheckbox when user has rights less than CheckboxSpec returns an unchecked check box 1`] = `
-<WithStyles(ForwardRef(Checkbox))
-  checked={false}
-  color="default"
-  onClick={[Function]}
-/>
 `;
 
 exports[`PureUserPermissionsTable renders correctly passing props to children 1`] = `
@@ -170,56 +103,6 @@ exports[`PureUserPermissionsTable renders correctly passing props to children 1`
     }
   />
 </div>
-`;
-
-exports[`RemoveUserButtonCell renders as disabled when on the row of the current user 1`] = `
-<WithStyles(ForwardRef(TableCell))
-  align="center"
-  className="tableCell"
-  padding="checkbox"
->
-  <WithStyles(ForwardRef(IconButton))
-    disabled={true}
-    onClick={[Function]}
-  >
-    <WithStyles(ForwardRef(Icon))>
-      remove_circle_outline
-    </WithStyles(ForwardRef(Icon))>
-  </WithStyles(ForwardRef(IconButton))>
-</WithStyles(ForwardRef(TableCell))>
-`;
-
-exports[`RemoveUserDialog when the dialog state has open equal to false renders as null 1`] = `""`;
-
-exports[`RemoveUserDialog when the dialog state has open equal to true and a user set renders to match snapshot 1`] = `
-<WithStyles(ForwardRef(Dialog))
-  open={true}
->
-  <WithStyles(ForwardRef(DialogTitle))>
-    Remove User Permissions?
-  </WithStyles(ForwardRef(DialogTitle))>
-  <WithStyles(ForwardRef(DialogContent))>
-    <WithStyles(ForwardRef(DialogContentText))>
-      Are you sure you want to remove all project permissions for User One?
-    </WithStyles(ForwardRef(DialogContentText))>
-  </WithStyles(ForwardRef(DialogContent))>
-  <WithStyles(ForwardRef(DialogActions))>
-    <WithStyles(ForwardRef(Button))
-      id="cancel-button"
-      onClick={[Function]}
-    >
-      Cancel
-    </WithStyles(ForwardRef(Button))>
-    <WithStyles(ForwardRef(Button))
-      className="dialogDeleteUserButton"
-      id="confirm-button"
-      onClick={[Function]}
-      variant="outlined"
-    >
-      Confirm
-    </WithStyles(ForwardRef(Button))>
-  </WithStyles(ForwardRef(DialogActions))>
-</WithStyles(ForwardRef(Dialog))>
 `;
 
 exports[`UserPermissionsTableBody when fetching data renders progress indicator 1`] = `

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
@@ -1,84 +1,162 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PureUserPermissionsTable when fetching data renders progress indicator 1`] = `
+exports[`CheckboxCell renders correctly passing props to PermissionsCheckbox in TableCell 1`] = `
+<WithStyles(ForwardRef(TableCell))
+  align="center"
+  key="key"
+  padding="checkbox"
+>
+  <PermissionsCheckbox
+    checkboxSpec={
+      Object {
+        "name": "admin",
+        "value": 2,
+      }
+    }
+    classes={
+      Object {
+        "activeSelection": "active",
+        "implicitSelection": "implicit",
+      }
+    }
+    dispatch={[MockFunction]}
+    isCurrentUser={false}
+    project="project"
+    user={
+      Object {
+        "role": "admin",
+      }
+    }
+  />
+</WithStyles(ForwardRef(TableCell))>
+`;
+
+exports[`FullWidthRow returns a table row with correct colSpan and content 1`] = `
+<WithStyles(ForwardRef(TableRow))>
+  <WithStyles(ForwardRef(TableCell))
+    align="center"
+    colSpan={4}
+  >
+    <div>
+      row content
+    </div>
+  </WithStyles(ForwardRef(TableCell))>
+</WithStyles(ForwardRef(TableRow))>
+`;
+
+exports[`FullWidthTextRow returns a table row with correct colSpan and text wrapped in Typography 1`] = `
+<FullWidthRow
+  numCols={4}
+>
+  <WithStyles(ForwardRef(Typography))
+    variant="body1"
+  >
+    Text to go in row.
+  </WithStyles(ForwardRef(Typography))>
+</FullWidthRow>
+`;
+
+exports[`PermissionsCheckbox when checkbox user is the current user renders with correct check status and as disabled 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="implicit"
+  color="default"
+  disabled={true}
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights equal to CheckboxSpec returns an checked active selection check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="active"
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights greater than CheckboxSpec returns an checked implicit selection check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="implicit"
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights less than CheckboxSpec returns an unchecked check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={false}
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`PureUserPermissionsTable renders correctly passing props to children 1`] = `
 <div>
   <WithStyles(ForwardRef(Table))>
     <WithStyles(ForwardRef(TableHead))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="left"
-          className="tableCell"
-          key="header-0"
-          padding={null}
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User Name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-1"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Admin
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-2"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-3"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Viewer
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-4"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
+      <UserPermissionsTableHead
+        classes={
+          Object {
+            "activeSelection": "activeSelection",
+            "implicitSelection": "implicitSelection",
+            "tableCell": "tableCell",
+            "tableHeader": "tableHeader",
+          }
+        }
+        headings={
+          Array [
+            Object {
+              "checkBoxCol": false,
+              "heading": "User Name",
+            },
+            Object {
+              "checkBoxCol": true,
+              "heading": "Admin",
+            },
+            Object {
+              "checkBoxCol": true,
+              "heading": "User",
+            },
+            Object {
+              "checkBoxCol": true,
+              "heading": "Viewer",
+            },
+            Object {
+              "checkBoxCol": true,
+              "heading": "",
+            },
+          ]
+        }
+      />
     </WithStyles(ForwardRef(TableHead))>
     <WithStyles(ForwardRef(TableBody))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          colSpan={5}
-        >
-          <WithStyles(ForwardRef(CircularProgress)) />
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
+      <UserPermissionsTableBody
+        classes={
+          Object {
+            "activeSelection": "activeSelection",
+            "implicitSelection": "implicitSelection",
+            "tableCell": "tableCell",
+            "tableHeader": "tableHeader",
+          }
+        }
+        numCols={5}
+        users={
+          Object {
+            "error": null,
+            "fetching": Object {
+              "error": false,
+              "inProgress": false,
+            },
+            "updating": Object {
+              "error": false,
+              "inProgress": false,
+            },
+            "value": Array [],
+          }
+        }
+      />
     </WithStyles(ForwardRef(TableBody))>
   </WithStyles(ForwardRef(Table))>
   <RemoveUserDialog
@@ -90,477 +168,25 @@ exports[`PureUserPermissionsTable when fetching data renders progress indicator 
         "tableHeader": "tableHeader",
       }
     }
-    project="project"
   />
 </div>
 `;
 
-exports[`PureUserPermissionsTable when there are no users renders correctly displaying there are no users 1`] = `
-<div>
-  <WithStyles(ForwardRef(Table))>
-    <WithStyles(ForwardRef(TableHead))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="left"
-          className="tableCell"
-          key="header-0"
-          padding={null}
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User Name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-1"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Admin
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-2"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-3"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Viewer
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-4"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableHead))>
-    <WithStyles(ForwardRef(TableBody))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          colSpan={5}
-        >
-          <WithStyles(ForwardRef(Typography))
-            variant="body1"
-          >
-            No users have project permissions.
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableBody))>
-  </WithStyles(ForwardRef(Table))>
-  <RemoveUserDialog
-    classes={
-      Object {
-        "activeSelection": "activeSelection",
-        "implicitSelection": "implicitSelection",
-        "tableCell": "tableCell",
-        "tableHeader": "tableHeader",
-      }
-    }
-    project="project"
-  />
-</div>
-`;
-
-exports[`PureUserPermissionsTable when there are users renders correctly showing users and their permissions 1`] = `
-<div>
-  <WithStyles(ForwardRef(Table))>
-    <WithStyles(ForwardRef(TableHead))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="left"
-          className="tableCell"
-          key="header-0"
-          padding={null}
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User Name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-1"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Admin
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-2"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-3"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Viewer
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-4"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableHead))>
-    <WithStyles(ForwardRef(TableBody))>
-      <WithStyles(ForwardRef(TableRow))
-        key="row-0"
-      >
-        <WithStyles(ForwardRef(TableCell))
-          className="tableCell"
-          key="row-0-USERNAME"
-        >
-          <WithStyles(ForwardRef(Typography))
-            variant="body1"
-          >
-            admin name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-0-admin"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="activeSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-0-user"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="implicitSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-0-viewer"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="implicitSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(IconButton))
-            onClick={[Function]}
-          >
-            <WithStyles(ForwardRef(Icon))>
-              remove_circle_outline
-            </WithStyles(ForwardRef(Icon))>
-          </WithStyles(ForwardRef(IconButton))>
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-      <WithStyles(ForwardRef(TableRow))
-        key="row-1"
-      >
-        <WithStyles(ForwardRef(TableCell))
-          className="tableCell"
-          key="row-1-USERNAME"
-        >
-          <WithStyles(ForwardRef(Typography))
-            variant="body1"
-          >
-            user name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-1-admin"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={false}
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-1-user"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="activeSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-1-viewer"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="implicitSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(IconButton))
-            onClick={[Function]}
-          >
-            <WithStyles(ForwardRef(Icon))>
-              remove_circle_outline
-            </WithStyles(ForwardRef(Icon))>
-          </WithStyles(ForwardRef(IconButton))>
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-      <WithStyles(ForwardRef(TableRow))
-        key="row-2"
-      >
-        <WithStyles(ForwardRef(TableCell))
-          className="tableCell"
-          key="row-2-USERNAME"
-        >
-          <WithStyles(ForwardRef(Typography))
-            variant="body1"
-          >
-            viewer name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-2-admin"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={false}
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-2-user"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={false}
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="row-2-viewer"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Checkbox))
-            checked={true}
-            className="activeSelection"
-            color="default"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(IconButton))
-            onClick={[Function]}
-          >
-            <WithStyles(ForwardRef(Icon))>
-              remove_circle_outline
-            </WithStyles(ForwardRef(Icon))>
-          </WithStyles(ForwardRef(IconButton))>
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableBody))>
-  </WithStyles(ForwardRef(Table))>
-  <RemoveUserDialog
-    classes={
-      Object {
-        "activeSelection": "activeSelection",
-        "implicitSelection": "implicitSelection",
-        "tableCell": "tableCell",
-        "tableHeader": "tableHeader",
-      }
-    }
-    project="project"
-  />
-</div>
-`;
-
-exports[`PureUserPermissionsTable when there is an error renders correctly displaying there is an error 1`] = `
-<div>
-  <WithStyles(ForwardRef(Table))>
-    <WithStyles(ForwardRef(TableHead))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="left"
-          className="tableCell"
-          key="header-0"
-          padding={null}
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User Name
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-1"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Admin
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-2"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            User
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-3"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          >
-            Viewer
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          className="tableCell"
-          key="header-4"
-          padding="checkbox"
-        >
-          <WithStyles(ForwardRef(Typography))
-            className="tableHeader"
-            variant="body1"
-          />
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableHead))>
-    <WithStyles(ForwardRef(TableBody))>
-      <WithStyles(ForwardRef(TableRow))>
-        <WithStyles(ForwardRef(TableCell))
-          align="center"
-          colSpan={5}
-        >
-          <WithStyles(ForwardRef(Typography))
-            variant="body1"
-          >
-            Error fetching data. Please try refreshing the page.
-          </WithStyles(ForwardRef(Typography))>
-        </WithStyles(ForwardRef(TableCell))>
-      </WithStyles(ForwardRef(TableRow))>
-    </WithStyles(ForwardRef(TableBody))>
-  </WithStyles(ForwardRef(Table))>
-  <RemoveUserDialog
-    classes={
-      Object {
-        "activeSelection": "activeSelection",
-        "implicitSelection": "implicitSelection",
-        "tableCell": "tableCell",
-        "tableHeader": "tableHeader",
-      }
-    }
-    project="project"
-  />
-</div>
+exports[`RemoveUserButtonCell renders as disabled when on the row of the current user 1`] = `
+<WithStyles(ForwardRef(TableCell))
+  align="center"
+  className="tableCell"
+  padding="checkbox"
+>
+  <WithStyles(ForwardRef(IconButton))
+    disabled={true}
+    onClick={[Function]}
+  >
+    <WithStyles(ForwardRef(Icon))>
+      remove_circle_outline
+    </WithStyles(ForwardRef(Icon))>
+  </WithStyles(ForwardRef(IconButton))>
+</WithStyles(ForwardRef(TableCell))>
 `;
 
 exports[`RemoveUserDialog when the dialog state has open equal to false renders as null 1`] = `""`;
@@ -596,66 +222,93 @@ exports[`RemoveUserDialog when the dialog state has open equal to true and a use
 </WithStyles(ForwardRef(Dialog))>
 `;
 
-exports[`getFullWidthRow returns a table row with correct colSpan and content 1`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
-    }
-  }
+exports[`UserPermissionsTableBody when fetching data renders progress indicator 1`] = `
+<FullWidthRow
+  numCols={5}
 >
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    colSpan={4}
-  >
-    <div>
-      row content
-    </div>
-  </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
+  <WithStyles(ForwardRef(CircularProgress)) />
+</FullWidthRow>
 `;
 
-exports[`getFullWidthTextRow returns a table row with correct colSpan and text wrapped in Typography 1`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
+exports[`UserPermissionsTableBody when there are users correctly renders row for each user 1`] = `
+Array [
+  <UserPermissionsTableRow
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+        "tableHeader": "tableHeader",
+      }
     }
-  }
->
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    colSpan={4}
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="body1"
-    >
-      Text to go in row.
-    </WithStyles(ForwardRef(Typography))>
-  </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
+    dispatch={[MockFunction]}
+    index={0}
+    isCurrentUser={true}
+    project="project"
+    setRemoveUserDialogState={[MockFunction]}
+    user={
+      Object {
+        "name": "admin name",
+        "role": "admin",
+        "userId": "admin-user-id",
+      }
+    }
+  />,
+  <UserPermissionsTableRow
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+        "tableHeader": "tableHeader",
+      }
+    }
+    dispatch={[MockFunction]}
+    index={1}
+    isCurrentUser={false}
+    project="project"
+    setRemoveUserDialogState={[MockFunction]}
+    user={
+      Object {
+        "name": "user name",
+        "role": "user",
+      }
+    }
+  />,
+  <UserPermissionsTableRow
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+        "tableHeader": "tableHeader",
+      }
+    }
+    dispatch={[MockFunction]}
+    index={2}
+    isCurrentUser={false}
+    project="project"
+    setRemoveUserDialogState={[MockFunction]}
+    user={
+      Object {
+        "name": "viewer name",
+        "role": "viewer",
+      }
+    }
+  />,
+]
 `;
 
-exports[`getTableHead renders correct header bar based on column headings 1`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
-    }
-  }
+exports[`UserPermissionsTableBody when there is an error fetching renders correctly displaying there is an error 1`] = `
+<FullWidthTextRow
+  numCols={5}
 >
+  Error fetching data. Please try refreshing the page.
+</FullWidthTextRow>
+`;
+
+exports[`UserPermissionsTableHead renders correct header bar based on column headings 1`] = `
+<WithStyles(ForwardRef(TableRow))>
   <WithStyles(ForwardRef(TableCell))
     align="left"
     className="tableCell"
@@ -682,24 +335,16 @@ exports[`getTableHead renders correct header bar based on column headings 1`] = 
       check box col
     </WithStyles(ForwardRef(Typography))>
   </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
+</WithStyles(ForwardRef(TableRow))>
 `;
 
-exports[`getTableRow for a given user renders correctly showing users and their permissions 1`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
-    }
-  }
+exports[`UserPermissionsTableRow for a given user correctly renders passing props to children when not current user 1`] = `
+<WithStyles(ForwardRef(TableRow))
+  key="row-2"
 >
   <WithStyles(ForwardRef(TableCell))
     className="tableCell"
-    key="row-0-USERNAME"
+    key="row-2-username"
   >
     <WithStyles(ForwardRef(Typography))
       variant="body1"
@@ -707,330 +352,100 @@ exports[`getTableRow for a given user renders correctly showing users and their 
       admin name
     </WithStyles(ForwardRef(Typography))>
   </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-0-admin"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="activeSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-0-user"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="implicitSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-0-viewer"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="implicitSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(IconButton))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(Icon))>
-        remove_circle_outline
-      </WithStyles(ForwardRef(Icon))>
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
-`;
-
-exports[`getTableRow for a given user renders correctly showing users and their permissions 2`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
+  <CheckboxCell
+    cellKey="row-2-admin"
+    checkboxSpec={
+      Object {
+        "name": "admin",
+        "value": 2,
+      }
     }
-  }
->
-  <WithStyles(ForwardRef(TableCell))
-    className="tableCell"
-    key="row-1-USERNAME"
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="body1"
-    >
-      user name
-    </WithStyles(ForwardRef(Typography))>
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-1-admin"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={false}
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-1-user"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="activeSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    key="row-1-viewer"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="implicitSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(IconButton))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(Icon))>
-        remove_circle_outline
-      </WithStyles(ForwardRef(Icon))>
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
-`;
-
-exports[`getTableRow for a given user renders correctly showing users and their permissions 3`] = `
-<ForwardRef(TableRow)
-  classes={
-    Object {
-      "footer": "MuiTableRow-footer",
-      "head": "MuiTableRow-head",
-      "hover": "MuiTableRow-hover",
-      "root": "MuiTableRow-root",
-      "selected": "Mui-selected",
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+      }
     }
-  }
->
-  <WithStyles(ForwardRef(TableCell))
-    className="tableCell"
-    key="row-2-USERNAME"
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="body1"
-    >
-      viewer name
-    </WithStyles(ForwardRef(Typography))>
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
+    dispatch={[MockFunction]}
+    isCurrentUser={false}
     key="row-2-admin"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={false}
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
+    project="project"
+    user={
+      Object {
+        "name": "admin name",
+        "role": "admin",
+      }
+    }
+  />
+  <CheckboxCell
+    cellKey="row-2-user"
+    checkboxSpec={
+      Object {
+        "name": "user",
+        "value": 1,
+      }
+    }
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+      }
+    }
+    dispatch={[MockFunction]}
+    isCurrentUser={false}
     key="row-2-user"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={false}
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
+    project="project"
+    user={
+      Object {
+        "name": "admin name",
+        "role": "admin",
+      }
+    }
+  />
+  <CheckboxCell
+    cellKey="row-2-viewer"
+    checkboxSpec={
+      Object {
+        "name": "viewer",
+        "value": 0,
+      }
+    }
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+      }
+    }
+    dispatch={[MockFunction]}
+    isCurrentUser={false}
     key="row-2-viewer"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(Checkbox))
-      checked={true}
-      className="activeSelection"
-      color="default"
-    />
-  </WithStyles(ForwardRef(TableCell))>
-  <WithStyles(ForwardRef(TableCell))
-    align="center"
-    className="tableCell"
-    padding="checkbox"
-  >
-    <WithStyles(ForwardRef(IconButton))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(Icon))>
-        remove_circle_outline
-      </WithStyles(ForwardRef(Icon))>
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(TableCell))>
-</ForwardRef(TableRow)>
-`;
-
-exports[`when getting checkbox cells when user has rights equal to check box getCheckbox returns an checked active selection check box 1`] = `
-<ForwardRef(Checkbox)
-  checked={true}
-  className="active"
-  classes={
-    Object {
-      "checked": "Mui-checked",
-      "colorPrimary": "MuiCheckbox-colorPrimary",
-      "colorSecondary": "MuiCheckbox-colorSecondary",
-      "disabled": "Mui-disabled",
-      "indeterminate": "MuiCheckbox-indeterminate",
-      "root": "MuiCheckbox-root",
+    project="project"
+    user={
+      Object {
+        "name": "admin name",
+        "role": "admin",
+      }
     }
-  }
-  color="default"
-/>
-`;
-
-exports[`when getting checkbox cells when user has rights equal to check box getCheckboxCell returns a table cell with a checked active check box inside 1`] = `
-<ForwardRef(TableCell)
-  align="center"
-  classes={
-    Object {
-      "alignCenter": "MuiTableCell-alignCenter",
-      "alignJustify": "MuiTableCell-alignJustify",
-      "alignLeft": "MuiTableCell-alignLeft",
-      "alignRight": "MuiTableCell-alignRight",
-      "body": "MuiTableCell-body",
-      "footer": "MuiTableCell-footer",
-      "head": "MuiTableCell-head",
-      "paddingCheckbox": "MuiTableCell-paddingCheckbox",
-      "paddingNone": "MuiTableCell-paddingNone",
-      "root": "MuiTableCell-root",
-      "sizeSmall": "MuiTableCell-sizeSmall",
-    }
-  }
-  padding="checkbox"
->
-  <WithStyles(ForwardRef(Checkbox))
-    checked={true}
-    className="active"
-    color="default"
   />
-</ForwardRef(TableCell)>
-`;
-
-exports[`when getting checkbox cells when user has rights greater than check box getCheckbox returns a check implicit selection check box 1`] = `
-<ForwardRef(Checkbox)
-  checked={true}
-  className="implicit"
-  classes={
-    Object {
-      "checked": "Mui-checked",
-      "colorPrimary": "MuiCheckbox-colorPrimary",
-      "colorSecondary": "MuiCheckbox-colorSecondary",
-      "disabled": "Mui-disabled",
-      "indeterminate": "MuiCheckbox-indeterminate",
-      "root": "MuiCheckbox-root",
+  <RemoveUserButtonCell
+    classes={
+      Object {
+        "activeSelection": "activeSelection",
+        "implicitSelection": "implicitSelection",
+        "tableCell": "tableCell",
+      }
     }
-  }
-  color="default"
-/>
-`;
-
-exports[`when getting checkbox cells when user has rights greater than check box getCheckboxCell returns a table cell with a checked implicit selection check box inside 1`] = `
-<ForwardRef(TableCell)
-  align="center"
-  classes={
-    Object {
-      "alignCenter": "MuiTableCell-alignCenter",
-      "alignJustify": "MuiTableCell-alignJustify",
-      "alignLeft": "MuiTableCell-alignLeft",
-      "alignRight": "MuiTableCell-alignRight",
-      "body": "MuiTableCell-body",
-      "footer": "MuiTableCell-footer",
-      "head": "MuiTableCell-head",
-      "paddingCheckbox": "MuiTableCell-paddingCheckbox",
-      "paddingNone": "MuiTableCell-paddingNone",
-      "root": "MuiTableCell-root",
-      "sizeSmall": "MuiTableCell-sizeSmall",
+    isCurrentUser={false}
+    setRemoveUserDialogState={[MockFunction]}
+    user={
+      Object {
+        "name": "admin name",
+        "role": "admin",
+      }
     }
-  }
-  padding="checkbox"
->
-  <WithStyles(ForwardRef(Checkbox))
-    checked={true}
-    className="implicit"
-    color="default"
   />
-</ForwardRef(TableCell)>
-`;
-
-exports[`when getting checkbox cells when user has rights less than check box getCheckbox returns an unchecked check box 1`] = `
-<ForwardRef(Checkbox)
-  checked={false}
-  classes={
-    Object {
-      "checked": "Mui-checked",
-      "colorPrimary": "MuiCheckbox-colorPrimary",
-      "colorSecondary": "MuiCheckbox-colorSecondary",
-      "disabled": "Mui-disabled",
-      "indeterminate": "MuiCheckbox-indeterminate",
-      "root": "MuiCheckbox-root",
-    }
-  }
-/>
-`;
-
-exports[`when getting checkbox cells when user has rights less than check box getCheckboxCell returns a table cell with an unchecked check box inside 1`] = `
-<ForwardRef(TableCell)
-  align="center"
-  classes={
-    Object {
-      "alignCenter": "MuiTableCell-alignCenter",
-      "alignJustify": "MuiTableCell-alignJustify",
-      "alignLeft": "MuiTableCell-alignLeft",
-      "alignRight": "MuiTableCell-alignRight",
-      "body": "MuiTableCell-body",
-      "footer": "MuiTableCell-footer",
-      "head": "MuiTableCell-head",
-      "paddingCheckbox": "MuiTableCell-paddingCheckbox",
-      "paddingNone": "MuiTableCell-paddingNone",
-      "root": "MuiTableCell-root",
-      "sizeSmall": "MuiTableCell-sizeSmall",
-    }
-  }
-  padding="checkbox"
->
-  <WithStyles(ForwardRef(Checkbox))
-    checked={false}
-  />
-</ForwardRef(TableCell)>
+</WithStyles(ForwardRef(TableRow))>
 `;

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTableActionCells.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTableActionCells.spec.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxCell renders correctly passing props to PermissionsCheckbox in TableCell 1`] = `
+<WithStyles(ForwardRef(TableCell))
+  align="center"
+  key="key"
+  padding="checkbox"
+>
+  <PermissionsCheckbox
+    checkboxSpec={
+      Object {
+        "name": "admin",
+        "value": 2,
+      }
+    }
+    classes={
+      Object {
+        "activeSelection": "active",
+        "implicitSelection": "implicit",
+      }
+    }
+    dispatch={[MockFunction]}
+    isCurrentUser={false}
+    project="project"
+    user={
+      Object {
+        "role": "admin",
+      }
+    }
+  />
+</WithStyles(ForwardRef(TableCell))>
+`;
+
+exports[`PermissionsCheckbox when checkbox user is the current user renders with correct check status and as disabled 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="implicit"
+  color="default"
+  disabled={true}
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights equal to CheckboxSpec returns an checked active selection check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="active"
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights greater than CheckboxSpec returns an checked implicit selection check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={true}
+  className="implicit"
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`PermissionsCheckbox when user has rights less than CheckboxSpec returns an unchecked check box 1`] = `
+<WithStyles(ForwardRef(Checkbox))
+  checked={false}
+  color="default"
+  onClick={[Function]}
+/>
+`;
+
+exports[`RemoveUserButtonCell renders as disabled when on the row of the current user 1`] = `
+<WithStyles(ForwardRef(TableCell))
+  align="center"
+  className="tableCell"
+  padding="checkbox"
+>
+  <WithStyles(ForwardRef(IconButton))
+    disabled={true}
+    onClick={[Function]}
+  >
+    <WithStyles(ForwardRef(Icon))>
+      remove_circle_outline
+    </WithStyles(ForwardRef(Icon))>
+  </WithStyles(ForwardRef(IconButton))>
+</WithStyles(ForwardRef(TableCell))>
+`;


### PR DESCRIPTION
Update the user permissions table to:
* Enable clicking on checkboxes to change permissions of users
* Disable controls in table for the current user so they can't change their own permissions

Refactored code to make user permissions tables use a series of functional components rather than series of functions returning react components to make the code more readable.