### PR TITLE
NERCDL-374 apply permissions to delete and update data store at infrastructure level

### DIFF
--- a/code/development-env/insomnia/datalabs-apis.yaml
+++ b/code/development-env/insomnia/datalabs-apis.yaml
@@ -1,157 +1,8 @@
 _type: export
 __export_format: 4
-__export_date: 2019-09-20T15:32:36.933Z
+__export_date: 2019-09-25T11:32:45.176Z
 __export_source: insomnia.desktop.app:v6.6.2
 resources:
-  - _id: req_b9b95c4383644bc1a22542c2470790b1
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    body: {}
-    created: 1568712933481
-    description: ""
-    headers: []
-    isPrivate: false
-    metaSortKey: -1568712933581
-    method: GET
-    modified: 1568990711216
-    name: Get Projects
-    parameters: []
-    parentId: fld_998699fb7271407c91200bc860ef8beb
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingSendCookies: true
-    settingStoreCookies: true
-    url: "{{ infra_api_url  }}/projects"
-    _type: request
-  - _id: fld_998699fb7271407c91200bc860ef8beb
-    created: 1568712917499
-    description: ""
-    environment: {}
-    environmentPropertyOrder: null
-    metaSortKey: -1568712917499
-    modified: 1568712917499
-    name: Infrastructure API
-    parentId: wrk_19ed8d51a0ec4d659f9962bcf31a741b
-    _type: request_group
-  - _id: wrk_19ed8d51a0ec4d659f9962bcf31a741b
-    created: 1519239116865
-    description: ""
-    modified: 1519239116865
-    name: Datalabs
-    parentId: null
-    _type: workspace
-  - _id: req_59dff46463f04da5aa0b427a1b91c429
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    body: {}
-    created: 1568727278931
-    description: ""
-    headers: []
-    isPrivate: false
-    metaSortKey: -1568712933556
-    method: GET
-    modified: 1568993252260
-    name: Get Project by Key
-    parameters: []
-    parentId: fld_998699fb7271407c91200bc860ef8beb
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingSendCookies: true
-    settingStoreCookies: true
-    url: "{{ infra_api_url  }}/projects/project"
-    _type: request
-  - _id: req_21517ac2a05e45d5af9813d3d84c98d7
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    body:
-      mimeType: application/json
-      text: |-
-        {
-        	"key": "another-project",
-        	"name": "Another Project",
-        	"description": "Another project that was added for testing purposes.",
-        	"collaborationLink": "https://google.com"
-        }
-    created: 1568718531356
-    description: ""
-    headers:
-      - id: pair_39e43053e7e84145ba27337b6f8de517
-        name: Content-Type
-        value: application/json
-    isPrivate: false
-    metaSortKey: -1568712933531
-    method: POST
-    modified: 1568991736404
-    name: Create Project
-    parameters: []
-    parentId: fld_998699fb7271407c91200bc860ef8beb
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingSendCookies: true
-    settingStoreCookies: true
-    url: "{{ infra_api_url  }}/projects"
-    _type: request
-  - _id: req_027e9bfb84de4e3c8a27e63e6c519eac
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    body:
-      mimeType: application/json
-      text: |-
-        {
-        	"key": "another-project",
-        	"name": "Another Project",
-        	"description": "An updated description for Anther Project.",
-        	"collaborationLink": "https://google.com"
-        }
-    created: 1568730196734
-    description: ""
-    headers:
-      - id: pair_ab5a02265f1848799a822c475f3d8942
-        name: Content-Type
-        value: application/json
-    isPrivate: false
-    metaSortKey: -1568712933506
-    method: PUT
-    modified: 1568993310809
-    name: Update or Create Project
-    parameters: []
-    parentId: fld_998699fb7271407c91200bc860ef8beb
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingSendCookies: true
-    settingStoreCookies: true
-    url: "{{ infra_api_url  }}/projects/another-project"
-    _type: request
-  - _id: req_7171a07c2408433296457db196a9077d
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    body: {}
-    created: 1568728770169
-    description: ""
-    headers: []
-    isPrivate: false
-    metaSortKey: -1568712933481
-    method: DELETE
-    modified: 1568823657985
-    name: Delete Project
-    parameters: []
-    parentId: fld_998699fb7271407c91200bc860ef8beb
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingSendCookies: true
-    settingStoreCookies: true
-    url: "{{ infra_api_url  }}/projects/another-project"
-    _type: request
   - _id: req_096786f5e88746f8b2d4eabe27e09694
     authentication:
       token: "{{ access_token  }}"
@@ -184,6 +35,13 @@ resources:
     name: Auth Service
     parentId: wrk_19ed8d51a0ec4d659f9962bcf31a741b
     _type: request_group
+  - _id: wrk_19ed8d51a0ec4d659f9962bcf31a741b
+    created: 1519239116865
+    description: ""
+    modified: 1519239116865
+    name: Datalabs
+    parentId: null
+    _type: workspace
   - _id: req_79f09f03b2724d34a32b791c74a38d6c
     authentication:
       token: "{{ internal_token  }}"
@@ -768,59 +626,157 @@ resources:
     settingStoreCookies: true
     url: "{{ client_api_url  }}/api"
     _type: request
-  - _id: req_3145a8c1efe04b898fd6e1a2e81e1deb
+  - _id: req_b9b95c4383644bc1a22542c2470790b1
     authentication:
       token: "{{ internal_token  }}"
       type: bearer
     body: {}
-    created: 1568395904928
+    created: 1568712933481
     description: ""
     headers: []
     isPrivate: false
-    metaSortKey: -1568395904928
+    metaSortKey: -1568712933681
     method: GET
-    modified: 1568395992271
-    name: List Active Volumes
+    modified: 1569410895273
+    name: Get Projects
     parameters: []
-    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: fld_5e6448fbd48f422ab34cfdce676516c9
     settingDisableRenderRequestBody: false
     settingEncodeUrl: true
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ infra_api_url  }}/volumes/active"
+    url: "{{ infra_api_url  }}/projects"
     _type: request
-  - _id: fld_13d24c525db74595ba879650f2fb4a60
-    created: 1568395892632
+  - _id: fld_5e6448fbd48f422ab34cfdce676516c9
+    created: 1569410878225
     description: ""
     environment: {}
     environmentPropertyOrder: null
-    metaSortKey: -1567588463167
-    modified: 1568899594162
-    name: Infrastructure
+    metaSortKey: -1569410878225
+    modified: 1569410878225
+    name: Projects
+    parentId: fld_998699fb7271407c91200bc860ef8beb
+    _type: request_group
+  - _id: fld_998699fb7271407c91200bc860ef8beb
+    created: 1568712917499
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1555504253486
+    modified: 1569410961206
+    name: Infrastructure API
     parentId: wrk_19ed8d51a0ec4d659f9962bcf31a741b
     _type: request_group
-  - _id: req_760977ccbdbd47d4a7656cd18f18b0af
+  - _id: req_59dff46463f04da5aa0b427a1b91c429
     authentication:
       token: "{{ internal_token  }}"
       type: bearer
     body: {}
-    created: 1568396572303
+    created: 1568727278931
     description: ""
     headers: []
     isPrivate: false
-    metaSortKey: -1567740477881.5
+    metaSortKey: -1568712933631
     method: GET
-    modified: 1568634302290
-    name: Volume By Id
+    modified: 1569410885983
+    name: Get Project by Key
     parameters: []
-    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: fld_5e6448fbd48f422ab34cfdce676516c9
     settingDisableRenderRequestBody: false
     settingEncodeUrl: true
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ infra_api_url  }}/volumes/5d7b83593e13cb668d09274b"
+    url: "{{ infra_api_url  }}/projects/project"
+    _type: request
+  - _id: req_21517ac2a05e45d5af9813d3d84c98d7
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body:
+      mimeType: application/json
+      text: |-
+        {
+        	"key": "another-project",
+        	"name": "Another Project",
+        	"description": "Another project that was added for testing purposes.",
+        	"collaborationLink": "https://google.com"
+        }
+    created: 1568718531356
+    description: ""
+    headers:
+      - id: pair_39e43053e7e84145ba27337b6f8de517
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1568712933606
+    method: POST
+    modified: 1569410888098
+    name: Create Project
+    parameters: []
+    parentId: fld_5e6448fbd48f422ab34cfdce676516c9
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/projects"
+    _type: request
+  - _id: req_027e9bfb84de4e3c8a27e63e6c519eac
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body:
+      mimeType: application/json
+      text: |-
+        {
+        	"key": "another-project",
+        	"name": "Another Project",
+        	"description": "An updated description for Anther Project.",
+        	"collaborationLink": "https://google.com"
+        }
+    created: 1568730196734
+    description: ""
+    headers:
+      - id: pair_ab5a02265f1848799a822c475f3d8942
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1568712933593.5
+    method: PUT
+    modified: 1569410890863
+    name: Update or Create Project
+    parameters: []
+    parentId: fld_5e6448fbd48f422ab34cfdce676516c9
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/projects/another-project"
+    _type: request
+  - _id: req_7171a07c2408433296457db196a9077d
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body: {}
+    created: 1568728770169
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1568712933587.25
+    method: DELETE
+    modified: 1569410892415
+    name: Delete Project
+    parameters: []
+    parentId: fld_5e6448fbd48f422ab34cfdce676516c9
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/projects/another-project"
     _type: request
   - _id: req_3d02cb70952b4c55a061a905edf1a5c6
     authentication:
@@ -831,18 +787,82 @@ resources:
     description: ""
     headers: []
     isPrivate: false
-    metaSortKey: -1567576621119.875
+    metaSortKey: -1568712933443.5
     method: GET
-    modified: 1568738774624
+    modified: 1569410946670
     name: Name is Unique
     parameters: []
-    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: fld_541180f583704c469aaea72ca36c35be
     settingDisableRenderRequestBody: false
     settingEncodeUrl: true
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
     url: "{{ infra_api_url  }}/stacks/asdf/isUnique"
+    _type: request
+  - _id: fld_541180f583704c469aaea72ca36c35be
+    created: 1569410940434
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1569236392035.875
+    modified: 1569410944009
+    name: Stacks
+    parentId: fld_998699fb7271407c91200bc860ef8beb
+    _type: request_group
+  - _id: req_3145a8c1efe04b898fd6e1a2e81e1deb
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body: {}
+    created: 1568395904928
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1568712933568.5
+    method: GET
+    modified: 1569410931523
+    name: List Active Volumes
+    parameters: []
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/volumes/active/project"
+    _type: request
+  - _id: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    created: 1569410909114
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1569061905846.75
+    modified: 1569410912789
+    name: Volumes
+    parentId: fld_998699fb7271407c91200bc860ef8beb
+    _type: request_group
+  - _id: req_760977ccbdbd47d4a7656cd18f18b0af
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body: {}
+    created: 1568396572303
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1568712933518.5
+    method: GET
+    modified: 1569411077574
+    name: Volume By Id
+    parameters: []
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/volumes/project/5d8a3ccd2f03f95f4d5a41c4"
     _type: request
   - _id: req_23eaa609bf05430fa401e3713ff540c4
     authentication:
@@ -863,18 +883,18 @@ resources:
         name: Content-Type
         value: application/json
     isPrivate: false
-    metaSortKey: -1567412764358.25
+    metaSortKey: -1568712933493.5
     method: PUT
-    modified: 1568632223917
+    modified: 1569410921401
     name: Add Volume User
     parameters: []
-    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
     settingDisableRenderRequestBody: false
     settingEncodeUrl: true
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ infra_api_url  }}/volumes/asdf/addUsers"
+    url: "{{ infra_api_url  }}/volumes/project/example/addUsers"
     _type: request
   - _id: req_177c66eb765f4a92b0e906f6de1a4e36
     authentication:
@@ -895,18 +915,18 @@ resources:
         name: Content-Type
         value: application/json
     isPrivate: false
-    metaSortKey: -1567248907596.625
+    metaSortKey: -1568712933418.5
     method: PUT
-    modified: 1568453254646
+    modified: 1569410923324
     name: Remove Volume User
     parameters: []
-    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
     settingDisableRenderRequestBody: false
     settingEncodeUrl: true
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ infra_api_url  }}/volumes/asdf/removeUsers"
+    url: "{{ infra_api_url  }}/volumes/project/example/removeUsers"
     _type: request
   - _id: req_7acd958c33ca45979bf71a34bc70c16a
     authentication:

--- a/code/workspaces/infrastructure-api/src/config/routes.js
+++ b/code/workspaces/infrastructure-api/src/config/routes.js
@@ -39,14 +39,14 @@ function configureRoutes(app) {
   app.get('/stack/name/:name', permissionWrapper(STACKS_CREATE), stack.withNameValidator, stack.getOneByName);
   app.delete('/stack', permissionWrapper(STACKS_DELETE), stack.deleteStackValidator, stack.deleteStack);
   app.post('/stack', permissionWrapper(STACKS_CREATE), stack.createStackValidator, stack.createStack);
-  app.post('/volume/query', permissionWrapper(STORAGE_LIST), volume.coreVolumeValidator, volume.queryVolume);
+  app.post('/volume/query', permissionWrapper(STORAGE_LIST), volume.queryVolumeValidator, volume.queryVolume);
   app.get('/volumes', permissionWrapper(STORAGE_LIST), ew(volume.listVolumes));
-  app.get('/volumes/active/:projectKey', permissionWrapper(STORAGE_LIST), volume.actionWithProjectKeyValidator(), ew(volume.listProjectActiveVolumes));
+  app.get('/volumes/active/:projectKey', permissionWrapper(STORAGE_LIST), volume.projectKeyValidator, ew(volume.listProjectActiveVolumes));
   app.get('/volumes/:projectKey/:id', permissionWrapper(STORAGE_LIST), volume.getByIdValidator, ew(volume.getById));
   app.put('/volumes/:projectKey/:name/addUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.addUsers));
   app.put('/volumes/:projectKey/:name/removeUsers', permissionWrapper(STORAGE_EDIT), volume.updateVolumeUserValidator, ew(volume.removeUsers));
   app.post('/volume', permissionWrapper(STORAGE_CREATE), volume.createVolumeValidator, ew(volume.createVolume));
-  app.delete('/volume', permissionWrapper(STORAGE_DELETE), volume.coreVolumeValidator, ew(volume.deleteVolume));
+  app.delete('/volume', permissionWrapper(STORAGE_DELETE), volume.deleteVolumeValidator, ew(volume.deleteVolume));
 }
 
 export default { configureRoutes };

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -3,6 +3,7 @@ import { check, matchedData } from 'express-validator';
 import volumeManager from '../stacks/volumeManager';
 import dataStorageRepository from '../dataaccess/dataStorageRepository';
 import logger from '../config/logger';
+import { DELETED } from '../models/dataStorage.model';
 
 async function createVolume(request, response, next) {
   // Build request params
@@ -12,6 +13,7 @@ async function createVolume(request, response, next) {
   const { user } = request;
 
   try {
+    await dataStorageRepository.create(user, params);
     await volumeManager.createVolume(user, params);
     response.status(201);
     response.send({ message: 'OK' });
@@ -26,11 +28,13 @@ async function deleteVolume(request, response, next) {
 
   // Handle request
   try {
+    // Tag datastore as deleted but record will remain in db.
+    await dataStorageRepository.update(request.user, params.projectKey, params.name, { status: DELETED });
     await volumeManager.deleteVolume(params);
     response.status(204);
     response.send({ message: 'OK' });
   } catch (error) {
-    next(new Error(`Error deleting volume: ${params.name}: ${error.message}`));
+    next(new Error(`Error deleting project: ${params.projectKey} volume: ${params.name}: ${error.message}`));
   }
 }
 
@@ -87,36 +91,38 @@ async function removeUsers(request, response, next) {
   }
 }
 
-const getByIdValidator = service.middleware.validator([
-  check('projectKey').exists().withMessage('projectKey must be specified').trim(),
-  check('id').exists().isMongoId().withMessage('id must be specified as a Mongo Id'),
+const existsCheck = fieldName => check(fieldName)
+  .exists()
+  .withMessage(`${fieldName} must be specified`)
+  .trim()
+  .isLength({ min: 1 })
+  .withMessage(`${fieldName} must have content`);
+
+const nameCheck = existsCheck('name')
+  .isAscii()
+  .withMessage('Name must only use the characters a-z')
+  .isLength({ min: 4, max: 12 })
+  .withMessage('Name must be 4-12 characters long');
+
+const projectKeyValidator = service.middleware.validator([
+  existsCheck('projectKey'),
 ], logger);
 
-const actionWithProjectKeyValidator = () => service.middleware.validator([
-  check('projectKey').exists().withMessage('projectKey must be specified'.trim()),
+const getByIdValidator = service.middleware.validator([
+  existsCheck('projectKey'),
+  existsCheck('id'),
 ], logger);
 
 const updateVolumeUserValidator = service.middleware.validator([
-  check('projectKey').exists().withMessage('projectKey must be specified').trim(),
-  check('name').exists().withMessage('volume name must be specified').trim(),
+  existsCheck('projectKey'),
+  nameCheck,
   check('userIds').exists().withMessage('userIds must be specified'),
   check('userIds.*').exists().withMessage('userIds must be specified').trim(),
 ], logger);
 
-const coreVolumeValidator = [
-  check('projectKey').exists().withMessage('projectKey must be specified').trim(),
-  check('name')
-    .exists()
-    .withMessage('Name must be specified')
-    .isAscii()
-    .withMessage('Name must only use the characters a-z')
-    .isLength({ min: 4, max: 12 })
-    .withMessage('Name must be 4-12 characters long')
-    .trim(),
-];
-
 const createVolumeValidator = service.middleware.validator([
-  ...coreVolumeValidator,
+  existsCheck('projectKey'),
+  nameCheck,
   check('displayName').exists().withMessage('displayName must be specified').trim(),
   check('description').exists().withMessage('description must be specified').trim(),
   check('type')
@@ -132,11 +138,22 @@ const createVolumeValidator = service.middleware.validator([
     .trim(),
 ], logger);
 
+const deleteVolumeValidator = service.middleware.validator([
+  existsCheck('projectKey'),
+  nameCheck,
+], logger);
+
+const queryVolumeValidator = service.middleware.validator([
+  existsCheck('projectKey'),
+  nameCheck,
+], logger);
+
 export default {
   getByIdValidator,
-  actionWithProjectKeyValidator,
-  coreVolumeValidator,
+  projectKeyValidator,
   createVolumeValidator,
+  deleteVolumeValidator,
+  queryVolumeValidator,
   updateVolumeUserValidator,
   createVolume,
   deleteVolume,

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -104,38 +104,39 @@ const nameCheck = existsCheck('name')
   .isLength({ min: 4, max: 12 })
   .withMessage('Name must be 4-12 characters long');
 
+const projectKeyCheck = existsCheck('projectKey');
+
+const idCheck = existsCheck('id')
+  .isMongoId()
+  .withMessage('id must be specified as a Mongo Id');
+
 const projectKeyValidator = service.middleware.validator([
-  existsCheck('projectKey'),
+  projectKeyCheck,
 ], logger);
 
 const getByIdValidator = service.middleware.validator([
-  existsCheck('projectKey'),
-  existsCheck('id'),
+  projectKeyCheck,
+  idCheck,
 ], logger);
 
 const updateVolumeUserValidator = service.middleware.validator([
-  existsCheck('projectKey'),
+  projectKeyCheck,
   nameCheck,
   check('userIds').exists().withMessage('userIds must be specified'),
-  check('userIds.*').exists().withMessage('userIds must be specified').trim(),
+  existsCheck('userIds.*'),
 ], logger);
 
 const createVolumeValidator = service.middleware.validator([
-  existsCheck('projectKey'),
+  projectKeyCheck,
   nameCheck,
-  check('displayName').exists().withMessage('displayName must be specified').trim(),
-  check('description').exists().withMessage('description must be specified').trim(),
-  check('type')
-    .exists()
+  existsCheck('displayName'),
+  existsCheck('description'),
+  existsCheck('type')
     .isInt({ min: 1, max: 1 })
-    .withMessage('type must be specified as a valid storage type')
-    .trim(),
-  check('volumeSize')
-    .exists()
-    .withMessage('Volume Size must be specified')
+    .withMessage('type must be specified as a valid storage type'),
+  existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
-    .withMessage('Volume Size must be an integer between 5 and 200')
-    .trim(),
+    .withMessage('Volume Size must be an integer between 5 and 200'),
 ], logger);
 
 const deleteVolumeValidator = service.middleware.validator([

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -140,12 +140,12 @@ const createVolumeValidator = service.middleware.validator([
 ], logger);
 
 const deleteVolumeValidator = service.middleware.validator([
-  existsCheck('projectKey'),
+  projectKeyCheck,
   nameCheck,
 ], logger);
 
 const queryVolumeValidator = service.middleware.validator([
-  existsCheck('projectKey'),
+  projectKeyCheck,
   nameCheck,
 ], logger);
 

--- a/code/workspaces/infrastructure-api/src/dataaccess/__snapshots__/dataStorageRepository.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/dataaccess/__snapshots__/dataStorageRepository.spec.js.snap
@@ -22,9 +22,3 @@ Object {
   "name": "Storage 1",
 }
 `;
-
-exports[`dataStorageRepository getByName returns expected snapshot 1`] = `
-Object {
-  "name": "Storage 1",
-}
-`;

--- a/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.js
@@ -22,12 +22,7 @@ function getById({ sub }, projectKey, id) {
   return DataStorage().findOne(query).exec();
 }
 
-function getByName({ sub }, name) {
-  const query = filterByUser(sub, { name });
-  return DataStorage().findOne(query).exec();
-}
-
-function createOrUpdate({ sub }, requestedDataStore) {
+function create({ sub }, requestedDataStore) {
   const query = filterByUser(sub, { name: requestedDataStore.name });
   const dataStore = {
     ...requestedDataStore,
@@ -37,16 +32,12 @@ function createOrUpdate({ sub }, requestedDataStore) {
   return DataStorage().findOneAndUpdate(query, dataStore, { upsert: true, setDefaultsOnInsert: true }).exec();
 }
 
-function deleteByName({ sub }, name) {
-  const query = filterByUser(sub, { name });
-  return DataStorage().remove(query).exec();
-}
-
-function update(name, updatedValues) {
+function update({ sub }, projectKey, name, updatedValues) {
+  const query = filterByUserAndProject(sub, projectKey, { name });
   const updateObj = {
     $set: updatedValues,
   };
-  return DataStorage().findOneAndUpdate({ name }, updateObj, { upsert: false }).exec();
+  return DataStorage().findOneAndUpdate(query, updateObj, { upsert: false }).exec();
 }
 
 function addUsers({ sub }, projectKey, name, userIds) {
@@ -85,4 +76,4 @@ const createStorageUrls = requestedDataStore => ({
   internalEndpoint: `http://minio-${requestedDataStore.name}/minio`,
 });
 
-export default { getAllProjectActive, getAllByName, getById, getByName, createOrUpdate, deleteByName, update, addUsers, removeUsers };
+export default { getAllProjectActive, getAllByName, getById, create, update, addUsers, removeUsers };

--- a/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/dataStorageRepository.spec.js
@@ -40,25 +40,17 @@ describe('dataStorageRepository', () => {
 
   it('getById returns expected snapshot', () => dataStorageRepository.getById(user, 'project99', '599aa983bdd5430daedc8eec').then((storage) => {
     expect(mockDatabase().query()).toEqual({
-      projectKey,
       _id: '599aa983bdd5430daedc8eec',
       users: { $elemMatch: { $eq: 'username' } },
+      projectKey,
     });
     expect(storage).toMatchSnapshot();
   }));
 
-  it('getByName returns expected snapshot', () => dataStorageRepository.getByName(user, 'expectedName').then((storage) => {
-    expect(mockDatabase().query()).toEqual({
-      name: 'expectedName',
-      users: { $elemMatch: { $eq: 'username' } },
-    });
-    expect(storage).toMatchSnapshot();
-  }));
-
-  it('createOrUpdate should query for data store with same name', () => {
+  it('create should query for data store with same name', () => {
     const dataStore = { name: 'newVolume', type: 'nfs' };
 
-    return dataStorageRepository.createOrUpdate(user, dataStore)
+    return dataStorageRepository.create(user, dataStore)
       .then((createdDataStore) => {
         expect(mockDatabase().query()).toEqual({
           name: createdDataStore.name,
@@ -69,22 +61,17 @@ describe('dataStorageRepository', () => {
       });
   });
 
-  it('deleteByName should query for data store with same name', () => {
-    const name = 'oldVolume';
-
-    return dataStorageRepository.deleteByName(user, name)
-      .then(() => {
-        expect(mockDatabase().query()).toEqual({ name, users: { $elemMatch: { $eq: 'username' } } });
-      });
-  });
-
   it('update should use correct operators to overwrite fields', () => {
     const name = 'deletedVolume';
     const updateObject = { status: 'deleted' };
 
-    return dataStorageRepository.update(name, updateObject)
+    return dataStorageRepository.update(user, projectKey, name, updateObject)
       .then(() => {
-        expect(mockDatabase().query()).toEqual({ name });
+        expect(mockDatabase().query()).toEqual({
+          name,
+          users: { $elemMatch: { $eq: 'username' } },
+          projectKey,
+        });
         expect(mockDatabase().entity()).toEqual({
           $set: { status: 'deleted' },
         });
@@ -99,9 +86,9 @@ describe('dataStorageRepository', () => {
     return dataStorageRepository.addUsers(user, projectKey, name, userIds)
       .then(() => {
         expect(mockDatabase().query()).toEqual({
-          projectKey,
           name,
           users: { $elemMatch: { $eq: 'username' } },
+          projectKey,
         });
         expect(mockDatabase().entity()).toEqual({
           $addToSet: { users: { $each: userIds } },
@@ -117,9 +104,9 @@ describe('dataStorageRepository', () => {
     return dataStorageRepository.removeUsers(user, projectKey, name, userIds)
       .then(() => {
         expect(mockDatabase().query()).toEqual({
-          projectKey,
           name,
           users: { $elemMatch: { $eq: 'username' } },
+          projectKey,
         });
         expect(mockDatabase().entity()).toEqual({
           $pull: { users: { $in: userIds } },

--- a/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
@@ -7,20 +7,15 @@ import deploymentApi from '../kubernetes/deploymentApi';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';
 import ingressGenerator from '../kubernetes/ingressGenerator';
 import ingressApi from '../kubernetes/ingressApi';
-import dataStorageRepository from '../dataaccess/dataStorageRepository';
 import { createPersistentVolume, createDeployment, createService, createIngressRuleWithConnect } from './stackBuilders';
-import { DELETED } from '../models/dataStorage.model';
 
 const type = 'minio';
 
 async function createVolume(user, params) {
-  await dataStorageRepository.createOrUpdate(user, params);
   await createVolumeStack(params);
 }
 
 async function deleteVolume(params) {
-  // Tag datastore as deleted but record will remain in db.
-  await dataStorageRepository.update(params.name, { status: DELETED });
   await deleteVolumeStack(params);
 }
 


### PR DESCRIPTION
This is my last PR planned for NERCDL-374, I've basically gone through the code picking up things which seemed to be missing following my previous UI-down PRs.
- I've moved the dataStorageRepository calls out of volumeManager into volumeController for create and delete, so they are where the other dataStorageRepository actions are
- I've refactored the volumeController validators
- I've added tests for volumeController deleteVolume (and moved the tests to async/await for better handling of unexpected errors), and added tests to check for the presence of projectKey where appropriate
- I've removed dataStorageRepository getByName and deleteByName, as they're unused.
- I've renamed dataStorageRepository createOrUpdate to create, because that's what it's used for
- dataStorageRepositroy update now checks the user and projectKey for permission