### PR TITLE
NERCDL-372 Project open button depends on permissions

### DIFF
--- a/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
@@ -13,7 +13,7 @@ exports[`projectsService loadProjects should build the correct query and unpack 
 "
     LoadProjects {
       projects {
-        id, key, name, description
+        id, key, name, description, accessible
       }
     }"
 `;

--- a/code/workspaces/web-app/src/api/projectsService.js
+++ b/code/workspaces/web-app/src/api/projectsService.js
@@ -5,7 +5,7 @@ function loadProjects() {
   const query = `
     LoadProjects {
       projects {
-        id, key, name, description
+        id, key, name, description, accessible
       }
     }`;
 

--- a/code/workspaces/web-app/src/components/stacks/StackCards.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.js
@@ -26,13 +26,13 @@ const StackCards = ({ stacks, typeName, openStack, deleteStack, editStack, openC
         openStack={openStack}
         deleteStack={deleteStack}
         editStack={editStack}
-        userPermissions={userPermissions}
+        userPermissions={userPermissions(stack)}
         openPermission={openPermission}
         deletePermission={deletePermission}
         editPermission={editPermission}
       />
     ))}
-    <PermissionWrapper style={{ width: '100%' }} userPermissions={userPermissions} permission={createPermission}>
+    <PermissionWrapper style={{ width: '100%' }} userPermissions={userPermissions()} permission={createPermission}>
       <Grid item {...breakPoints}>
         <NewStackButton onClick={openCreationForm} typeName={typeName} />
       </Grid>
@@ -47,7 +47,7 @@ StackCards.propTypes = {
   deleteStack: PropTypes.func.isRequired,
   editStack: PropTypes.func,
   openCreationForm: PropTypes.func.isRequired,
-  userPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  userPermissions: PropTypes.func.isRequired,
   createPermission: PropTypes.string.isRequired,
   openPermission: PropTypes.string.isRequired,
   deletePermission: PropTypes.string.isRequired,

--- a/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
@@ -17,7 +17,7 @@ describe('StackCards', () => {
     openStack: () => {},
     deleteStack: () => {},
     openCreationForm: () => {},
-    userPermissions: ['open', 'delete', 'create', 'edit'],
+    userPermissions: () => ['open', 'delete', 'create', 'edit'],
     openPermission: 'open',
     deletePermission: 'delete',
     createPermission: 'create',

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
@@ -34,14 +34,7 @@ exports[`StackCards creates correct snapshot for an array of notebooks 1`] = `
     ]
   }
   typeName="expectedTypeName"
-  userPermissions={
-    Array [
-      "open",
-      "delete",
-      "create",
-      "edit",
-    ]
-  }
+  userPermissions={[Function]}
 />
 `;
 
@@ -61,13 +54,6 @@ exports[`StackCards creates correct snapshot for an empty array 1`] = `
   openStack={[Function]}
   stacks={Array []}
   typeName="expectedTypeName"
-  userPermissions={
-    Array [
-      "open",
-      "delete",
-      "create",
-      "edit",
-    ]
-  }
+  userPermissions={[Function]}
 />
 `;

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -114,7 +114,7 @@ class DataStorageContainer extends Component {
           deleteStack={this.chooseDialogue}
           editStack={this.editDataStore}
           openCreationForm={this.openCreationForm}
-          userPermissions={this.props.userPermissions}
+          userPermissions={() => this.props.userPermissions}
           createPermission={PROJECT_STORAGE_CREATE}
           openPermission={PROJECT_STORAGE_OPEN}
           deletePermission={PROJECT_STORAGE_DELETE}

--- a/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
@@ -77,11 +77,7 @@ exports[`DataStorageContainer is a container which passes correct props to Stack
       ]
     }
     typeName="Data Store"
-    userPermissions={
-      Array [
-        "expectedPermission",
-      ]
-    }
+    userPermissions={[Function]}
   />
 </PromisedContentWrapper>
 `;

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
@@ -3,14 +3,12 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-import { permissionTypes } from 'common';
 import projectActions from '../../actions/projectActions';
 import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 import StackCards from '../../components/stacks/StackCards';
 
-const { projectPermissions: { PROJECT_STORAGE_OPEN } } = permissionTypes;
-
 const TYPE_NAME = 'Project';
+const PROJECT_OPEN_PERMISSION = 'project.open';
 
 class ProjectsContainer extends Component {
   shouldComponentUpdate(nextProps) {
@@ -28,9 +26,17 @@ class ProjectsContainer extends Component {
       key: project.key,
       displayName: project.name,
       description: project.description,
+      accessible: project.accessible,
       type: 'project',
       status: 'ready',
     }));
+  }
+
+  projectUserPermissions(project) {
+    if (project === undefined) {
+      return [];
+    }
+    return project.accessible ? [PROJECT_OPEN_PERMISSION] : [];
   }
 
   render() {
@@ -43,9 +49,9 @@ class ProjectsContainer extends Component {
             openStack={project => this.props.history.push(`/projects/${project.key}/info`)}
             deleteStack={() => { }}
             openCreationForm={() => { }}
-            userPermissions={this.props.userPermissions}
+            userPermissions={project => this.projectUserPermissions(project)}
             createPermission=""
-            openPermission={PROJECT_STORAGE_OPEN}
+            openPermission={PROJECT_OPEN_PERMISSION}
             deletePermission=""
             editPermission=""
           />

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
@@ -33,10 +33,7 @@ class ProjectsContainer extends Component {
   }
 
   projectUserPermissions(project) {
-    if (project === undefined) {
-      return [];
-    }
-    return project.accessible ? [PROJECT_OPEN_PERMISSION] : [];
+    return project && project.accessible ? [PROJECT_OPEN_PERMISSION] : [];
   }
 
   render() {

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
@@ -11,6 +11,7 @@ const projectsPayload = {
     key: 'project2',
     name: 'A project name',
     description: 'A project description',
+    accessible: true,
   }],
 };
 const loadProjectsMock = jest.fn().mockReturnValue(Promise.resolve(projectsPayload));

--- a/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
@@ -15,6 +15,7 @@ exports[`ProjectsContainer is a container which passes correct props to StackCar
       "value": Object {
         "projectsArray": Array [
           Object {
+            "accessible": true,
             "description": "A project description",
             "id": 123,
             "key": "project2",

--- a/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
+++ b/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
@@ -91,7 +91,7 @@ class StacksContainer extends Component {
           openStack={this.openStack}
           deleteStack={this.confirmDeleteStack}
           openCreationForm={this.openCreationForm}
-          userPermissions={this.props.userPermissions}
+          userPermissions={() => this.props.userPermissions}
           createPermission={PROJECT_STACKS_CREATE}
           openPermission={PROJECT_STACKS_OPEN}
           deletePermission={PROJECT_STACKS_DELETE}

--- a/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
@@ -63,11 +63,7 @@ exports[`StacksContainer is a container which passes correct props to StackCard 
       ]
     }
     typeName="Notebook"
-    userPermissions={
-      Array [
-        "expectedPermission",
-      ]
-    }
+    userPermissions={[Function]}
   />
 </PromisedContentWrapper>
 `;


### PR DESCRIPTION
- project.accessible is obtained from GraphQL.
- since permissions can be different for each card, a function for user permissions is passed to stackCards.
- ProjectContainer uses this to turn the permissions for the Open button off and on.