### PR TITLE
Nercdl 415 link client and infra api projects endpoints

### DIFF
--- a/code/development-env/config/mongo/projectsCollection.json
+++ b/code/development-env/config/mongo/projectsCollection.json
@@ -1,6 +1,6 @@
 [
   {
-    "projectKey": "project",
+    "key": "project",
     "name": "Project",
     "description": "Default project available in the test instance of Datalabs.",
     "collaborationLink": "https://testlab.test-datalabs.nerc.ac.uk/"

--- a/code/development-env/insomnia/datalabs-apis.yaml
+++ b/code/development-env/insomnia/datalabs-apis.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2019-09-19T13:27:08.309Z
+__export_date: 2019-09-20T14:01:02.350Z
 __export_source: insomnia.desktop.app:v6.6.2
 resources:
   - _id: req_b9b95c4383644bc1a22542c2470790b1
@@ -393,6 +393,34 @@ resources:
     settingStoreCookies: true
     url: "{{ client_api_url  }}/api"
     _type: request
+  - _id: req_1bb07662812b4c49b19edc6c195a781d
+    authentication:
+      token: "{{ access_token  }}"
+      type: bearer
+    body:
+      mimeType: application/graphql
+      text: '{"query":"query {\n  projects
+        {\n    id\n    key\n    name\n    description\n    collaborationLink\n    accessible\n  }\n}"}'
+    created: 1568644168939
+    description: ""
+    headers:
+      - id: pair_420491f04c4d4360a1d824ef4dcbf6d8
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566905934951
+    method: POST
+    modified: 1568981228650
+    name: projects
+    parameters: []
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ client_api_url  }}/api"
+    _type: request
   - _id: req_62f3cb4b31c84181884cf475dc5185a5
     authentication:
       token: "{{ access_token  }}"
@@ -502,6 +530,39 @@ resources:
     settingStoreCookies: true
     url: "{{ client_api_url  }}/api"
     _type: request
+  - _id: req_23924ad71f224bb5bac9ff07cfdefde6
+    authentication:
+      token: "{{ access_token  }}"
+      type: bearer
+    body:
+      mimeType: application/graphql
+      text: '{"query":"mutation {\n  createProject(project: { \n    projectKey:
+        \"gql-create-project\", \n    name: \"GQL Create
+        Project\",\n    description: \"A project created using the createProject
+        mutation in GraphQL.\",\n    collaborationLink:
+        \"some-collaboration-url\",\n  })
+        {\n    id\n    key\n    name\n    description\n    collaborationLink\n    accessible\n  }\n}
+        "}'
+    created: 1568905829672
+    description: ""
+    headers:
+      - id: pair_57ece199c6814d9b82e04a41480b77bb
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566905934938.5
+    method: POST
+    modified: 1568981379545
+    name: createProject
+    parameters: []
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ client_api_url  }}/api"
+    _type: request
   - _id: req_957c83a53645464e9edd5cd83c340c87
     authentication:
       token: "{{ access_token  }}"
@@ -522,6 +583,67 @@ resources:
     method: POST
     modified: 1568029068062
     name: Storage
+    parameters: []
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ client_api_url  }}/api"
+    _type: request
+  - _id: req_1e855f4eb84f48eb909addb89a59835d
+    authentication:
+      token: "{{ access_token  }}"
+      type: bearer
+    body:
+      mimeType: application/graphql
+      text: '{"query":"mutation {\n  updateProject(project: { \n    projectKey:
+        \"gql-update-project\", \n    name: \"GQL Update
+        Project\",\n    description: \"A project created using the updateProject
+        mutation in GraphQL.\",\n    collaborationLink:
+        \"some-collaboration-url\",\n  })
+        {\n    id\n    key\n    name\n    description\n    collaborationLink\n    accessible\n  }\n}
+        "}'
+    created: 1568906446384
+    description: ""
+    headers:
+      - id: pair_57ece199c6814d9b82e04a41480b77bb
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566905934932.25
+    method: POST
+    modified: 1568981971509
+    name: updateProject
+    parameters: []
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ client_api_url  }}/api"
+    _type: request
+  - _id: req_9dd25c2245294667aa561c46ca3a250b
+    authentication:
+      token: "{{ access_token  }}"
+      type: bearer
+    body:
+      mimeType: application/graphql
+      text: '{"query":"mutation {\n  deleteProject(project: {projectKey:
+        \"gql-create-project\"})\n}\n"}'
+    created: 1568906791713
+    description: ""
+    headers:
+      - id: pair_420491f04c4d4360a1d824ef4dcbf6d8
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1566905934929.125
+    method: POST
+    modified: 1568981405171
+    name: deleteProject
     parameters: []
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
     settingDisableRenderRequestBody: false

--- a/code/workspaces/client-api/src/dataaccess/projectService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.spec.js
@@ -1,0 +1,91 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import config from '../config';
+import projectService, { projectActionRequestToProject } from './projectService';
+
+const httpMock = new MockAdapter(axios);
+const token = 'token';
+
+const testProject = {
+  key: 'test-key',
+  name: 'Test Name',
+  description: 'Test description',
+  collaborationLink: 'test-link',
+};
+
+const testProjects = [
+  testProject,
+  { key: 'key-1', name: 'name 1', description: 'description 1' },
+  { key: 'key-2', name: 'name 2', description: 'description 2' },
+];
+
+const infraServiceUrl = config.get('infrastructureApi');
+
+describe('projectService', () => {
+  beforeEach(() => {
+    httpMock.reset();
+  });
+
+  afterAll(() => {
+    httpMock.restore();
+  });
+
+  it('listProjects makes an api call and returns response data', async () => {
+    httpMock.onGet(`${infraServiceUrl}/projects`)
+      .reply(200, testProjects);
+
+    const result = await projectService.listProjects(token);
+    expect(result).toEqual(testProjects);
+  });
+
+  it('getProjectByKey makes an api call and returns response data', async () => {
+    const { key } = testProject;
+    httpMock.onGet(`${infraServiceUrl}/projects/${key}`)
+      .reply(200, testProject);
+
+    const result = await projectService.getProjectByKey(key, token);
+    expect(result).toEqual(testProject);
+  });
+
+  it('createProject makes an api call and returns the response data', async () => {
+    const dummyResponse = { id: 'id', ...testProject };
+    httpMock.onPost(`${infraServiceUrl}/projects`, testProject)
+      .reply(200, dummyResponse);
+
+    const creationRequest = { ...testProject, projectKey: testProject.key };
+    delete creationRequest.key;
+    const result = await projectService.createProject(creationRequest, token);
+    expect(result).toEqual(dummyResponse);
+  });
+
+  it('updateProject makes an api call and returns the response data', async () => {
+    const { key } = testProject;
+    const dummyResponse = { id: 'id', ...testProject };
+    httpMock.onPut(`${infraServiceUrl}/projects/${key}`, testProject)
+      .reply(200, dummyResponse);
+
+    const updateRequest = { ...testProject, projectKey: testProject.key };
+    delete updateRequest.key;
+    const result = await projectService.updateProject(updateRequest, token);
+    expect(result).toEqual(dummyResponse);
+  });
+
+  it('deleteProject makes an api call and returns the response data', async () => {
+    const { key } = testProject;
+    httpMock.onDelete(`${infraServiceUrl}/projects/${key}`)
+      .reply(200, true);
+
+    const result = await projectService.deleteProject(key, token);
+    expect(result).toEqual(true);
+  });
+});
+
+describe('projectActionRequestToProject', () => {
+  it('converts action request to a project definition', () => {
+    const projectKey = 'projectKey';
+    const baseData = { name: 'name', description: 'description', collaborationLink: 'collaborationLink' };
+    const actionRequest = { projectKey, ...baseData };
+    const projcetDefinition = { key: projectKey, ...baseData };
+    expect(projectActionRequestToProject(actionRequest)).toEqual(projcetDefinition);
+  });
+});

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -79,6 +79,7 @@ const resolvers = {
   },
 
   Project: {
+    id: obj => (obj._id), // eslint-disable-line no-underscore-dangle
     projectUsers: (obj, args, ctx) => userService.getProjectUsers(obj.key, ctx.token),
     accessible: (obj, args, ctx) => userService.isMemberOfProject(obj.key, ctx.token),
   },

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -67,7 +67,7 @@ type Mutation {
     updateProject(project: ProjectUpdateRequest): Project
 
     # Delete a project
-    deleteProject(project: ProjectDeletionRequest): Project
+    deleteProject(project: ProjectDeletionRequest): Boolean
 
     # Add a user permission to a project
     addProjectPermission(permission: PermissionAddRequest): Permission

--- a/code/workspaces/infrastructure-api/src/controllers/__snapshots__/projectsController.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/controllers/__snapshots__/projectsController.spec.js.snap
@@ -6,7 +6,7 @@ exports[`createOrUpdateProject returns 400 if key in URL and key in body do not 
 Object {
   "errors": Array [
     Object {
-      "msg": "'projectKey' parameter in URL and 'projectKey' field in request body must match. Got 'key' in URL and 'projectKey' in body.",
+      "msg": "'projectKey' parameter in URL and 'projectKey' field in request body must match. Got 'non-matching-key' in URL and 'key' in body.",
     },
   ],
 }
@@ -18,7 +18,7 @@ exports[`createProject returns 400 if a project with the same key already exists
 Object {
   "errors": Array [
     Object {
-      "msg": "Entry with projectKey 'projectKey' already exists.",
+      "msg": "Entry with key 'projectKey' already exists.",
     },
   ],
 }

--- a/code/workspaces/infrastructure-api/src/controllers/projectsController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/projectsController.js
@@ -29,9 +29,9 @@ async function getProjectByKey(request, response, next) {
 async function createProject(request, response, next) {
   const project = matchedData(request, { locations: ['body'] });
 
-  if (await projectsRepository.exists(project.projectKey)) {
+  if (await projectsRepository.exists(project.key)) {
     response.status(400).send({
-      errors: [{ msg: `Entry with projectKey '${project.projectKey}' already exists.` }],
+      errors: [{ msg: `Entry with key '${project.key}' already exists.` }],
     });
   } else {
     try {
@@ -47,9 +47,9 @@ async function createOrUpdateProject(request, response, next) {
   const { projectKey } = matchedData(request, { locations: ['params'] });
   const project = matchedData(request, { locations: ['body'] });
 
-  if (projectKey !== project.projectKey) {
+  if (projectKey !== project.key) {
     const msg = "'projectKey' parameter in URL and 'projectKey' field in request body must "
-      + `match. Got '${projectKey}' in URL and '${project.projectKey}' in body.`;
+      + `match. Got '${projectKey}' in URL and '${project.key}' in body.`;
     response.status(400).send({ errors: [{ msg }] });
   } else {
     try {
@@ -67,8 +67,11 @@ async function deleteProjectByKey(request, response, next) {
 
   try {
     const result = await projectsRepository.deleteByKey(projectKey);
-    if (result.n === 0) response.status(404).send();
-    else response.send(result);
+    if (result.n === 0) {
+      response.status(404).send(false);
+    } else {
+      response.send(true);
+    }
   } catch (error) {
     next(new Error(`Error deleting project: ${error.message}`));
   }
@@ -81,11 +84,11 @@ const actionWithKeyValidator = () => service.middleware.validator([
 // Checking fields makes them appear in matchedData which is used to get the data
 // from the body of the request.
 const projectDocumentValidator = () => service.middleware.validator([
-  check('projectKey')
+  check('key')
     .exists()
-    .withMessage("'projectKey' must be specified in request body.")
+    .withMessage("'key' must be specified in request body.")
     .isLength({ min: 2 })
-    .withMessage("'projectKey' must be 2 or more characters long.")
+    .withMessage("'key' must be 2 or more characters long.")
     .trim(),
   check('name')
     .exists()

--- a/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.js
@@ -7,11 +7,11 @@ async function getAll() {
 }
 
 async function getByKey(projectKey) {
-  return Project().findOne({ projectKey }).exec();
+  return Project().findOne({ key: projectKey }).exec();
 }
 
 async function exists(projectKey) {
-  return Project().exists({ projectKey });
+  return Project().exists({ key: projectKey });
 }
 
 async function create(project) {
@@ -20,14 +20,14 @@ async function create(project) {
 
 async function createOrUpdate(project) {
   return Project().findOneAndUpdate(
-    { projectKey: project.projectKey },
+    { key: project.key },
     project,
     { upsert: true, setDefaultsOnInsert: true, new: true },
   );
 }
 
 async function deleteByKey(projectKey) {
-  return Project().remove({ projectKey }).exec();
+  return Project().remove({ key: projectKey }).exec();
 }
 
 export default {

--- a/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.spec.js
@@ -4,7 +4,7 @@ import database from '../config/database';
 jest.mock('../config/database');
 
 const testProject = {
-  projectKey: 'projectKey',
+  key: 'key',
   name: 'name',
   description: 'description',
   collaborationLink: 'collaborationLink',
@@ -32,16 +32,16 @@ describe('projectsRepository', () => {
   });
 
   it('getByKey calls correct methods with correct arguments', async () => {
-    const projectKey = 'expected-key';
-    await projectsRepository.getByKey(projectKey);
-    expectToHaveBeenCalledOnceWith(ProjectMock.findOne, { projectKey });
+    const key = 'expected-key';
+    await projectsRepository.getByKey(key);
+    expectToHaveBeenCalledOnceWith(ProjectMock.findOne, { key });
     expectToHaveBeenCalledOnceWith(ProjectMock.exec);
   });
 
   it('exists calls correct methods with correct arguments', async () => {
-    const { projectKey } = testProject;
-    await projectsRepository.exists(projectKey);
-    expectToHaveBeenCalledOnceWith(ProjectMock.exists, { projectKey });
+    const { key } = testProject;
+    await projectsRepository.exists(key);
+    expectToHaveBeenCalledOnceWith(ProjectMock.exists, { key });
   });
 
   it('create calls correct methods with correct arguments', async () => {
@@ -53,16 +53,16 @@ describe('projectsRepository', () => {
     await projectsRepository.createOrUpdate(testProject);
     expectToHaveBeenCalledOnceWith(
       ProjectMock.findOneAndUpdate,
-      { projectKey: testProject.projectKey },
+      { key: testProject.key },
       testProject,
       { upsert: true, setDefaultsOnInsert: true, new: true },
     );
   });
 
   it('deleteByKey calls correct methods with correct arguments', async () => {
-    const { projectKey } = testProject;
-    await projectsRepository.deleteByKey(projectKey);
-    expectToHaveBeenCalledOnceWith(ProjectMock.remove, { projectKey });
+    const { key } = testProject;
+    await projectsRepository.deleteByKey(key);
+    expectToHaveBeenCalledOnceWith(ProjectMock.remove, { key });
     expectToHaveBeenCalledOnceWith(ProjectMock.exec);
   });
 });

--- a/code/workspaces/infrastructure-api/src/models/project.model.js
+++ b/code/workspaces/infrastructure-api/src/models/project.model.js
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 const { Schema } = mongoose;
 
 const ProjectSchema = new Schema({
-  projectKey: { type: String, required: true },
+  key: { type: String, required: true },
   name: { type: String, required: true },
   description: String,
   collaborationLink: String,

--- a/code/workspaces/web-app/src/api/__snapshots__/projectSettingsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectSettingsService.spec.js.snap
@@ -11,8 +11,8 @@ exports[`projectSettingsService addProjectUserPermission should build correct qu
 
 exports[`projectSettingsService getProjectUsers should build correct query and unpack the result 1`] = `
 "
-    GetProjectUsers($projectId: String!) {
-      project(key: $projectId) {
+    GetProjectUsers($projectKey: String!) {
+      project(projectKey: $projectKey) {
         projectUsers { 
           userId, name, role
         },

--- a/code/workspaces/web-app/src/api/projectSettingsService.js
+++ b/code/workspaces/web-app/src/api/projectSettingsService.js
@@ -1,17 +1,17 @@
 import { gqlQuery, gqlMutation } from './graphqlClient';
 import errorHandler from './graphqlErrorHandler';
 
-export function getProjectUsers(projectId) {
+export function getProjectUsers(projectKey) {
   const query = `
-    GetProjectUsers($projectId: String!) {
-      project(key: $projectId) {
+    GetProjectUsers($projectKey: String!) {
+      project(projectKey: $projectKey) {
         projectUsers { 
           userId, name, role
         },
       }
     }`;
 
-  return gqlQuery(query, { projectId })
+  return gqlQuery(query, { projectKey })
     .then(errorHandler('data.project.projectUsers'));
 }
 


### PR DESCRIPTION
* Update GraphQL project resolvers to call the infrastructure api project endpoints.
* Consolidate the naming convention of `projectKey` and `project.key`.