### PR TITLE
feat(web app): user permissions table respects current project

### DIFF
--- a/code/workspaces/auth-service/src/auth/permissionChecker.spec.js
+++ b/code/workspaces/auth-service/src/auth/permissionChecker.spec.js
@@ -32,7 +32,7 @@ describe('Permission Checker Middleware', () => {
       expect(actionMock).not.toHaveBeenCalled();
       expect(response.statusCode).toBe(401);
       expect(response._getData()) // eslint-disable-line no-underscore-dangle
-        .toEqual({ message: 'User missing expected permission(s): project:elementName:missingActionName' });
+        .toEqual({ message: 'User missing expected permission(s): project:elementName:missingActionName,system:instance:admin' });
     });
 
     it('throws error for shortened permission name', () => {
@@ -43,7 +43,7 @@ describe('Permission Checker Middleware', () => {
       expect(actionMock).not.toHaveBeenCalled();
       expect(response.statusCode).toBe(401);
       expect(response._getData()) // eslint-disable-line no-underscore-dangle
-        .toEqual({ message: 'User missing expected permission(s): project:elementName:actionNam' });
+        .toEqual({ message: 'User missing expected permission(s): project:elementName:actionNam,system:instance:admin' });
     });
   });
 
@@ -69,7 +69,7 @@ describe('Permission Checker Middleware', () => {
       expect(actionMock).not.toHaveBeenCalled();
       expect(response.statusCode).toBe(401);
       expect(response._getData()) // eslint-disable-line no-underscore-dangle
-        .toEqual({ message: 'User missing expected permission(s): anotherproject:elementName:actionName' });
+        .toEqual({ message: 'User missing expected permission(s): anotherproject:elementName:actionName,system:instance:admin' });
     });
 
     it('should return 401 if no project name included in request', () => {

--- a/code/workspaces/auth-service/src/auth/permissionCheckerMiddleware.js
+++ b/code/workspaces/auth-service/src/auth/permissionCheckerMiddleware.js
@@ -1,5 +1,8 @@
 import { get } from 'lodash';
 import logger from 'winston';
+import { permissionTypes } from 'common';
+
+const { SYSTEM_INSTANCE_ADMIN } = permissionTypes;
 
 const PROJECT = 'project';
 const permissionDelim = ':';
@@ -23,7 +26,9 @@ function checkPermissions(permissionSuffixes, projectNameFn) {
       return response.send({ message: 'Request missing parameter: projectKey' });
     }
 
-    const requiredPermissions = permissionSuffixes.map(suffix => projectKey.concat(permissionDelim, suffix));
+    const requiredPermissions = permissionSuffixes
+      .map(suffix => projectKey.concat(permissionDelim, suffix))
+      .concat(SYSTEM_INSTANCE_ADMIN);
     const grantedPermissions = get(request, 'user.permissions') || [];
 
     logger.debug('Auth: checking permissions');

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
@@ -48,7 +48,7 @@ const PERMISSIONS = SORTED_PERMISSIONS.map(item => startCase(item.name));
 
 export const getUsersFromState = ({ users }) => users;
 
-export default function AddUserPermission() {
+export default function AddUserPermission({ projectKey }) {
   const users = useSelector(getUsersFromState);
   const dispatch = useDispatch();
   const [selectedPermissions, setSelectedPermissions] = useState(PERMISSIONS[PERMISSIONS.length - 1]);
@@ -60,6 +60,7 @@ export default function AddUserPermission() {
 
   return <PureAddUserPermission
     users={users}
+    projectKey={projectKey}
     permissionLevels={PERMISSIONS}
     selectedPermissions={selectedPermissions} setSelectedPermissions={setSelectedPermissions}
     selectedUserName={selectedUserName} setSelectedUserName={setSelectedUserName}
@@ -68,7 +69,7 @@ export default function AddUserPermission() {
 }
 
 export function PureAddUserPermission({
-  users, permissionLevels, selectedPermissions, setSelectedPermissions, selectedUserName, setSelectedUserName, dispatch,
+  users, projectKey, permissionLevels, selectedPermissions, setSelectedPermissions, selectedUserName, setSelectedUserName, dispatch,
 }) {
   const classes = useStyles();
   const userNames = users.value.map(user => user.name);
@@ -84,7 +85,7 @@ export function PureAddUserPermission({
       <AddUserButton
         userInformation={users.value}
         selectedUserName={selectedUserName}
-        project="project"
+        projectKey={projectKey}
         onClickFn={dispatchAddUserAction}
         dispatch={dispatch}
         selectedPermissions={selectedPermissions}
@@ -165,23 +166,23 @@ export function PermissionsSelector({ permissionLevels, selectedPermissions, set
   );
 }
 
-export function AddUserButton({ userInformation, selectedUserName, project, selectedPermissions, onClickFn, dispatch, classes }) {
+export function AddUserButton({ userInformation, selectedUserName, projectKey, selectedPermissions, onClickFn, dispatch, classes }) {
   const selectedUser = userInformation.find(user => user.name === selectedUserName);
   return (
     <PrimaryActionButton
       className={classes.addButton}
       disabled={!selectedUser}
-      onClick={() => onClickFn(project, selectedUser, selectedPermissions, dispatch)}
+      onClick={() => onClickFn(projectKey, selectedUser, selectedPermissions, dispatch)}
     >
       Add
     </PrimaryActionButton>
   );
 }
 
-export function dispatchAddUserAction(project, user, selectedPermissions, dispatch) {
+export function dispatchAddUserAction(projectKey, user, selectedPermissions, dispatch) {
   dispatch(
     projectSettingsActions.addUserPermission(
-      'project', user, selectedPermissions.toLowerCase(),
+      projectKey, user, selectedPermissions.toLowerCase(),
     ),
   );
 }

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.spec.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.spec.js
@@ -33,6 +33,7 @@ describe('PureAddUserPermission', () => {
       shallow(
         <PureAddUserPermission
           users={initialUsers}
+          projectKey="projectKey"
           permissionLevels={permissionLevels}
           selectedPermissions={'Viewer'}
           setSelectedPermissions={jest.fn()}
@@ -222,7 +223,7 @@ describe('AddUserButton', () => {
   it('calls onClickFn with correct arguments when clicked', () => {
     const userInformation = initialUsers.value;
     const selectedUser = initialUsers.value[0];
-    const project = 'project';
+    const projectKey = 'projectKey';
     const selectedPermissions = permissionLevels[0];
     const onClickFnMock = jest.fn();
     const dispatch = jest.fn();
@@ -231,7 +232,7 @@ describe('AddUserButton', () => {
       <AddUserButton
         userInformation={userInformation}
         selectedUserName={selectedUser.name}
-        project={project}
+        projectKey={projectKey}
         selectedPermissions={selectedPermissions}
         onClickFn={onClickFnMock}
         dispatch={dispatch}
@@ -241,7 +242,7 @@ describe('AddUserButton', () => {
     render.simulate('click');
     expect(onClickFnMock).toHaveBeenCalledTimes(1);
     expect(onClickFnMock)
-      .toHaveBeenCalledWith(project, selectedUser, selectedPermissions, dispatch);
+      .toHaveBeenCalledWith(projectKey, selectedUser, selectedPermissions, dispatch);
   });
 });
 

--- a/code/workspaces/web-app/src/components/settings/RemoveUserDialog.js
+++ b/code/workspaces/web-app/src/components/settings/RemoveUserDialog.js
@@ -7,7 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import SecondaryActionButton from '../common/buttons/SecondaryActionButton';
 import DangerButton from '../common/buttons/DangerButton';
 
-export default function RemoveUserDialog({ classes, state, setState, onRemoveConfirmationFn, project, dispatch }) {
+export default function RemoveUserDialog({ classes, state, setState, onRemoveConfirmationFn, projectKey, dispatch }) {
   if (!state.open) return null;
 
   const closedState = { user: null, open: false };
@@ -25,7 +25,7 @@ export default function RemoveUserDialog({ classes, state, setState, onRemoveCon
           className={classes.dialogDeleteUserButton}
           variant="outlined"
           onClick={() => {
-            onRemoveConfirmationFn(project, state.user, dispatch);
+            onRemoveConfirmationFn(projectKey, state.user, dispatch);
             setState(closedState);
           }}
         >

--- a/code/workspaces/web-app/src/components/settings/RemoveUserDialog.spec.js
+++ b/code/workspaces/web-app/src/components/settings/RemoveUserDialog.spec.js
@@ -73,14 +73,14 @@ describe('RemoveUserDialog', () => {
       const mockSetState = jest.fn();
       const mockOnRemoveConfirmationFn = jest.fn();
       const mockDispatch = jest.fn();
-      const projectName = 'project';
+      const projectKey = 'project';
       const render = shallow(
         <RemoveUserDialog
           classes={classes}
           state={openState}
           setState={mockSetState}
           onRemoveConfirmationFn={mockOnRemoveConfirmationFn}
-          project={projectName}
+          projectKey={projectKey}
           dispatch={mockDispatch}
         />,
       );
@@ -90,7 +90,7 @@ describe('RemoveUserDialog', () => {
       expect(mockSetState).toHaveBeenCalledWith({ open: false, user: null });
       expect(mockOnRemoveConfirmationFn).toHaveBeenCalledTimes(1);
       expect(mockOnRemoveConfirmationFn)
-        .toHaveBeenCalledWith(projectName, openState.user, mockDispatch);
+        .toHaveBeenCalledWith(projectKey, openState.user, mockDispatch);
     });
   });
 });

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
@@ -56,7 +56,7 @@ const checkBoxColumnOrder = SORTED_PERMISSIONS;
 export const projectUsersSelector = ({ projectUsers }) => projectUsers;
 export const currentUserIdSelector = ({ authentication: { identity: { sub } } }) => sub;
 
-function UserPermissionsTable({ classes }) {
+function UserPermissionsTable({ classes, projectKey }) {
   const users = useSelector(projectUsersSelector, shallowEqual);
   const currentUserId = useSelector(currentUserIdSelector, shallowEqual);
   const dispatch = useDispatch();
@@ -65,9 +65,9 @@ function UserPermissionsTable({ classes }) {
 
   useEffect(
     () => {
-      dispatch(projectSettingsActions.getProjectUserPermissions('project'));
+      dispatch(projectSettingsActions.getProjectUserPermissions(projectKey));
     },
-    [dispatch],
+    [dispatch, projectKey],
   );
 
   const actions = {
@@ -79,7 +79,7 @@ function UserPermissionsTable({ classes }) {
     <PureUserPermissionsTable
       users={users}
       currentUserId={currentUserId}
-      project="project"
+      projectKey={projectKey}
       classes={classes}
       colHeadings={columnHeadings}
       removeUserDialogState={removeUserDialogState}
@@ -92,7 +92,7 @@ function UserPermissionsTable({ classes }) {
 }
 
 export function PureUserPermissionsTable(
-  { users, currentUserId, project, classes, colHeadings, removeUserDialogState,
+  { users, currentUserId, projectKey, classes, colHeadings, removeUserDialogState,
     setRemoveUserDialogState, onRemoveUserDialogConfirmationFn, actions, dispatch },
 ) {
   return (
@@ -105,7 +105,7 @@ export function PureUserPermissionsTable(
           <UserPermissionsTableBody
             users={users}
             currentUserId={currentUserId}
-            project={project}
+            projectKey={projectKey}
             classes={classes}
             numCols={colHeadings.length}
             setRemoveUserDialogState={setRemoveUserDialogState}
@@ -119,7 +119,7 @@ export function PureUserPermissionsTable(
         state={removeUserDialogState}
         setState={setRemoveUserDialogState}
         onRemoveConfirmationFn={onRemoveUserDialogConfirmationFn}
-        project={project}
+        projectKey={projectKey}
         dispatch={dispatch}
       />
     </div>
@@ -143,7 +143,7 @@ export function UserPermissionsTableHead({ headings, classes }) {
   );
 }
 
-export function UserPermissionsTableBody({ users, currentUserId, project, classes, numCols, setRemoveUserDialogState, actions, dispatch }) {
+export function UserPermissionsTableBody({ users, currentUserId, projectKey, classes, numCols, setRemoveUserDialogState, actions, dispatch }) {
   if (users.fetching.error || !users.value) {
     return <FullWidthTextRow numCols={numCols}>{'Error fetching data. Please try refreshing the page.'}</FullWidthTextRow>;
   }
@@ -161,7 +161,7 @@ export function UserPermissionsTableBody({ users, currentUserId, project, classe
       user={user}
       isCurrentUser={user.userId === currentUserId}
       index={index}
-      project={project}
+      projectKey={projectKey}
       classes={classes}
       setRemoveUserDialogState={setRemoveUserDialogState}
       actions={actions}
@@ -188,7 +188,7 @@ export function FullWidthTextRow({ children, numCols }) {
   );
 }
 
-export function UserPermissionsTableRow({ user, isCurrentUser, index, project, classes, setRemoveUserDialogState, actions, dispatch }) {
+export function UserPermissionsTableRow({ user, isCurrentUser, index, projectKey, classes, setRemoveUserDialogState, actions, dispatch }) {
   const rowKey = `row-${index}`;
   return (
     <TableRow key={rowKey}>
@@ -200,7 +200,7 @@ export function UserPermissionsTableRow({ user, isCurrentUser, index, project, c
           user={user}
           isCurrentUser={isCurrentUser}
           checkboxSpec={permission}
-          project={project}
+          projectKey={projectKey}
           classes={classes}
           cellKey={`${rowKey}-${permission.name}`}
           key={`${rowKey}-${permission.name}`}

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
@@ -177,7 +177,7 @@ describe('UserPermissionsTableBody', () => {
           <UserPermissionsTableBody
             users={users}
             currentUserId="admin-user-id"
-            project="project"
+            projectKey="projectKey"
             classes={classes}
             colHeadings={columnHeadings}
             numCols={columnHeadings.length}
@@ -247,7 +247,7 @@ describe('UserPermissionsTableRow', () => {
             user={user}
             isCurrentUser={false}
             index={2}
-            project="project"
+            projectKey="projectKey"
             classes={classes}
             setRemoveUserDialogState={jest.fn()}
             dispatch={jest.fn()}

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.js
@@ -5,7 +5,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Icon from '@material-ui/core/Icon';
 import { PERMISSION_VALUES } from '../../constants/permissions';
 
-export function CheckboxCell({ user, isCurrentUser, checkboxSpec, project, classes, cellKey, actions, dispatch }) {
+export function CheckboxCell({ user, isCurrentUser, checkboxSpec, projectKey, classes, cellKey, actions, dispatch }) {
   return (
     <TableCell
       className={classes.tableCell}
@@ -17,7 +17,7 @@ export function CheckboxCell({ user, isCurrentUser, checkboxSpec, project, class
         user={user}
         isCurrentUser={isCurrentUser}
         checkboxSpec={checkboxSpec}
-        project={project}
+        projectKey={projectKey}
         classes={classes}
         actions={actions}
         dispatch={dispatch}
@@ -26,7 +26,7 @@ export function CheckboxCell({ user, isCurrentUser, checkboxSpec, project, class
   );
 }
 
-export function PermissionsCheckbox({ user, isCurrentUser, checkboxSpec, project, classes, actions, dispatch }) {
+export function PermissionsCheckbox({ user, isCurrentUser, checkboxSpec, projectKey, classes, actions, dispatch }) {
   const props = { checked: true, color: 'default' };
   if (user.role === checkboxSpec.name) {
     props.className = classes.activeSelection;
@@ -38,7 +38,7 @@ export function PermissionsCheckbox({ user, isCurrentUser, checkboxSpec, project
 
   if (isCurrentUser) props.disabled = true;
 
-  return <Checkbox {...props} onClick={() => actions.addUserPermission(project, user, checkboxSpec.name, dispatch)}/>;
+  return <Checkbox {...props} onClick={() => actions.addUserPermission(projectKey, user, checkboxSpec.name, dispatch)}/>;
 }
 
 export function RemoveUserButtonCell({ user, isCurrentUser, classes, setRemoveUserDialogState }) {

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.spec.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTableActionCells.spec.js
@@ -27,7 +27,7 @@ describe('CheckboxCell', () => {
           user={user}
           isCurrentUser={false}
           checkboxSpec={checkboxSpec}
-          project="project"
+          projectKey="projectKey"
           classes={classes}
           cellKey="key"
           dispatch={jest.fn()}
@@ -133,7 +133,7 @@ describe('PermissionsCheckbox', () => {
     mockActions.addUserPermission.mockReturnValue('expected-result');
 
     const mockDispatch = jest.fn();
-    const project = 'project';
+    const projectKey = 'projectKey';
     const user = { name: 'User One', userId: 'user-one-id', role: PERMISSIONS.USER };
     const checkboxSpec = { name: PERMISSIONS.ADMIN, value: PERMISSION_VALUES.ADMIN };
 
@@ -143,7 +143,7 @@ describe('PermissionsCheckbox', () => {
           user={user}
           isCurrentUser={true}
           checkboxSpec={checkboxSpec}
-          project={project}
+          projectKey={projectKey}
           classes={classes}
           actions={mockActions}
           dispatch={mockDispatch}
@@ -151,7 +151,7 @@ describe('PermissionsCheckbox', () => {
       );
       render.find(Checkbox).simulate('click');
       expect(mockActions.addUserPermission).toHaveBeenCalledTimes(1);
-      expect(mockActions.addUserPermission).toHaveBeenCalledWith(project, user, checkboxSpec.name, mockDispatch);
+      expect(mockActions.addUserPermission).toHaveBeenCalledWith(projectKey, user, checkboxSpec.name, mockDispatch);
     });
   });
 });

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
@@ -89,7 +89,7 @@ exports[`PureAddUserPermission renders to match snapshot 1`] = `
     }
     dispatch={[MockFunction]}
     onClickFn={[Function]}
-    project="project"
+    projectKey="projectKey"
     selectedPermissions="Viewer"
     selectedUserName=""
     userInformation={

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
@@ -128,7 +128,7 @@ Array [
     index={0}
     isCurrentUser={true}
     key="row-admin-user-id"
-    project="project"
+    projectKey="projectKey"
     setRemoveUserDialogState={[MockFunction]}
     user={
       Object {
@@ -151,7 +151,7 @@ Array [
     index={1}
     isCurrentUser={false}
     key="row-user-user-id"
-    project="project"
+    projectKey="projectKey"
     setRemoveUserDialogState={[MockFunction]}
     user={
       Object {
@@ -174,7 +174,7 @@ Array [
     index={2}
     isCurrentUser={false}
     key="row-viewer-user-id"
-    project="project"
+    projectKey="projectKey"
     setRemoveUserDialogState={[MockFunction]}
     user={
       Object {
@@ -258,7 +258,7 @@ exports[`UserPermissionsTableRow for a given user correctly renders passing prop
     dispatch={[MockFunction]}
     isCurrentUser={false}
     key="row-2-admin"
-    project="project"
+    projectKey="projectKey"
     user={
       Object {
         "name": "admin name",
@@ -284,7 +284,7 @@ exports[`UserPermissionsTableRow for a given user correctly renders passing prop
     dispatch={[MockFunction]}
     isCurrentUser={false}
     key="row-2-user"
-    project="project"
+    projectKey="projectKey"
     user={
       Object {
         "name": "admin name",
@@ -310,7 +310,7 @@ exports[`UserPermissionsTableRow for a given user correctly renders passing prop
     dispatch={[MockFunction]}
     isCurrentUser={false}
     key="row-2-viewer"
-    project="project"
+    projectKey="projectKey"
     user={
       Object {
         "name": "admin name",

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTableActionCells.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTableActionCells.spec.js.snap
@@ -21,7 +21,7 @@ exports[`CheckboxCell renders correctly passing props to PermissionsCheckbox in 
     }
     dispatch={[MockFunction]}
     isCurrentUser={false}
-    project="project"
+    projectKey="projectKey"
     user={
       Object {
         "role": "admin",

--- a/code/workspaces/web-app/src/pages/SettingsPage.js
+++ b/code/workspaces/web-app/src/pages/SettingsPage.js
@@ -5,11 +5,11 @@ import Page from './Page';
 import UserPermissionsTable from '../components/settings/UserPermissionsTable';
 import AddUserPermissions from '../components/settings/AddUserPermissions';
 
-const SettingsPage = ({ userPermissions }) => (
+const SettingsPage = ({ userPermissions, match: { params: { projectKey } } }) => (
   <Page title="Settings">
     <Typography variant="h5">User Permissions</Typography>
-    <AddUserPermissions />
-    <UserPermissionsTable />
+    <AddUserPermissions projectKey={projectKey} />
+    <UserPermissionsTable projectKey={projectKey} />
   </Page>
 );
 

--- a/code/workspaces/web-app/src/pages/SettingsPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SettingsPage.spec.js
@@ -13,7 +13,7 @@ describe('SettingsPage', () => {
 
   it('renders to match snapshot', () => {
     expect(
-      shallow(<SettingsPage userPermissions={userPermissions}/>),
+      shallow(<SettingsPage userPermissions={userPermissions} match={{ params: { projectKey: 'projectKey' } }} />),
     ).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/pages/__snapshots__/SettingsPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SettingsPage.spec.js.snap
@@ -15,7 +15,11 @@ exports[`SettingsPage renders to match snapshot 1`] = `
   >
     User Permissions
   </WithStyles(ForwardRef(Typography))>
-  <AddUserPermission />
-  <WithStyles(UserPermissionsTable) />
+  <AddUserPermission
+    projectKey="projectKey"
+  />
+  <WithStyles(UserPermissionsTable)
+    projectKey="projectKey"
+  />
 </Page>
 `;


### PR DESCRIPTION
* Updated user permission components to respect the currently active project.

* Renamed `project` prop to `projectKey` through user permission components to align with naming convention used elsewhere.

* Updated the permissions checker middleware in the auth service to allow permission for anyone who is an instance admin.