### PR TITLE
NERCDL-374: add projectKey to createDataStore

### DIFF
--- a/code/development-env/config/mongo/dataStorageCollection.json
+++ b/code/development-env/config/mongo/dataStorageCollection.json
@@ -5,6 +5,7 @@
     "created" : "2018-02-13T12:45:47.306Z",
     "displayName" : "Example Storage",
     "description" : "An Example Data Store",
+    "projectKey" : "project",
     "type" : 1,
     "volumeSize" : "5",
     "url" : "https://testlab-example.datalabs.localhost/minio",

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -43,8 +43,8 @@ const resolvers = {
   Mutation: {
     createStack: (obj, { stack }, { user, token }) => permissionChecker(STACKS_CREATE, user, () => stackApi.createStack({ user, token }, DATALAB_NAME, { projectKey: PROJECT_KEY, ...stack })),
     deleteStack: (obj, { stack }, { user, token }) => permissionChecker(STACKS_DELETE, user, () => stackApi.deleteStack({ user, token }, DATALAB_NAME, { projectKey: PROJECT_KEY, ...stack })),
-    createDataStore: (obj, { dataStore }, { user, token }) => (
-      permissionChecker(STORAGE_CREATE, user, () => storageService.createVolume({ projectKey: PROJECT_KEY, ...dataStore }, token))
+    createDataStore: (obj, args, { user, token }) => (
+      projectPermissionWrapper(args, STORAGE_CREATE, user, () => storageService.createVolume({ projectKey: args.projectKey, ...args.dataStore }, token))
     ),
     deleteDataStore: (obj, { dataStore }, { user, token }) => (
       permissionChecker(STORAGE_DELETE, user, () => storageService.deleteVolume({ projectKey: PROJECT_KEY, ...dataStore }, token))

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -49,7 +49,7 @@ type Mutation {
     deleteStack(stack: StackDeletionRequest): Stack
 
     # Create a new data store
-    createDataStore(dataStore: DataStorageCreationRequest): DataStore
+    createDataStore(projectKey: String!, dataStore: DataStorageCreationRequest): DataStore
 
     # Delete a data store
     deleteDataStore(dataStore: DataStorageUpdateRequest): DataStore

--- a/code/workspaces/web-app/src/actions/dataStorageActions.js
+++ b/code/workspaces/web-app/src/actions/dataStorageActions.js
@@ -24,9 +24,9 @@ const openMinioDataStore = (storageUrl, token) => ({
   payload: minioService.openStorage(storageUrl, token),
 });
 
-const createDataStore = dataStore => ({
+const createDataStore = (projectKey, dataStore) => ({
   type: CREATE_DATASTORE_ACTION,
-  payload: dataStorageService.createDataStore(dataStore),
+  payload: dataStorageService.createDataStore(projectKey, dataStore),
 });
 
 const deleteDataStore = ({ name }) => ({

--- a/code/workspaces/web-app/src/actions/dataStorageActions.spec.js
+++ b/code/workspaces/web-app/src/actions/dataStorageActions.spec.js
@@ -70,11 +70,11 @@ describe('dataStorageActions', () => {
       dataStorageService.createDataStore = createDataStoreMock;
 
       // Act
-      const output = dataStorageActions.createDataStore(dataStore);
+      const output = dataStorageActions.createDataStore('project99', dataStore);
 
       // Assert
       expect(createDataStoreMock).toHaveBeenCalledTimes(1);
-      expect(createDataStoreMock).toHaveBeenCalledWith(dataStore);
+      expect(createDataStoreMock).toHaveBeenCalledWith('project99', dataStore);
       expect(output.type).toBe(CREATE_DATASTORE_ACTION);
       expect(output.payload).toBe('expectedCreationPayload');
     });

--- a/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
@@ -11,8 +11,8 @@ exports[`dataStorageService addUserToDataStore should build the correct correct 
 
 exports[`dataStorageService createDataStore should build the correct correct mutation and unpack the results 1`] = `
 "
-    CreateDataStore($dataStore:  DataStorageCreationRequest) {
-      createDataStore(dataStore: $dataStore) {
+    CreateDataStore($projectKey: String!, $dataStore:  DataStorageCreationRequest) {
+      createDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }"

--- a/code/workspaces/web-app/src/api/dataStorageService.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.js
@@ -25,15 +25,15 @@ function getCredentials(projectKey, id) {
     .then(errorHandler('data.dataStore'));
 }
 
-function createDataStore(dataStore) {
+function createDataStore(projectKey, dataStore) {
   const mutation = `
-    CreateDataStore($dataStore:  DataStorageCreationRequest) {
-      createDataStore(dataStore: $dataStore) {
+    CreateDataStore($projectKey: String!, $dataStore:  DataStorageCreationRequest) {
+      createDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }`;
 
-  return gqlMutation(mutation, { dataStore })
+  return gqlMutation(mutation, { projectKey, dataStore })
     .then(errorHandler('data.dataStorage'));
 }
 

--- a/code/workspaces/web-app/src/api/dataStorageService.spec.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.spec.js
@@ -18,7 +18,6 @@ describe('dataStorageService', () => {
 
     it('should throw an error if the query fails', async () => {
       mockClient.prepareFailure('error');
-
       let error;
       try {
         await dataStorageService.loadDataStorage('project99');
@@ -35,40 +34,46 @@ describe('dataStorageService', () => {
       const queryParams = { projectKey: 'project99', id: 'idValue' };
       mockClient.prepareSuccess(data);
 
-      return dataStorageService.getCredentials(queryParams.projectKey, queryParams.id).then((response) => {
+      dataStorageService.getCredentials(queryParams.projectKey, queryParams.id).then((response) => {
         expect(response).toEqual(data.dataStore);
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(queryParams);
       });
     });
 
-    it('should throw an error if the query fails', () => {
+    it('should throw an error if the query fails', async () => {
       mockClient.prepareFailure('error');
-
-      return dataStorageService.getCredentials().catch((error) => {
-        expect(error).toEqual({ error: 'error' });
-      });
+      let error;
+      try {
+        await dataStorageService.getCredentials();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual({ error: 'error' });
     });
   });
 
   describe('createDataStore', () => {
     it('should build the correct correct mutation and unpack the results', () => {
-      const data = { dataStore: { name: 'name' } };
+      const data = { projectKey: 'project99', dataStore: { name: 'name' } };
       mockClient.prepareSuccess(data);
 
-      return dataStorageService.createDataStore(data.dataStore).then((response) => {
+      dataStorageService.createDataStore(data.projectKey, data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
-    it('should throw an error if the mutation fails', () => {
-      const data = { dataStore: { name: 'name' } };
+    it('should throw an error if the mutation fails', async () => {
+      const data = { projectKey: 'project99', dataStore: { name: 'name' } };
       mockClient.prepareFailure('error');
-
-      return dataStorageService.createDataStore(data.dataStore).catch((error) => {
-        expect(error).toEqual({ error: 'error' });
-      });
+      let error;
+      try {
+        await dataStorageService.createDataStore(data.projectKey, data.dataStore);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual({ error: 'error' });
     });
   });
 
@@ -77,19 +82,22 @@ describe('dataStorageService', () => {
       const data = { dataStore: { name: 'name' } };
       mockClient.prepareSuccess(data);
 
-      return dataStorageService.deleteDataStore(data.dataStore).then((response) => {
+      dataStorageService.deleteDataStore(data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
-    it('should throw an error if the mutation fails', () => {
+    it('should throw an error if the mutation fails', async () => {
       const data = { dataStore: { name: 'name' } };
       mockClient.prepareFailure('error');
-
-      return dataStorageService.deleteDataStore(data.dataStore).catch((error) => {
-        expect(error).toEqual({ error: 'error' });
-      });
+      let error;
+      try {
+        await dataStorageService.deleteDataStore(data.dataStore);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual({ error: 'error' });
     });
   });
 
@@ -98,19 +106,22 @@ describe('dataStorageService', () => {
       const data = { dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareSuccess(data);
 
-      return dataStorageService.addUserToDataStore(data.dataStore).then((response) => {
+      dataStorageService.addUserToDataStore(data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
-    it('should throw an error if the mutation fails', () => {
+    it('should throw an error if the mutation fails', async () => {
       const data = { dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareFailure('error');
-
-      return dataStorageService.addUserToDataStore(data.dataStore).catch((error) => {
-        expect(error).toEqual({ error: 'error' });
-      });
+      let error;
+      try {
+        await dataStorageService.addUserToDataStore(data.dataStore);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual({ error: 'error' });
     });
   });
 
@@ -119,19 +130,22 @@ describe('dataStorageService', () => {
       const data = { dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareSuccess(data);
 
-      return dataStorageService.removeUserFromDataStore(data.dataStore).then((response) => {
+      dataStorageService.removeUserFromDataStore(data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
-    it('should throw an error if the mutation fails', () => {
+    it('should throw an error if the mutation fails', async () => {
       const data = { dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareFailure('error');
-
-      return dataStorageService.removeUserFromDataStore(data.dataStore).catch((error) => {
-        expect(error).toEqual({ error: 'error' });
-      });
+      let error;
+      try {
+        await dataStorageService.removeUserFromDataStore(data.dataStore);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toEqual({ error: 'error' });
     });
   });
 });

--- a/code/workspaces/web-app/src/components/dataStorage/PreviewDataStoreCard.js
+++ b/code/workspaces/web-app/src/components/dataStorage/PreviewDataStoreCard.js
@@ -9,6 +9,7 @@ class PreviewDataStoreCard extends Component {
         stack={this.props.stack}
         typeName="dataStore"
         userPermissions={['open', 'delete']}
+        editPermission="edit"
         openPermission="open"
         deletePermission="delete" />
     );

--- a/code/workspaces/web-app/src/components/dataStorage/__snapshots__/PreviewDataStoreCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/dataStorage/__snapshots__/PreviewDataStoreCard.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`PreviewDataStoreCard is a component which passes correct props to StackCards 1`] = `
 <WithStyles(StackCard)
   deletePermission="delete"
+  editPermission="edit"
   openPermission="open"
   stack="expectedStack"
   typeName="dataStore"

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -47,7 +47,7 @@ class DataStorageContainer extends Component {
     .catch(err => notify.error(`Unable to open ${TYPE_NAME}`));
 
   createDataStore = dataStore => Promise.resolve(this.props.actions.closeModalDialog())
-    .then(() => this.props.actions.createDataStore(dataStore))
+    .then(() => this.props.actions.createDataStore(this.props.projectKey, dataStore))
     .then(() => this.props.actions.resetForm())
     .then(() => notify.success(`${TYPE_NAME} created`))
     .catch(err => notify.error(`Unable to create ${TYPE_NAME}`))

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
@@ -273,7 +273,7 @@ describe('DataStorageContainer', () => {
       return onSubmit(stack)
         .then(() => {
           expect(createDataStoreMock).toHaveBeenCalledTimes(1);
-          expect(createDataStoreMock).toHaveBeenCalledWith(stack);
+          expect(createDataStoreMock).toHaveBeenCalledWith('project99', stack);
           expect(resetFormMock).toHaveBeenCalledTimes(1);
         });
     });


### PR DESCRIPTION
- Added projectKey to createDataStore
- Put initial 'Example Storage' into default project
- Added missing prop in PreviewDataStoreCard
- Fix error tests in dataStorageService.spec so they catch promises not rejecting.