### PR TITLE
Move API URL from Subdomain

### DIFF
--- a/code/development-env/config/local/web_auth_config.json
+++ b/code/development-env/config/local/web_auth_config.json
@@ -1,5 +1,5 @@
 {
-  "audience": "https://datalab-api.datalabs.nerc.ac.uk/",
+  "audience": "https://datalab.datalabs.nerc.ac.uk/api",
   "clientID": "pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd",
   "domain": "mjbr.eu.auth0.com",
   "redirectUri": "https://testlab.datalabs.localhost/callback",

--- a/code/development-env/config/manifests/minikube-proxy.yml
+++ b/code/development-env/config/manifests/minikube-proxy.yml
@@ -39,27 +39,11 @@ spec:
   - host: testlab.datalabs.localhost
     http:
       paths:
-      - path: /
-        backend:
-          serviceName: datalab-app-proxy
-          servicePort: 3000
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-
-metadata:
-  name: datalab-api-ingress
-  namespace: devtest
-spec:
-  tls:
-  - hosts:
-    - testlab.datalabs.localhost
-    secretName: tls-secret
-  rules:
-  - host: testlab.datalabs.localhost
-    http:
-      paths:
       - path: /api
         backend:
           serviceName: datalab-api-proxy
           servicePort: 8000
+      - path: /
+        backend:
+          serviceName: datalab-app-proxy
+          servicePort: 3000

--- a/code/development-env/config/manifests/minikube-proxy.yml
+++ b/code/development-env/config/manifests/minikube-proxy.yml
@@ -50,15 +50,13 @@ kind: Ingress
 metadata:
   name: datalab-api-ingress
   namespace: devtest
-  annotations:
-    ingress.kubernetes.io/rewrite-target: /
 spec:
   tls:
   - hosts:
     - testlab.datalabs.localhost
     secretName: tls-secret
   rules:
-  - host: testlab-api.datalabs.localhost
+  - host: testlab.datalabs.localhost
     http:
       paths:
       - path: /api

--- a/code/development-env/config/manifests/minikube-proxy.yml
+++ b/code/development-env/config/manifests/minikube-proxy.yml
@@ -46,19 +46,22 @@ spec:
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
+
 metadata:
   name: datalab-api-ingress
   namespace: devtest
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
 spec:
   tls:
   - hosts:
-    - testlab-api.datalabs.localhost
+    - testlab.datalabs.localhost
     secretName: tls-secret
   rules:
   - host: testlab-api.datalabs.localhost
     http:
       paths:
-      - path: /
+      - path: /api
         backend:
           serviceName: datalab-api-proxy
           servicePort: 8000

--- a/code/workspaces/auth-service/src/config/config.js
+++ b/code/workspaces/auth-service/src/config/config.js
@@ -82,7 +82,7 @@ const config = convict({
   authZeroAudience: {
     doc: 'Audience for authorisation',
     format: 'String',
-    default: 'https://datalab-api.datalabs.nerc.ac.uk/',
+    default: 'https://datalab.datalabs.nerc.ac.uk/api',
     env: 'AUTH_ZERO_AUDIENCE',
   },
   databaseHost: {

--- a/code/workspaces/web-app/public/web_auth_config.json
+++ b/code/workspaces/web-app/public/web_auth_config.json
@@ -1,5 +1,5 @@
 {
-  "audience": "https://datalab-api.datalabs.nerc.ac.uk/",
+  "audience": "https://datalab.datalabs.nerc.ac.uk/api",
   "clientID": "pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd",
   "domain": "mjbr.eu.auth0.com",
   "redirectUri": "https://datalab.datalabs.nerc.ac.uk/callback",

--- a/code/workspaces/web-app/src/api/graphqlClient.js
+++ b/code/workspaces/web-app/src/api/graphqlClient.js
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 import request from '../auth/secureRequest';
-import { extendSubdomain } from '../core/getDomainInfo';
+import { createUrlFromPath } from '../core/getDomainInfo';
 
-const apiURL = `${extendSubdomain('api', 8000)}/api`;
+const apiURL = createUrlFromPath('api', '8000');
 
 export const gqlQuery = (query, variables) => {
   const options = { headers: { 'Content-Type': 'application/json' } };

--- a/code/workspaces/web-app/src/api/graphqlClient.js
+++ b/code/workspaces/web-app/src/api/graphqlClient.js
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 import request from '../auth/secureRequest';
 import { createUrlFromPath } from '../core/getDomainInfo';
 
-const apiURL = createUrlFromPath('api', '8000');
+const apiURL = createUrlFromPath('api', 8000);
 
 export const gqlQuery = (query, variables) => {
   const options = { headers: { 'Content-Type': 'application/json' } };

--- a/code/workspaces/web-app/src/auth/auth.spec.js
+++ b/code/workspaces/web-app/src/auth/auth.spec.js
@@ -10,7 +10,7 @@ const logoutMock = jest.fn();
 const authConfig = {
   domain: 'expected.auth0.com',
   clientID: 'expected-client-id',
-  audience: 'https://datalab-api.datalabs.nerc.ac.uk/',
+  audience: 'https://datalab.datalabs.nerc.ac.uk/api',
   responseType: 'token id_token',
   scope: 'openid profile',
   redirectUri: `${window.location.origin}/callback`,

--- a/code/workspaces/web-app/src/core/getDomainInfo.js
+++ b/code/workspaces/web-app/src/core/getDomainInfo.js
@@ -8,6 +8,16 @@ function extendSubdomain(extension, localhostPort, location) {
   return `${domainInfo.protocol}//${domainInfo.subdomain}-${extension}.${domainInfo.domain}`;
 }
 
+function createUrlFromPath(path, localhostPort, location) {
+  const domainInfo = getDomainInfo(location);
+
+  if (domainInfo === 'localhost') {
+    return `http://localhost:${localhostPort}/${path}`;
+  }
+
+  return `${domainInfo.baseUrl}/${path}`;
+}
+
 function replaceSubdomain(subdomain, altHref, location) {
   const domainInfo = getDomainInfo(location);
 
@@ -28,8 +38,8 @@ function getDomainInfo(location) {
   const { protocol, hostname } = currentLocation;
   const subdomain = hostname.split('.')[0];
   const domain = hostname.substring(subdomain.length + 1, hostname.length);
-
-  return { protocol, subdomain, domain };
+  const baseUrl = `${protocol}//${subdomain}.${domain}`;
+  return { baseUrl, protocol, subdomain, domain };
 }
 
-export { getDomainInfo, replaceSubdomain, extendSubdomain };
+export { getDomainInfo, replaceSubdomain, extendSubdomain, createUrlFromPath };

--- a/code/workspaces/web-app/src/core/getDomainInfo.spec.js
+++ b/code/workspaces/web-app/src/core/getDomainInfo.spec.js
@@ -1,4 +1,4 @@
-import { getDomainInfo, replaceSubdomain, extendSubdomain } from './getDomainInfo';
+import { getDomainInfo, replaceSubdomain, extendSubdomain, createUrlFromPath } from './getDomainInfo';
 
 describe('Extend Subdomain', () => {
   it('should generate an extended subdomain', () => {
@@ -31,10 +31,36 @@ describe('Extend Subdomain', () => {
       protocol: 'http:',
       hostname: 'datalab.datalabs.nerc.ac.uk',
     };
-    const apiBase = extendSubdomain('api', 8000, location);
+    const apiBase = extendSubdomain('docs', 3000, location);
 
     // Assert
-    expect(apiBase).toEqual('http://datalab-api.datalabs.nerc.ac.uk');
+    expect(apiBase).toEqual('http://datalab-docs.datalabs.nerc.ac.uk');
+  });
+});
+
+describe('Create URL from Path', () => {
+  it('should generate a correct URL for a given path', () => {
+    // Arrange/Act
+    const location = {
+      protocol: 'https:',
+      hostname: 'testlab.test-datalabs.nerc.ac.uk',
+    };
+    const address = createUrlFromPath('api', 8000, location);
+
+    // Assert
+    expect(address).toBe('https://testlab.test-datalabs.nerc.ac.uk/api');
+  });
+
+  it('should generate a correct URL when using localhost', () => {
+    // Arrange/Act
+    const location = {
+      protocol: 'http:',
+      hostname: 'localhost',
+    };
+    const subdomain = createUrlFromPath('api', 8000, location);
+
+    // Assert
+    expect(subdomain).toBe('http://localhost:8000/api');
   });
 });
 
@@ -51,7 +77,7 @@ describe('Replace subdomain', () => {
     expect(address).toBe('https://discourse.test-datalabs.nerc.ac.uk');
   });
 
-  it('should return the alturnative address when using localhost', () => {
+  it('should return the alternative address when using localhost', () => {
     // Arrange/Act
     const location = {
       protocol: 'http:',
@@ -78,6 +104,7 @@ describe('Get Domain Info', () => {
       protocol: 'http:',
       subdomain: 'datalab',
       domain: 'datalabs.nerc.ac.uk',
+      baseUrl: 'http://datalab.datalabs.nerc.ac.uk',
     });
   });
 });


### PR DESCRIPTION
I've tested this locally fine using localhost and the Docker setup and as much functionality as I can, but you may be aware of something I've missed.

These changes will need to be made at the same time as a corresponding PR in datalab-k8s-manifests

Also a reminder that we'll all need to re-run the local ingress for our dev environments