### PR TITLE
NERCDL-430 protect master branch

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -4,12 +4,13 @@
     "workspaces/*"
   ],
   "scripts": {
-    "update-version": "shx echo \"{ \\\"version\\\": \\\"`git describe --tags --always`\\\" }\" > version.json"
+    "update-version": "shx echo \"{ \\\"version\\\": \\\"`git describe --tags --always`\\\" }\" > version.json",
+    "check-not-master": "git branch | egrep \"\\*\"  | egrep -v \"^\\* master$\""
   },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run check-not-master && lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
This is a small npm scriptlet used in the husky pre-commit to prevent direct commits to master.