### PR TITLE
NERCDL-372 Apply project accessible permission to project info

### DIFF
--- a/code/workspaces/client-api/src/auth/permissionChecker.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.js
@@ -1,5 +1,6 @@
 import logger from 'winston';
 import { permissionTypes } from 'common';
+import userService from '../dataaccess/usersService';
 
 const { SYSTEM_INSTANCE_ADMIN, PROJECT, delimiter } = permissionTypes;
 
@@ -10,6 +11,25 @@ export const permissionWrapper = (permissionSuffix, ...rest) => permissionCheck(
   ],
   ...rest,
 );
+
+export function projectPermissionWrapper(projectKey, permissionSuffix, token, user, next) {
+  return userService.isMemberOfProject(projectKey, token)
+    .then((accessible) => {
+      if (!accessible) {
+        logger.warn('Auth: permission check: FAILED');
+        return Promise.reject(new Error(`Requested projectKey ${projectKey} not accessible to user`));
+      }
+
+      return permissionCheck(
+        [
+          PROJECT.concat(delimiter, permissionSuffix),
+          SYSTEM_INSTANCE_ADMIN,
+        ],
+        user,
+        next,
+      );
+    });
+}
 
 export const multiPermissionsWrapper = (permissionSuffixes, ...rest) => permissionCheck(
   [

--- a/code/workspaces/client-api/src/auth/permissionChecker.spec.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.spec.js
@@ -1,11 +1,9 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import config from '../config';
 import { permissionWrapper, multiPermissionsWrapper, instanceAdminWrapper, projectPermissionWrapper } from './permissionChecker';
 
 const user = {
   permissions: [
     'project:elementName:actionName',
+    'project2:elementName:actionName',
   ],
 };
 
@@ -19,17 +17,20 @@ const actionMock = jest.fn().mockReturnValue(Promise.resolve());
 
 const next = () => actionMock('value');
 
-const AUTH_URL_BASE = config.get('authorisationService');
-
 describe('Permission Checker', () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe('permissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => permissionWrapper('elementName:missingActionName', user, next)
-      .catch((err) => {
-        expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
-        expect(actionMock).not.toHaveBeenCalled();
-      }));
+    it('throws an error if user is lacking correct permission', async () => {
+      let error;
+      try {
+        await permissionWrapper('elementName:missingActionName', user, next);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
+      expect(actionMock).not.toHaveBeenCalled();
+    });
 
     it('callback to be called if user has correct permission', () => permissionWrapper('elementName:actionName', user, next)
       .then(() => {
@@ -45,11 +46,16 @@ describe('Permission Checker', () => {
   });
 
   describe('multiPermissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => multiPermissionsWrapper(['elementName:missingActionName', 'elementName:anotherAction'], user, next)
-      .catch((err) => {
-        expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,project:elementName:anotherAction,system:instance:admin'));
-        expect(actionMock).not.toHaveBeenCalled();
-      }));
+    it('throws an error if user is lacking correct permission', async () => {
+      let error;
+      try {
+        await multiPermissionsWrapper(['elementName:missingActionName', 'elementName:anotherAction'], user, next);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,project:elementName:anotherAction,system:instance:admin'));
+      expect(actionMock).not.toHaveBeenCalled();
+    });
 
     it('callback to be called if user has correct permission', () => multiPermissionsWrapper(['elementName:actionName', 'elementName:anotherAction'], user, next)
       .then(() => {
@@ -65,11 +71,16 @@ describe('Permission Checker', () => {
   });
 
   describe('instanceAdminWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => instanceAdminWrapper(user, next)
-      .catch((err) => {
-        expect(err).toEqual(new Error('User missing expected permission(s): system:instance:admin'));
-        expect(actionMock).not.toHaveBeenCalled();
-      }));
+    it('throws an error if user is lacking correct permission', async () => {
+      let error;
+      try {
+        await instanceAdminWrapper(user, next);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual(new Error('User missing expected permission(s): system:instance:admin'));
+      expect(actionMock).not.toHaveBeenCalled();
+    });
 
     it('callback to be called if user has instance admin permission', () => instanceAdminWrapper(admin, next)
       .then(() => {
@@ -79,55 +90,38 @@ describe('Permission Checker', () => {
   });
 
   describe('projectPermissionWrapper', () => {
-    const httpMock = new MockAdapter(axios);
-
-    beforeEach(() => {
-      httpMock.reset();
+    it('throws an error if user is lacking correct permission', async () => {
+      let error;
+      try {
+        await projectPermissionWrapper({ projectKey: 'project2' }, 'elementName:missingActionName', user, next);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual(new Error('User missing expected permission(s): project2:elementName:missingActionName,system:instance:admin'));
+      expect(actionMock).not.toHaveBeenCalled();
     });
 
-    afterAll(() => {
-      httpMock.restore();
+    it('throws an error if projectKey not passed', async () => {
+      let error;
+      try {
+        await projectPermissionWrapper({}, 'elementName:actionName', user, next);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual(new Error('projectKey not passed, expected suffix: elementName:actionName'));
+      expect(actionMock).not.toHaveBeenCalled();
     });
 
-    it('throws an error if user is lacking user permission', () => {
-      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
-      projectPermissionWrapper('project2', 'elementName:missingActionName', 'token', user, next)
-        .catch((err) => {
-          expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
-          expect(actionMock).not.toHaveBeenCalled();
-        });
-    });
-
-    it('throws an error if user is lacking project permission', () => {
-      httpMock.onGet(`${AUTH_URL_BASE}/projects/projectX/is-member`).reply(200, false);
-      projectPermissionWrapper('projectX', 'elementName:actionName', 'token', user, next)
-        .catch((err) => {
-          expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
-          expect(actionMock).not.toHaveBeenCalled();
-        });
-    });
-
-    it('throws an error if user has instance admin permission but is lacking project permission', () => {
-      httpMock.onGet(`${AUTH_URL_BASE}/projects/projectX/is-member`).reply(200, false);
-      projectPermissionWrapper('projectX', 'elementName:actionName', 'token', admin, next)
-        .catch((err) => {
-          expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
-          expect(actionMock).not.toHaveBeenCalled();
-        });
-    });
-
-    it('callback to be called if user has correct user and project permission', () => {
-      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
-      projectPermissionWrapper('project2', 'elementName:actionName', 'token', user, next)
+    it('callback to be called if user has correct permission', () => {
+      projectPermissionWrapper({ projectKey: 'project2' }, 'elementName:actionName', user, next)
         .then(() => {
           expect(actionMock).toHaveBeenCalledTimes(1);
           expect(actionMock).toHaveBeenCalledWith('value');
         });
     });
 
-    it('callback to be called if user has instance admin permission with project permission', () => {
-      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
-      projectPermissionWrapper('project2', 'elementName:actionName', 'token', admin, next)
+    it('callback to be called if user has instance admin permission', async () => {
+      projectPermissionWrapper({ projectKey: 'project2' }, 'elementName:actionName', admin, next)
         .then(() => {
           expect(actionMock).toHaveBeenCalledTimes(1);
           expect(actionMock).toHaveBeenCalledWith('value');

--- a/code/workspaces/client-api/src/auth/permissionChecker.spec.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.spec.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import config from '../config';
 import { permissionWrapper, multiPermissionsWrapper, instanceAdminWrapper, projectPermissionWrapper } from './permissionChecker';
 
 const user = {
@@ -17,6 +18,8 @@ const admin = {
 const actionMock = jest.fn().mockReturnValue(Promise.resolve());
 
 const next = () => actionMock('value');
+
+const AUTH_URL_BASE = config.get('authorisationService');
 
 describe('Permission Checker', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -87,7 +90,7 @@ describe('Permission Checker', () => {
     });
 
     it('throws an error if user is lacking user permission', () => {
-      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
       projectPermissionWrapper('project2', 'elementName:missingActionName', 'token', user, next)
         .catch((err) => {
           expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
@@ -96,7 +99,7 @@ describe('Permission Checker', () => {
     });
 
     it('throws an error if user is lacking project permission', () => {
-      httpMock.onGet('http://localhost:9000/projects/projectX/is-member').reply(200, false);
+      httpMock.onGet(`${AUTH_URL_BASE}/projects/projectX/is-member`).reply(200, false);
       projectPermissionWrapper('projectX', 'elementName:actionName', 'token', user, next)
         .catch((err) => {
           expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
@@ -105,7 +108,7 @@ describe('Permission Checker', () => {
     });
 
     it('throws an error if user has instance admin permission but is lacking project permission', () => {
-      httpMock.onGet('http://localhost:9000/projects/projectX/is-member').reply(200, false);
+      httpMock.onGet(`${AUTH_URL_BASE}/projects/projectX/is-member`).reply(200, false);
       projectPermissionWrapper('projectX', 'elementName:actionName', 'token', admin, next)
         .catch((err) => {
           expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
@@ -114,7 +117,7 @@ describe('Permission Checker', () => {
     });
 
     it('callback to be called if user has correct user and project permission', () => {
-      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
       projectPermissionWrapper('project2', 'elementName:actionName', 'token', user, next)
         .then(() => {
           expect(actionMock).toHaveBeenCalledTimes(1);
@@ -123,7 +126,7 @@ describe('Permission Checker', () => {
     });
 
     it('callback to be called if user has instance admin permission with project permission', () => {
-      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`).reply(200, true);
       projectPermissionWrapper('project2', 'elementName:actionName', 'token', admin, next)
         .then(() => {
           expect(actionMock).toHaveBeenCalledTimes(1);

--- a/code/workspaces/client-api/src/auth/permissionChecker.spec.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.spec.js
@@ -1,4 +1,6 @@
-import { permissionWrapper, multiPermissionsWrapper, instanceAdminWrapper } from './permissionChecker';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { permissionWrapper, multiPermissionsWrapper, instanceAdminWrapper, projectPermissionWrapper } from './permissionChecker';
 
 const user = {
   permissions: [
@@ -14,23 +16,25 @@ const admin = {
 
 const actionMock = jest.fn().mockReturnValue(Promise.resolve());
 
+const next = () => actionMock('value');
+
 describe('Permission Checker', () => {
   beforeEach(() => jest.clearAllMocks());
 
   describe('permissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => permissionWrapper('elementName:missingActionName', user, () => actionMock('value'))
+    it('throws an error if user is lacking correct permission', () => permissionWrapper('elementName:missingActionName', user, next)
       .catch((err) => {
         expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
         expect(actionMock).not.toHaveBeenCalled();
       }));
 
-    it('callback to be called if user has correct permission', () => permissionWrapper('elementName:actionName', user, () => actionMock('value'))
+    it('callback to be called if user has correct permission', () => permissionWrapper('elementName:actionName', user, next)
       .then(() => {
         expect(actionMock).toHaveBeenCalledTimes(1);
         expect(actionMock).toHaveBeenCalledWith('value');
       }));
 
-    it('callback to be called if user has instance admin permission', () => permissionWrapper('elementName:actionName', admin, () => actionMock('value'))
+    it('callback to be called if user has instance admin permission', () => permissionWrapper('elementName:actionName', admin, next)
       .then(() => {
         expect(actionMock).toHaveBeenCalledTimes(1);
         expect(actionMock).toHaveBeenCalledWith('value');
@@ -38,19 +42,19 @@ describe('Permission Checker', () => {
   });
 
   describe('multiPermissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => multiPermissionsWrapper(['elementName:missingActionName', 'elementName:anotherAction'], user, () => actionMock('value'))
+    it('throws an error if user is lacking correct permission', () => multiPermissionsWrapper(['elementName:missingActionName', 'elementName:anotherAction'], user, next)
       .catch((err) => {
         expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,project:elementName:anotherAction,system:instance:admin'));
         expect(actionMock).not.toHaveBeenCalled();
       }));
 
-    it('callback to be called if user has correct permission', () => multiPermissionsWrapper(['elementName:actionName', 'elementName:anotherAction'], user, () => actionMock('value'))
+    it('callback to be called if user has correct permission', () => multiPermissionsWrapper(['elementName:actionName', 'elementName:anotherAction'], user, next)
       .then(() => {
         expect(actionMock).toHaveBeenCalledTimes(1);
         expect(actionMock).toHaveBeenCalledWith('value');
       }));
 
-    it('callback to be called if user has instance admin permission', () => multiPermissionsWrapper(['elementName:actionName'], admin, () => actionMock('value'))
+    it('callback to be called if user has instance admin permission', () => multiPermissionsWrapper(['elementName:actionName'], admin, next)
       .then(() => {
         expect(actionMock).toHaveBeenCalledTimes(1);
         expect(actionMock).toHaveBeenCalledWith('value');
@@ -58,16 +62,73 @@ describe('Permission Checker', () => {
   });
 
   describe('instanceAdminWrapper', () => {
-    it('throws an error if user is lacking correct permission', () => instanceAdminWrapper(user, () => actionMock('value'))
+    it('throws an error if user is lacking correct permission', () => instanceAdminWrapper(user, next)
       .catch((err) => {
         expect(err).toEqual(new Error('User missing expected permission(s): system:instance:admin'));
         expect(actionMock).not.toHaveBeenCalled();
       }));
 
-    it('callback to be called if user has instance admin permission', () => instanceAdminWrapper(admin, () => actionMock('value'))
+    it('callback to be called if user has instance admin permission', () => instanceAdminWrapper(admin, next)
       .then(() => {
         expect(actionMock).toHaveBeenCalledTimes(1);
         expect(actionMock).toHaveBeenCalledWith('value');
       }));
+  });
+
+  describe('projectPermissionWrapper', () => {
+    const httpMock = new MockAdapter(axios);
+
+    beforeEach(() => {
+      httpMock.reset();
+    });
+
+    afterAll(() => {
+      httpMock.restore();
+    });
+
+    it('throws an error if user is lacking user permission', () => {
+      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      projectPermissionWrapper('project2', 'elementName:missingActionName', 'token', user, next)
+        .catch((err) => {
+          expect(err).toEqual(new Error('User missing expected permission(s): project:elementName:missingActionName,system:instance:admin'));
+          expect(actionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    it('throws an error if user is lacking project permission', () => {
+      httpMock.onGet('http://localhost:9000/projects/projectX/is-member').reply(200, false);
+      projectPermissionWrapper('projectX', 'elementName:actionName', 'token', user, next)
+        .catch((err) => {
+          expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
+          expect(actionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    it('throws an error if user has instance admin permission but is lacking project permission', () => {
+      httpMock.onGet('http://localhost:9000/projects/projectX/is-member').reply(200, false);
+      projectPermissionWrapper('projectX', 'elementName:actionName', 'token', admin, next)
+        .catch((err) => {
+          expect(err).toEqual(new Error('Requested projectKey projectX not accessible to user'));
+          expect(actionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    it('callback to be called if user has correct user and project permission', () => {
+      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      projectPermissionWrapper('project2', 'elementName:actionName', 'token', user, next)
+        .then(() => {
+          expect(actionMock).toHaveBeenCalledTimes(1);
+          expect(actionMock).toHaveBeenCalledWith('value');
+        });
+    });
+
+    it('callback to be called if user has instance admin permission with project permission', () => {
+      httpMock.onGet('http://localhost:9000/projects/project2/is-member').reply(200, true);
+      projectPermissionWrapper('project2', 'elementName:actionName', 'token', admin, next)
+        .then(() => {
+          expect(actionMock).toHaveBeenCalledTimes(1);
+          expect(actionMock).toHaveBeenCalledWith('value');
+        });
+    });
   });
 });

--- a/code/workspaces/client-api/src/dataaccess/userPermissionsService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/userPermissionsService.spec.js
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import config from '../config';
 import getUserPermissions from './userPermissionsService';
 
 const mock = new MockAdapter(axios);
 
-const authServiceUrl = 'http://localhost:9000/permissions';
+const AUTH_URL_BASE = config.get('authorisationService');
+const authServiceUrl = `${AUTH_URL_BASE}/permissions`;
 
 describe('User Identity Service', () => {
   beforeEach(() => {

--- a/code/workspaces/client-api/src/dataaccess/usersService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/usersService.spec.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import config from '../config';
 import usersService from './usersService';
 
+const AUTH_URL_BASE = config.get('authorisationService');
 const httpMock = new MockAdapter(axios);
 
 const testUsers = [
@@ -21,7 +23,7 @@ describe('userService', () => {
   });
 
   it('getAll makes an api request', () => {
-    httpMock.onGet('http://localhost:9000/users')
+    httpMock.onGet(`${AUTH_URL_BASE}/users`)
       .reply(200, testUsers);
 
     return usersService.getAll(context)
@@ -29,7 +31,7 @@ describe('userService', () => {
   });
 
   it('isMemberOfProject makes an api request', () => {
-    httpMock.onGet('http://localhost:9000/projects/project2/is-member')
+    httpMock.onGet(`${AUTH_URL_BASE}/projects/project2/is-member`)
       .reply(200, true);
 
     return usersService.isMemberOfProject('project2', context)

--- a/code/workspaces/client-api/src/dataaccess/usersService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/usersService.spec.js
@@ -27,4 +27,12 @@ describe('userService', () => {
     return usersService.getAll(context)
       .then(response => expect(response).toEqual(testUsers));
   });
+
+  it('isMemberOfProject makes an api request', () => {
+    httpMock.onGet('http://localhost:9000/projects/project2/is-member')
+      .reply(200, true);
+
+    return usersService.isMemberOfProject('project2', context)
+      .then(response => expect(response).toEqual(true));
+  });
 });

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -1,6 +1,6 @@
 import { statusTypes, permissionTypes } from 'common';
 import { version } from '../version';
-import permissionChecker, { instanceAdminWrapper } from '../auth/permissionChecker';
+import permissionChecker, { instanceAdminWrapper, projectPermissionWrapper } from '../auth/permissionChecker';
 import stackService from '../dataaccess/stackService';
 import dataStorageRepository from '../dataaccess/dataStorageRepository';
 import datalabRepository from '../dataaccess/datalabRepository';
@@ -38,7 +38,7 @@ const resolvers = {
     checkNameUniqueness: (obj, { name }, { user, token }) => permissionChecker([STACKS_CREATE, STORAGE_CREATE], user, () => internalNameChecker({ user, token }, name)),
     users: (obj, args, { user, token }) => permissionChecker(USERS_LIST, user, () => userService.getAll({ token })),
     projects: (obj, args, { token }) => projectService.listProjects(token),
-    project: (obj, { key }, { user, token }) => permissionChecker(SETTINGS_READ, user, () => projectService.getProjectByKey(key, token)),
+    project: (obj, { projectKey }, { user, token }) => projectPermissionWrapper(projectKey, SETTINGS_READ, token, user, () => projectService.getProjectByKey(projectKey, token)),
   },
 
   Mutation: {

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -38,7 +38,7 @@ const resolvers = {
     checkNameUniqueness: (obj, { name }, { user, token }) => permissionChecker([STACKS_CREATE, STORAGE_CREATE], user, () => internalNameChecker({ user, token }, name)),
     users: (obj, args, { user, token }) => permissionChecker(USERS_LIST, user, () => userService.getAll({ token })),
     projects: (obj, args, { token }) => projectService.listProjects(token),
-    project: (obj, { projectKey }, { user, token }) => projectPermissionWrapper(projectKey, SETTINGS_READ, token, user, () => projectService.getProjectByKey(projectKey, token)),
+    project: (obj, args, { user, token }) => projectPermissionWrapper(args, SETTINGS_READ, user, () => projectService.getProjectByKey(args.projectKey, token)),
   },
 
   Mutation: {

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -37,7 +37,7 @@ type Query {
     projects: [Project]
 
     # Details of a single project
-    project(key: String!): Project
+    project(projectKey: String!): Project
 }
 
 # Root mutation methods for Datalabs.

--- a/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`projectsService loadProjectInfo should build the correct query and unpack the results 1`] = `
 "
-    LoadProjectInfo($key: String!) {
-      project(key: $key) {
+    LoadProjectInfo($projectKey: String!) {
+      project(projectKey: $projectKey) {
         id, key, name, description
       }
     }"

--- a/code/workspaces/web-app/src/api/projectsService.js
+++ b/code/workspaces/web-app/src/api/projectsService.js
@@ -13,15 +13,15 @@ function loadProjects() {
     .then(errorHandler('data.projects'));
 }
 
-function loadProjectInfo(key) {
+function loadProjectInfo(projectKey) {
   const query = `
-    LoadProjectInfo($key: String!) {
-      project(key: $key) {
+    LoadProjectInfo($projectKey: String!) {
+      project(projectKey: $projectKey) {
         id, key, name, description
       }
     }`;
 
-  return gqlQuery(query, { key })
+  return gqlQuery(query, { projectKey })
     .then(errorHandler('data.project'));
 }
 


### PR DESCRIPTION
There is a new permission wrapper for use by client-api resolvers.js, which checks to see if the projectKey is accessible to the user as part of the permission check.  It has been applied to the project resolver.   As other functionality becomes project-aware, they can be wrapped in the project permission checker.

NOTE: The 'can this user see this project?' question is answered by userService.isMemberOfProject, since that's what project.accessible is derived from (see client-api resolvers.js), which is what determines whether the Open button appears on the projects page.  This method doesn't check to see whether the use is an instance admin, and so:
- an instance-admin won't necessarily have the Open project button
- an instance-admin won't necessarily have permission to view project info.  This is covered in the unit tests.

This seems wrong in the longer term, but at least it's consistent for now.  As we develop the instance admin functionality, it should become clear what needs to change (and will be partly determined by whether an instance admin is looking at the Projects page with their user hat on, or their admin hat).

Project 'key' is now consistently 'projectKey', so that it's not confusing when the project permission wrapper wraps other dataAccess functions.