### PR TITLE
Nercdl 372 - get project data from graphQL

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/projectService.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.js
@@ -7,14 +7,14 @@ const authServiceUrl = `${config.get('authorisationService')}`;
 const dummyProjects = [
   {
     id: 123,
-    name: 'The project with id "project"',
+    name: 'The project with key "project"',
     key: 'project',
     description: 'Once upon a time there was only one...',
     collaborationLink: 'https://testlab.test-datalabs.nerc.ac.uk/',
   },
   {
     id: 222,
-    name: '"project2" is the ID of this',
+    name: '"project2" is the key of this',
     key: 'project2',
     description: 'This is the second project.',
   },

--- a/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`projectsService loadProjects should build the correct query and unpack the results 1`] = `
+"
+    LoadProjects {
+      projects {
+        id, key, name, description
+      }
+    }"
+`;

--- a/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`projectsService loadProjectInfo should build the correct query and unpack the results 1`] = `
+"
+    LoadProjectInfo($key: String!) {
+      project(key: $key) {
+        id, key, name, description
+      }
+    }"
+`;
+
 exports[`projectsService loadProjects should build the correct query and unpack the results 1`] = `
 "
     LoadProjects {

--- a/code/workspaces/web-app/src/api/dataStorageService.spec.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.spec.js
@@ -23,10 +23,6 @@ describe('dataStorageService', () => {
         expect(error).toEqual({ error: 'error' });
       });
     });
-
-    it('should not throw an error if there is an in users', () => {
-
-    });
   });
 
   describe('getCredentials', () => {

--- a/code/workspaces/web-app/src/api/projectsService.js
+++ b/code/workspaces/web-app/src/api/projectsService.js
@@ -1,37 +1,6 @@
 import { gqlQuery } from './graphqlClient';
 import errorHandler from './graphqlErrorHandler';
 
-const dummyProjects = [
-  {
-    id: 'project',
-    displayName: 'The project with id "project"',
-    description: 'Once upon a time there was only one...',
-    type: 'project',
-    status: 'ready',
-  },
-  {
-    id: 'project2',
-    displayName: '"project2" is the ID of this',
-    description: 'This is the second project.',
-    type: 'project',
-    status: 'ready',
-  },
-  {
-    id: 'project3',
-    displayName: 'And this is "project3"',
-    description: 'This is another project.',
-    type: 'project',
-    status: 'ready',
-  },
-  {
-    id: 'projectX',
-    displayName: 'What?',
-    description: 'No-one has permission to see this...',
-    type: 'project',
-    status: 'ready',
-  },
-];
-
 function loadProjects() {
   const query = `
     LoadProjects {
@@ -44,14 +13,16 @@ function loadProjects() {
     .then(errorHandler('data.projects'));
 }
 
-function loadProjectInfo(projectKey) {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        currentProject: dummyProjects.filter(project => project.id === projectKey)[0],
-      });
-    }, 2000);
-  });
+function loadProjectInfo(key) {
+  const query = `
+    LoadProjectInfo($key: String!) {
+      project(key: $key) {
+        id, key, name, description
+      }
+    }`;
+
+  return gqlQuery(query, { key })
+    .then(errorHandler('data.project'));
 }
 
 export default { loadProjects, loadProjectInfo };

--- a/code/workspaces/web-app/src/api/projectsService.js
+++ b/code/workspaces/web-app/src/api/projectsService.js
@@ -1,3 +1,6 @@
+import { gqlQuery } from './graphqlClient';
+import errorHandler from './graphqlErrorHandler';
+
 const dummyProjects = [
   {
     id: 'project',
@@ -30,13 +33,15 @@ const dummyProjects = [
 ];
 
 function loadProjects() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({
-        projectArray: dummyProjects,
-      });
-    }, 2000);
-  });
+  const query = `
+    LoadProjects {
+      projects {
+        id, key, name, description
+      }
+    }`;
+
+  return gqlQuery(query)
+    .then(errorHandler('data.projects'));
 }
 
 function loadProjectInfo(projectKey) {

--- a/code/workspaces/web-app/src/api/projectsService.spec.js
+++ b/code/workspaces/web-app/src/api/projectsService.spec.js
@@ -1,0 +1,27 @@
+import mockClient from './graphqlClient';
+import projectsService from './projectsService';
+
+jest.mock('./graphqlClient');
+
+describe('projectsService', () => {
+  beforeEach(() => mockClient.clearResult());
+
+  describe('loadProjects', () => {
+    it('should build the correct query and unpack the results', () => {
+      mockClient.prepareSuccess({ projects: 'expectedValue' });
+
+      return projectsService.loadProjects().then((response) => {
+        expect(response).toEqual('expectedValue');
+        expect(mockClient.lastQuery()).toMatchSnapshot();
+      });
+    });
+
+    it('should throw an error if the query fails', () => {
+      mockClient.prepareFailure('error');
+
+      return projectsService.loadProjects().catch((error) => {
+        expect(error).toEqual({ error: 'error' });
+      });
+    });
+  });
+});

--- a/code/workspaces/web-app/src/api/projectsService.spec.js
+++ b/code/workspaces/web-app/src/api/projectsService.spec.js
@@ -24,4 +24,23 @@ describe('projectsService', () => {
       });
     });
   });
+
+  describe('loadProjectInfo', () => {
+    it('should build the correct query and unpack the results', () => {
+      mockClient.prepareSuccess({ project: 'expectedValue' });
+
+      return projectsService.loadProjectInfo().then((response) => {
+        expect(response).toEqual('expectedValue');
+        expect(mockClient.lastQuery()).toMatchSnapshot();
+      });
+    });
+
+    it('should throw an error if the query fails', () => {
+      mockClient.prepareFailure('error');
+
+      return projectsService.loadProjectInfo().catch((error) => {
+        expect(error).toEqual({ error: 'error' });
+      });
+    });
+  });
 });

--- a/code/workspaces/web-app/src/components/projectInfo/ProjectInfoContent.js
+++ b/code/workspaces/web-app/src/components/projectInfo/ProjectInfoContent.js
@@ -4,7 +4,7 @@ import { Typography } from '@material-ui/core';
 
 const ProjectInfoContent = ({ projectInfo }) => (
   <div>
-    <Typography variant='h5'>{projectInfo.id}: {projectInfo.displayName}</Typography>
+    <Typography variant='h5'>{projectInfo.key}: {projectInfo.name}</Typography>
     <Typography variant='body1'>
       {projectInfo.description}
     </Typography>

--- a/code/workspaces/web-app/src/components/projectInfo/ProjectInfoContent.spec.js
+++ b/code/workspaces/web-app/src/components/projectInfo/ProjectInfoContent.spec.js
@@ -4,11 +4,9 @@ import ProjectInfoContent from './ProjectInfoContent';
 
 describe('ProjectInfoContent', () => {
   const projectInfo = {
-    id: 'project2',
-    displayName: '"project2" is the ID of this',
+    key: 'project2',
+    name: '"project2" is the ID of this',
     description: 'This is the second project.',
-    type: 'project',
-    status: 'ready',
   };
 
   function shallowRender() {

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions.js
@@ -28,7 +28,7 @@ const StackCardActions = ({ stack, openStack, deleteStack, editStack, userPermis
         className={classes.button}
         color="primary"
         disabled={!openStack || !isReady(stack)}
-        onClick={() => openStack(stack.id)}
+        onClick={() => openStack(stack)}
         variant="contained" >
         Open
       </Button>

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions.spec.js
@@ -60,7 +60,12 @@ describe('StackCardActions', () => {
     expect(openStackMock).not.toHaveBeenCalled();
     onClick();
     expect(openStackMock).toHaveBeenCalledTimes(1);
-    expect(openStackMock).toHaveBeenCalledWith('abc1234');
+    expect(openStackMock).toHaveBeenCalledWith({
+      displayName: 'expectedDisplayName',
+      id: 'abc1234',
+      type: 'expectedType',
+      status: 'ready',
+    });
   });
 
   it('Delete button onClick function calls openStack with correct props', () => {

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -41,7 +41,7 @@ class DataStorageContainer extends Component {
     return !isFetching;
   }
 
-  openDataStore = id => this.props.actions.getCredentials(id)
+  openDataStore = dataStore => this.props.actions.getCredentials(dataStore.id)
     .then(payload => pick(payload.value, ['url', 'accessKey']))
     .then(({ url, accessKey }) => this.props.actions.openMinioDataStore(url, accessKey))
     .catch(err => notify.error(`Unable to open ${TYPE_NAME}`));

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
@@ -127,7 +127,7 @@ describe('DataStorageContainer', () => {
       // Act/Assert
       expect(getCredentialsMock).not.toHaveBeenCalled();
       expect(openMinioDataStoreMock).not.toHaveBeenCalled();
-      return openStack(1000)
+      return openStack({ id: 1000 })
         .then(() => {
           expect(getCredentialsMock).toHaveBeenCalledTimes(1);
           expect(getCredentialsMock).toHaveBeenCalledWith(1000);

--- a/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.js
+++ b/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.js
@@ -10,7 +10,7 @@ class ProjectTitleContainer extends Component {
     return (
       <PromisedContentWrapper promise={this.props.projects}>
         {this.props.projects.value.currentProject ? (
-          <span>{this.props.projects.value.currentProject.displayName}</span>
+          <span>{this.props.projects.value.currentProject.name}</span>
         ) : (<div/>)}
       </PromisedContentWrapper>
     );

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
@@ -22,14 +22,25 @@ class ProjectsContainer extends Component {
     this.props.actions.loadProjects();
   }
 
+  adaptProjectsToStacks() {
+    return this.props.projects.value.projectArray.map(project => ({
+      id: project.id,
+      key: project.key,
+      displayName: project.name,
+      description: project.description,
+      type: 'project',
+      status: 'ready',
+    }));
+  }
+
   render() {
     return (
       <PromisedContentWrapper promise={this.props.projects}>
         {this.props.projects.value.projectArray ? (
           <StackCards
-            stacks={this.props.projects.value.projectArray}
+            stacks={this.adaptProjectsToStacks()}
             typeName={TYPE_NAME}
-            openStack={id => this.props.history.push(`/projects/${id}/info`)}
+            openStack={project => this.props.history.push(`/projects/${project.key}/info`)}
             deleteStack={() => { }}
             openCreationForm={() => { }}
             userPermissions={this.props.userPermissions}

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
@@ -5,7 +5,15 @@ import { PureProjectsContainer, ConnectedProjectsContainer } from './ProjectsCon
 import projectsService from '../../api/projectsService';
 
 jest.mock('../../api/projectsService');
-const loadProjectsMock = jest.fn().mockReturnValue(Promise.resolve('expectedPayload'));
+const projectsPayload = {
+  projectsArray: [{
+    id: 123,
+    key: 'project2',
+    name: 'A project name',
+    description: 'A project description',
+  }],
+};
+const loadProjectsMock = jest.fn().mockReturnValue(Promise.resolve(projectsPayload));
 projectsService.loadProjects = loadProjectsMock;
 
 describe('ProjectsContainer', () => {
@@ -13,8 +21,8 @@ describe('ProjectsContainer', () => {
     function shallowRenderConnected(store) {
       const props = {
         store,
-        PrivateComponent: () => {},
-        PublicComponent: () => {},
+        PrivateComponent: () => { },
+        PublicComponent: () => { },
         userPermissions: ['expectedPermission'],
       };
 
@@ -63,7 +71,7 @@ describe('ProjectsContainer', () => {
       output.prop('actions').loadProjects();
       const { type, payload } = store.getActions()[0];
       expect(type).toBe('LOAD_PROJECTS');
-      return payload.then(value => expect(value).toBe('expectedPayload'));
+      return payload.then(value => expect(value).toBe(projectsPayload));
     });
   });
 
@@ -72,7 +80,7 @@ describe('ProjectsContainer', () => {
       return shallow(<PureProjectsContainer {...props} />);
     }
 
-    const projects = { fetching: false, value: { projectArray: ['expectedArray'] } };
+    const projects = { fetching: false, value: projectsPayload };
 
     const generateProps = () => ({
       projects,

--- a/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
@@ -13,32 +13,18 @@ exports[`ProjectsContainer is a container which passes correct props to StackCar
     Object {
       "fetching": false,
       "value": Object {
-        "projectArray": Array [
-          "expectedArray",
+        "projectsArray": Array [
+          Object {
+            "description": "A project description",
+            "id": 123,
+            "key": "project2",
+            "name": "A project name",
+          },
         ],
       },
     }
   }
 >
-  <WithStyles(StackCards)
-    createPermission=""
-    deletePermission=""
-    deleteStack={[Function]}
-    editPermission=""
-    openCreationForm={[Function]}
-    openPermission="project:storage:open"
-    openStack={[Function]}
-    stacks={
-      Array [
-        "expectedArray",
-      ]
-    }
-    typeName="Project"
-    userPermissions={
-      Array [
-        "expectedPermission",
-      ]
-    }
-  />
+  <div />
 </PromisedContentWrapper>
 `;

--- a/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
+++ b/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
@@ -27,8 +27,8 @@ class StacksContainer extends Component {
     this.loadStack = this.loadStack.bind(this);
   }
 
-  openStack(id) {
-    return this.props.actions.getUrl(id)
+  openStack(stack) {
+    return this.props.actions.getUrl(stack.id)
       .then(payload => this.props.actions.openStack(payload.value.redirectUrl))
       .catch(err => notify.error(`Unable to open ${this.props.typeName}`));
   }

--- a/code/workspaces/web-app/src/containers/stacks/StacksContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/stacks/StacksContainer.spec.js
@@ -155,7 +155,7 @@ describe('StacksContainer', () => {
       // Act/Assert
       expect(getUrlMock).not.toHaveBeenCalled();
       expect(openStackMock).not.toHaveBeenCalled();
-      return openStack(1000)
+      return openStack({ id: 1000 })
         .then(() => {
           expect(getUrlMock).toHaveBeenCalledTimes(1);
           expect(getUrlMock).toHaveBeenCalledWith(1000);
@@ -174,7 +174,7 @@ describe('StacksContainer', () => {
       // Act/Assert
       expect(getUrlMock).not.toHaveBeenCalled();
       expect(toastrErrorMock).not.toHaveBeenCalled();
-      return openStack(1000)
+      return openStack({ id: 1000 })
         .then(() => {
           expect(getUrlMock).toHaveBeenCalledTimes(1);
           expect(getUrlMock).toHaveBeenCalledWith(1000);

--- a/code/workspaces/web-app/src/reducers/projectsReducer.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.js
@@ -18,7 +18,7 @@ export default typeToReducer({
   [LOAD_PROJECTS_ACTION]: {
     [PROMISE_TYPE_PENDING]: () => ({ ...initialState, fetching: true }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload }),
-    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { projectArray: action.payload } }),
   },
   [LOAD_PROJECTINFO_ACTION]: {
     [PROMISE_TYPE_PENDING]: () => ({ ...initialState, fetching: true }),

--- a/code/workspaces/web-app/src/reducers/projectsReducer.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.js
@@ -23,6 +23,6 @@ export default typeToReducer({
   [LOAD_PROJECTINFO_ACTION]: {
     [PROMISE_TYPE_PENDING]: () => ({ ...initialState, fetching: true }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload }),
-    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { currentProject: action.payload } }),
   },
 }, { ...initialState });

--- a/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
@@ -23,16 +23,14 @@ describe('projectsReducer', () => {
   it('should handle LOAD_PROJECTS_SUCCESS', () => {
     // Arrange
     const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
-    const payload = {
-      projectArray: [{ project: 'firstProject' }, { project: 'secondProject' }],
-    };
+    const payload = [{ project: 'firstProject' }, { project: 'secondProject' }];
     const action = { type, payload };
 
     // Act
     const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
 
     // Assert
-    expect(nextstate).toEqual({ error: null, fetching: false, value: payload });
+    expect(nextstate).toEqual({ error: null, fetching: false, value: { projectArray: action.payload } });
   });
 
   it('should handle LOAD_PROJECTS_FAILURE', () => {

--- a/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
@@ -1,6 +1,6 @@
 import projectsReducer from './projectsReducer';
 import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
-import { LOAD_PROJECTS_ACTION } from '../actions/projectActions';
+import { LOAD_PROJECTS_ACTION, LOAD_PROJECTINFO_ACTION } from '../actions/projectActions';
 
 describe('projectsReducer', () => {
   it('should return the initial state', () => {
@@ -8,41 +8,83 @@ describe('projectsReducer', () => {
     expect(projectsReducer(undefined, {})).toEqual({ fetching: false, value: {}, error: null });
   });
 
-  it('should handle LOAD_PROJECTS_PENDING', () => {
-    // Arrange
-    const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_PENDING}`;
-    const action = { type };
+  describe('LOAD_PROJECTS', () => {
+    it('should handle LOAD_PROJECTS_PENDING', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
 
-    // Act
-    const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
+    });
+
+    it('should handle LOAD_PROJECTS_SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ project: 'firstProject' }, { project: 'secondProject' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, value: { projectArray: action.payload } });
+    });
+
+    it('should handle LOAD_PROJECTS_FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
+    });
   });
 
-  it('should handle LOAD_PROJECTS_SUCCESS', () => {
-    // Arrange
-    const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
-    const payload = [{ project: 'firstProject' }, { project: 'secondProject' }];
-    const action = { type, payload };
+  describe('LOAD_PROJECTINFO', () => {
+    it('should handle LOAD_PROJECTINFO_PENDING', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
 
-    // Act
-    const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: null, fetching: false, value: { projectArray: action.payload } });
-  });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
+    });
 
-  it('should handle LOAD_PROJECTS_FAILURE', () => {
-    // Arrange
-    const type = `${LOAD_PROJECTS_ACTION}_${PROMISE_TYPE_FAILURE}`;
-    const payload = 'example error';
-    const action = { type, payload };
+    it('should handle LOAD_PROJECTINFO_SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = { project: 'secondProject' };
+      const action = { type, payload };
 
-    // Act
-    const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, value: { currentProject: action.payload } });
+    });
+
+    it('should handle LOAD_PROJECTINFOFAILURE', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
+    });
   });
 });


### PR DESCRIPTION
Rather than using dummy data from the web app projects service, project data now comes from the GraphQL endpoint.  This has brought a few minor changes along with it, e.g. in the redux state, project.displayName is now project.name, and what I was referring to as project.id is now project.key.

The StackCardAction openStack method now takes the stack object as an argument rather than just the id, but that just brings it in line with the other action methods.

An adaptProjectsToStacks method is called above StackCards, so that the project data looks like stack data - previous comments about needing to refactor here still apply!