### PR TITLE
NERDCL-413 Projects page loads even if user has no permissions

### DIFF
--- a/code/workspaces/web-app/src/PrivateApp.js
+++ b/code/workspaces/web-app/src/PrivateApp.js
@@ -35,17 +35,14 @@ const PrivateApp = ({ promisedUserPermissions, location }) => (
         exact path="/projects"
         component={ProjectsPage}
         promisedUserPermissions={promisedUserPermissions}
-        permission={PROJECT_STACKS_LIST}
+        permission=''
         alt={NotFoundPage} />
       />
       <Redirect exact from="/" to="/projects" />
-      <RoutePermissions
+      <Route
         exact
         path="/projects/:projectKey/info"
-        component={ProjectInfoPage}
-        promisedUserPermissions={promisedUserPermissions}
-        permission={PROJECT_STORAGE_LIST}
-        alt={NotFoundPage} />
+        component={ProjectInfoPage} />
       <RoutePermissions
         exact
         path="/projects/:projectKey/storage"

--- a/code/workspaces/web-app/src/components/common/RoutePermissionWrapper.js
+++ b/code/workspaces/web-app/src/components/common/RoutePermissionWrapper.js
@@ -13,7 +13,7 @@ class RoutePermissionWrapper extends Component {
       return () => (<CircularProgress />);
     }
 
-    if (!fetching && value.includes(this.props.permission)) {
+    if (!fetching && (!this.props.permission || value.includes(this.props.permission))) {
       return props => (<WrappedComponent userPermissions={value} {...props} />);
     }
 

--- a/code/workspaces/web-app/src/components/common/RoutePermissionWrapper.spec.js
+++ b/code/workspaces/web-app/src/components/common/RoutePermissionWrapper.spec.js
@@ -76,6 +76,23 @@ describe('RoutePermissionWrapper', () => {
     expect(output.prop('children')).toBe('Has Permission');
   });
 
+  it('renders given component when no permissions required', () => {
+    // Arrange
+    const promisedUserPermissions = {
+      error: null,
+      fetching: false,
+      value: ['expectedPermission'],
+    };
+    const props = generateProps({ promisedUserPermissions });
+    props.permission = '';
+
+    // Act
+    const output = fullRender(props).find('span');
+
+    // Assert
+    expect(output.prop('children')).toBe('Has Permission');
+  });
+
   it('renders alt component when permissions do not match', () => {
     // Arrange
     const promisedUserPermissions = {


### PR DESCRIPTION
The projects page needs to know about user permissions, so I've left it wrapped up in RoutePermissions, but that now has the option of having no required permission to load the page (permission = '').
The info page doesn't show anything that's not on the project page, so I've removed a permissions check from it (the previous permission, PROJECT_STORAGE_LIST, was not the right one to use anyway).