### PR TITLE
NERCDL-374 projectKey in add/remove users for data store

### DIFF
--- a/code/workspaces/client-api/src/infrastructure/storageService.js
+++ b/code/workspaces/client-api/src/infrastructure/storageService.js
@@ -34,14 +34,14 @@ async function getById(projectKey, id, token) {
   return response.data;
 }
 
-async function addUsers(name, users, token) {
-  const url = `${API_URL_BASE}/volumes/${name}/addUsers`;
+async function addUsers(projectKey, name, users, token) {
+  const url = `${API_URL_BASE}/volumes/${projectKey}/${name}/addUsers`;
   const response = await axios.put(url, { userIds: users }, generateOptions(token));
   return response.data;
 }
 
-async function removeUsers(name, users, token) {
-  const url = `${API_URL_BASE}/volumes/${name}/removeUsers`;
+async function removeUsers(projectKey, name, users, token) {
+  const url = `${API_URL_BASE}/volumes/${projectKey}/${name}/removeUsers`;
   const response = await axios.put(url, { userIds: users }, generateOptions(token));
   return response.data;
 }

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -49,11 +49,11 @@ const resolvers = {
     deleteDataStore: (obj, args, { user, token }) => (
       projectPermissionWrapper(args, STORAGE_DELETE, user, () => storageService.deleteVolume({ projectKey: args.projectKey, ...args.dataStore }, token))
     ),
-    addUserToDataStore: (obj, { dataStore: { name, users } }, { user, token }) => (
-      permissionChecker(STORAGE_EDIT, user, () => storageService.addUsers(name, users, token))
+    addUserToDataStore: (obj, args, { user, token }) => (
+      projectPermissionWrapper(args, STORAGE_EDIT, user, () => storageService.addUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token))
     ),
-    removeUserFromDataStore: (obj, { dataStore: { name, users } }, { user, token }) => (
-      permissionChecker(STORAGE_EDIT, user, () => storageService.removeUsers(name, users, token))
+    removeUserFromDataStore: (obj, args, { user, token }) => (
+      projectPermissionWrapper(args, STORAGE_EDIT, user, () => storageService.removeUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token))
     ),
     addProjectPermission: (obj, { permission: { projectKey, userId, role } }, { user, token }) => (
       permissionChecker(PERMISSIONS_CREATE, user, () => projectService.addProjectPermission(projectKey, userId, role, token))

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -55,10 +55,10 @@ type Mutation {
     deleteDataStore(projectKey: String!, dataStore: DataStorageUpdateRequest): DataStore
 
     # Grant user access to data store
-    addUserToDataStore(dataStore: DataStorageUpdateRequest): DataStore
+    addUserToDataStore(projectKey: String!, dataStore: DataStorageUpdateRequest): DataStore
 
     # Remove user access to data store
-    removeUserFromDataStore(dataStore: DataStorageUpdateRequest): DataStore
+    removeUserFromDataStore(projectKey: String!, dataStore: DataStorageUpdateRequest): DataStore
 
     # Create a new project
     createProject(project: ProjectCreationRequest): Project

--- a/code/workspaces/infrastructure-api/src/config/routes.js
+++ b/code/workspaces/infrastructure-api/src/config/routes.js
@@ -43,8 +43,8 @@ function configureRoutes(app) {
   app.get('/volumes', permissionWrapper(STORAGE_LIST), ew(volume.listVolumes));
   app.get('/volumes/active/:projectKey', permissionWrapper(STORAGE_LIST), volume.actionWithProjectKeyValidator(), ew(volume.listProjectActiveVolumes));
   app.get('/volumes/:projectKey/:id', permissionWrapper(STORAGE_LIST), volume.getByIdValidator, ew(volume.getById));
-  app.put('/volumes/:name/addUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.addUsers));
-  app.put('/volumes/:name/removeUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.removeUsers));
+  app.put('/volumes/:projectKey/:name/addUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.addUsers));
+  app.put('/volumes/:projectKey/:name/removeUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.removeUsers));
   app.post('/volume', permissionWrapper(STORAGE_CREATE), volume.createVolumeValidator, ew(volume.createVolume));
   app.delete('/volume', permissionWrapper(STORAGE_DELETE), volume.coreVolumeValidator, ew(volume.deleteVolume));
 }

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -66,24 +66,24 @@ async function getById(request, response) {
 }
 
 async function addUsers(request, response, next) {
-  const { name, userIds } = matchedData(request);
+  const { projectKey, name, userIds } = matchedData(request);
 
   try {
-    const volume = await dataStorageRepository.addUsers(name, userIds);
+    const volume = await dataStorageRepository.addUsers(request.user, projectKey, name, userIds);
     response.send(volume);
   } catch (error) {
-    next(new Error(`Unable to add users to volume ${name}: ${error.message}`));
+    next(new Error(`Unable to add users to project ${projectKey} volume ${name}: ${error.message}`));
   }
 }
 
 async function removeUsers(request, response, next) {
-  const { name, userIds } = matchedData(request);
+  const { projectKey, name, userIds } = matchedData(request);
 
   try {
-    const volume = await dataStorageRepository.removeUsers(name, userIds);
+    const volume = await dataStorageRepository.removeUsers(request.user, projectKey, name, userIds);
     response.send(volume);
   } catch (error) {
-    next(new Error(`Unable to remove users from volume ${name}: ${error.message}`));
+    next(new Error(`Unable to remove users from project ${projectKey} volume ${name}: ${error.message}`));
   }
 }
 
@@ -97,6 +97,7 @@ const actionWithProjectKeyValidator = () => service.middleware.validator([
 ], logger);
 
 const updateVolumeUserValidator = service.middleware.validator([
+  check('projectKey').exists().withMessage('projectKey must be specified').trim(),
   check('name').exists().withMessage('volume name must be specified').trim(),
   check('userIds').exists().withMessage('userIds must be specified'),
   check('userIds.*').exists().withMessage('userIds must be specified').trim(),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -135,7 +135,7 @@ describe('Volume Controller', () => {
       const response = httpMocks.createResponse();
 
       await volumeController.addUsers(request, response, next.handler);
-      expect(next.getError().message).toEqual('Unable to add users to volume volumeName: error');
+      expect(next.getError().message).toEqual('Unable to add users to project project99 volume volumeName: error');
     });
   });
 
@@ -156,7 +156,7 @@ describe('Volume Controller', () => {
       const response = httpMocks.createResponse();
 
       await volumeController.removeUsers(request, response, next.handler);
-      expect(next.getError().message).toEqual('Unable to remove users from volume volumeName: error');
+      expect(next.getError().message).toEqual('Unable to remove users from project project99 volume volumeName: error');
     });
   });
 
@@ -189,7 +189,7 @@ function createRequestBody() {
       domain: 'test-datalabs.nerc.ac.uk',
     },
     name: 'volumeName',
-    projectKey: 'project',
+    projectKey: 'project99',
     displayName: 'displayName',
     description: 'description',
     type: 1,
@@ -210,6 +210,7 @@ function validatedUpdateUserRequest() {
   request = httpMocks.createRequest({
     method: 'PUT',
     body: {
+      projectKey: 'project99',
       name: 'volumeName',
       userIds: ['uid1', 'uid2'],
     },

--- a/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.js
@@ -49,14 +49,16 @@ function update(name, updatedValues) {
   return DataStorage().findOneAndUpdate({ name }, updateObj, { upsert: false }).exec();
 }
 
-function addUsers(name, userIds) { // user, name, userId
+function addUsers({ sub }, projectKey, name, userIds) {
+  const query = filterByUserAndProject(sub, projectKey, { name });
   const updateObj = setUsers(userIds);
-  return DataStorage().findOneAndUpdate({ name }, updateObj, { upsert: false, new: true }).exec();
+  return DataStorage().findOneAndUpdate(query, updateObj, { upsert: false, new: true }).exec();
 }
 
-function removeUsers(name, userIds) { // user, name, userId
+function removeUsers({ sub }, projectKey, name, userIds) {
+  const query = filterByUserAndProject(sub, projectKey, { name });
   const updateObj = unsetUsers(userIds);
-  return DataStorage().findOneAndUpdate({ name }, updateObj, { upsert: false, new: true }).exec();
+  return DataStorage().findOneAndUpdate(query, updateObj, { upsert: false, new: true }).exec();
 }
 
 const filterByUser = (userId, findQuery) => ({
@@ -67,7 +69,7 @@ const filterByUser = (userId, findQuery) => ({
 const filterByUserAndProject = (userId, projectKey, findQuery) => ({
   ...findQuery,
   users: { $elemMatch: { $eq: userId } },
-  projectKey: { $eq: projectKey },
+  projectKey,
 });
 
 const setUsers = userIds => ({

--- a/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.spec.js
@@ -26,7 +26,7 @@ describe('dataStorageRepository', () => {
     expect(mockDatabase().query()).toEqual({
       status: { $ne: 'deleted' },
       users: { $elemMatch: { $eq: 'username' } },
-      projectKey: { $eq: 'project99' },
+      projectKey,
     });
     expect(storage).toMatchSnapshot();
   }));
@@ -40,7 +40,7 @@ describe('dataStorageRepository', () => {
 
   it('getById returns expected snapshot', () => dataStorageRepository.getById(user, 'project99', '599aa983bdd5430daedc8eec').then((storage) => {
     expect(mockDatabase().query()).toEqual({
-      projectKey: { $eq: 'project99' },
+      projectKey,
       _id: '599aa983bdd5430daedc8eec',
       users: { $elemMatch: { $eq: 'username' } },
     });
@@ -96,9 +96,13 @@ describe('dataStorageRepository', () => {
     const name = 'volume';
     const userIds = ['user1', 'users2'];
 
-    return dataStorageRepository.addUsers(name, userIds)
+    return dataStorageRepository.addUsers(user, projectKey, name, userIds)
       .then(() => {
-        expect(mockDatabase().query()).toEqual({ name });
+        expect(mockDatabase().query()).toEqual({
+          projectKey,
+          name,
+          users: { $elemMatch: { $eq: 'username' } },
+        });
         expect(mockDatabase().entity()).toEqual({
           $addToSet: { users: { $each: userIds } },
         });
@@ -110,9 +114,13 @@ describe('dataStorageRepository', () => {
     const name = 'volume';
     const userIds = ['user1', 'users2'];
 
-    return dataStorageRepository.removeUsers(name, userIds)
+    return dataStorageRepository.removeUsers(user, projectKey, name, userIds)
       .then(() => {
-        expect(mockDatabase().query()).toEqual({ name });
+        expect(mockDatabase().query()).toEqual({
+          projectKey,
+          name,
+          users: { $elemMatch: { $eq: 'username' } },
+        });
         expect(mockDatabase().entity()).toEqual({
           $pull: { users: { $in: userIds } },
         });

--- a/code/workspaces/web-app/src/actions/dataStorageActions.js
+++ b/code/workspaces/web-app/src/actions/dataStorageActions.js
@@ -34,14 +34,14 @@ const deleteDataStore = (projectKey, { name }) => ({
   payload: dataStorageService.deleteDataStore(projectKey, { name }),
 });
 
-const addUserToDataStore = ({ name, users }) => ({
+const addUserToDataStore = (projectKey, { name, users }) => ({
   type: ADD_USER_TO_DATASTORE_ACTION,
-  payload: dataStorageService.addUserToDataStore({ name, users }),
+  payload: dataStorageService.addUserToDataStore(projectKey, { name, users }),
 });
 
-const removeUserFromDataStore = ({ name, users }) => ({
+const removeUserFromDataStore = (projectKey, { name, users }) => ({
   type: REMOVE_USER_FROM_DATASTORE_ACTION,
-  payload: dataStorageService.removeUserFromDataStore({ name, users }),
+  payload: dataStorageService.removeUserFromDataStore(projectKey, { name, users }),
 });
 
 export default {

--- a/code/workspaces/web-app/src/actions/dataStorageActions.spec.js
+++ b/code/workspaces/web-app/src/actions/dataStorageActions.spec.js
@@ -100,11 +100,11 @@ describe('dataStorageActions', () => {
       dataStorageService.addUserToDataStore = addUserToDataStoreMock;
 
       // Act
-      const output = dataStorageActions.addUserToDataStore(dataStore);
+      const output = dataStorageActions.addUserToDataStore('project99', dataStore);
 
       // Assert
       expect(addUserToDataStoreMock).toHaveBeenCalledTimes(1);
-      expect(addUserToDataStoreMock).toHaveBeenCalledWith({ name: dataStore.name, users: dataStore.users });
+      expect(addUserToDataStoreMock).toHaveBeenCalledWith('project99', { name: dataStore.name, users: dataStore.users });
       expect(output.type).toBe(ADD_USER_TO_DATASTORE_ACTION);
       expect(output.payload).toBe('expectedPayload');
     });
@@ -115,11 +115,11 @@ describe('dataStorageActions', () => {
       dataStorageService.removeUserFromDataStore = removeUserFromDataStoreMock;
 
       // Act
-      const output = dataStorageActions.removeUserFromDataStore(dataStore);
+      const output = dataStorageActions.removeUserFromDataStore('project99', dataStore);
 
       // Assert
       expect(removeUserFromDataStoreMock).toHaveBeenCalledTimes(1);
-      expect(removeUserFromDataStoreMock).toHaveBeenCalledWith({ name: dataStore.name, users: dataStore.users });
+      expect(removeUserFromDataStoreMock).toHaveBeenCalledWith('project99', { name: dataStore.name, users: dataStore.users });
       expect(output.type).toBe(REMOVE_USER_FROM_DATASTORE_ACTION);
       expect(output.payload).toBe('expectedPayload');
     });

--- a/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`dataStorageService addUserToDataStore should build the correct correct mutation and unpack the results 1`] = `
 "
-    AddUserToDataStore($dataStore:  DataStorageUpdateRequest) {
-      addUserToDataStore(dataStore: $dataStore) {
+    AddUserToDataStore($projectKey: String!, $dataStore:  DataStorageUpdateRequest) {
+      addUserToDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }"
@@ -47,8 +47,8 @@ exports[`dataStorageService loadDataStorage should build the correct query and u
 
 exports[`dataStorageService removeUserFromDataStore should build the correct correct mutation and unpack the results 1`] = `
 "
-    RemoveUserFromDataStore($dataStore:  DataStorageUpdateRequest) {
-      removeUserFromDataStore(dataStore: $dataStore) {
+    RemoveUserFromDataStore($projectKey: String!, $dataStore:  DataStorageUpdateRequest) {
+      removeUserFromDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }"

--- a/code/workspaces/web-app/src/api/dataStorageService.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.js
@@ -49,27 +49,27 @@ function deleteDataStore(projectKey, dataStore) {
     .then(errorHandler('data.dataStorage'));
 }
 
-function addUserToDataStore(dataStore) {
+function addUserToDataStore(projectKey, dataStore) {
   const mutation = `
-    AddUserToDataStore($dataStore:  DataStorageUpdateRequest) {
-      addUserToDataStore(dataStore: $dataStore) {
+    AddUserToDataStore($projectKey: String!, $dataStore:  DataStorageUpdateRequest) {
+      addUserToDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }`;
 
-  return gqlMutation(mutation, { dataStore })
+  return gqlMutation(mutation, { projectKey, dataStore })
     .then(errorHandler('data.dataStorage'));
 }
 
-function removeUserFromDataStore(dataStore) {
+function removeUserFromDataStore(projectKey, dataStore) {
   const mutation = `
-    RemoveUserFromDataStore($dataStore:  DataStorageUpdateRequest) {
-      removeUserFromDataStore(dataStore: $dataStore) {
+    RemoveUserFromDataStore($projectKey: String!, $dataStore:  DataStorageUpdateRequest) {
+      removeUserFromDataStore(projectKey: $projectKey, dataStore: $dataStore) {
         name
       }
     }`;
 
-  return gqlMutation(mutation, { dataStore })
+  return gqlMutation(mutation, { projectKey, dataStore })
     .then(errorHandler('data.dataStorage'));
 }
 

--- a/code/workspaces/web-app/src/api/dataStorageService.spec.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.spec.js
@@ -103,21 +103,21 @@ describe('dataStorageService', () => {
 
   describe('addUserToDataStore', () => {
     it('should build the correct correct mutation and unpack the results', () => {
-      const data = { dataStore: { name: 'name', user: ['userId'] } };
+      const data = { projectKey: 'project99', dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareSuccess(data);
 
-      dataStorageService.addUserToDataStore(data.dataStore).then((response) => {
+      dataStorageService.addUserToDataStore(data.projectKey, data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
     it('should throw an error if the mutation fails', async () => {
-      const data = { dataStore: { name: 'name', user: ['userId'] } };
+      const data = { projectKey: 'project99', dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareFailure('error');
       let error;
       try {
-        await dataStorageService.addUserToDataStore(data.dataStore);
+        await dataStorageService.addUserToDataStore(data.projectKey, data.dataStore);
       } catch (err) {
         error = err;
       }
@@ -127,21 +127,21 @@ describe('dataStorageService', () => {
 
   describe('removeUserFromDataStore', () => {
     it('should build the correct correct mutation and unpack the results', () => {
-      const data = { dataStore: { name: 'name', user: ['userId'] } };
+      const data = { projectKey: 'project99', dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareSuccess(data);
 
-      dataStorageService.removeUserFromDataStore(data.dataStore).then((response) => {
+      dataStorageService.removeUserFromDataStore(data.projectKey, data.dataStore).then((response) => {
         expect(mockClient.lastQuery()).toMatchSnapshot();
         expect(mockClient.lastOptions()).toEqual(data);
       });
     });
 
     it('should throw an error if the mutation fails', async () => {
-      const data = { dataStore: { name: 'name', user: ['userId'] } };
+      const data = { projectKey: 'project99', dataStore: { name: 'name', user: ['userId'] } };
       mockClient.prepareFailure('error');
       let error;
       try {
-        await dataStorageService.removeUserFromDataStore(data.dataStore);
+        await dataStorageService.removeUserFromDataStore(data.projectKey, data.dataStore);
       } catch (err) {
         error = err;
       }

--- a/code/workspaces/web-app/src/containers/modal/LoadUserManagementModalWrapper.js
+++ b/code/workspaces/web-app/src/containers/modal/LoadUserManagementModalWrapper.js
@@ -27,7 +27,7 @@ class LoadUserManagementModalWrapper extends Component {
 
   addUser({ value }) {
     const { name } = this.getDataStore();
-    this.props.actions.addUserToDataStore({ name, users: [value] })
+    this.props.actions.addUserToDataStore(this.props.projectKey, { name, users: [value] })
       .then(() => notify.success('User added to data store'))
       .then(() => this.props.actions.loadDataStorage(this.props.projectKey));
   }
@@ -35,7 +35,7 @@ class LoadUserManagementModalWrapper extends Component {
   removeUser({ value }) {
     if (this.props.loginUserId !== value) {
       const { name } = this.getDataStore();
-      this.props.actions.removeUserFromDataStore({ name, users: [value] })
+      this.props.actions.removeUserFromDataStore(this.props.projectKey, { name, users: [value] })
         .then(() => notify.success('User removed from data store'))
         .then(() => this.props.actions.loadDataStorage(this.props.projectKey));
     } else {

--- a/code/workspaces/web-app/src/containers/modal/LoadUserManagementModalWrapper.spec.js
+++ b/code/workspaces/web-app/src/containers/modal/LoadUserManagementModalWrapper.spec.js
@@ -110,7 +110,7 @@ describe('LoadUserManagement Modal Wrapper', () => {
 
       // Assert
       expect(store.getActions().length).toBe(0);
-      output.prop('actions').addUserToDataStore({ name: 'name', users: ['user'] });
+      output.prop('actions').addUserToDataStore('project99', { name: 'name', users: ['user'] });
       const { type, payload } = store.getActions()[0];
       expect(type).toBe('ADD_USER_TO_DATASTORE');
       return payload.then(value => expect(value).toBe('expectedPayload'));
@@ -129,7 +129,7 @@ describe('LoadUserManagement Modal Wrapper', () => {
 
       // Assert
       expect(store.getActions().length).toBe(0);
-      output.prop('actions').removeUserFromDataStore({ name: 'name', users: ['user'] });
+      output.prop('actions').removeUserFromDataStore('project99', { name: 'name', users: ['user'] });
       const { type, payload } = store.getActions()[0];
       expect(type).toBe('REMOVE_USER_FROM_DATASTORE');
       return payload.then(value => expect(value).toBe('expectedPayload'));


### PR DESCRIPTION
Note, increases security - you can't add or remove users from a data store unless you are a user on the data store (see code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.js).