### PR TITLE
Nercdl 366 project namespace

### DIFF
--- a/code/development-env/config/manifests/minikube-project-namespaces.yml
+++ b/code/development-env/config/manifests/minikube-project-namespaces.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: project
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: project-compute

--- a/code/workspaces/infrastructure-api/src/config/config.js
+++ b/code/workspaces/infrastructure-api/src/config/config.js
@@ -37,12 +37,6 @@ const config = convict({
     default: 'http://localhost:8001',
     env: 'KUBERNETES_API',
   },
-  podNamespace: {
-    doc: 'The namespace for the pod',
-    format: 'String',
-    default: 'devtest',
-    env: 'KUBERNETES_NAMESPACE',
-  },
   storageClass: {
     doc: 'The storage class to use for new volumes',
     format: 'String',

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
@@ -26,7 +26,7 @@ const createOrReplace = (name, namespace, manifest) => (existingDeployment) => {
 };
 
 function getDeployment(name, namespace) {
-  return axios.get(`${getDeploymentUrl(namespace, name)}`)
+  return axios.get(getDeploymentUrl(namespace, name))
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -34,13 +34,13 @@ function getDeployment(name, namespace) {
 function createDeployment(name, namespace, manifest) {
   logger.info('Creating deployment: %s in namespace: %s', name, namespace);
   return axios.post(getDeploymentUrl(namespace), manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+    .catch(handleCreateError('deployment', name));
 }
 
 function updateDeployment(name, namespace, manifest) {
   logger.info('Updating deployment: %s in namespace: %s', name, namespace);
-  return axios.put(`${getDeploymentUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+  return axios.put(getDeploymentUrl(namespace, name), manifest, YAML_CONTENT_HEADER)
+    .catch(handleCreateError('deployment', name));
 }
 
 function deleteDeployment(name, namespace) {
@@ -51,7 +51,7 @@ function deleteDeployment(name, namespace) {
     propagationPolicy: 'Foreground',
   };
 
-  return axios.delete(`${getDeploymentUrl(namespace, name)}`, { data: deleteOptions })
+  return axios.delete(getDeploymentUrl(namespace, name), { data: deleteOptions })
     .then(response => response.data)
     .catch(handleDeleteError('deployment', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
@@ -29,19 +29,19 @@ function getDeployment(name, namespace) {
 }
 
 function createDeployment(name, namespace, manifest) {
-  logger.info('Creating deployment: %s', name);
+  logger.info('Creating deployment: %s in namespace: %s', name, namespace);
   return axios.post(getDeploymentUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function updateDeployment(name, namespace, manifest) {
-  logger.info('Updating deployment: %s', name);
+  logger.info('Updating deployment: %s in namespace: %s', name, namespace);
   return axios.put(`${getDeploymentUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function deleteDeployment(name, namespace) {
-  logger.info('Deleting deployment: %s', name);
+  logger.info('Deleting deployment: %s in namespace: %s', name, namespace);
   const deleteOptions = {
     kind: 'DeleteOptions',
     apiVersion: 'v1',

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
@@ -5,7 +5,10 @@ import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
 
-const getDeploymentUrl = namespace => `${API_BASE}/apis/apps/v1beta1/namespaces/${namespace}/deployments`;
+const getDeploymentUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/apis/apps/v1beta1/namespaces/${namespace}/deployments${nameComponent}`;
+};
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
@@ -23,7 +26,7 @@ const createOrReplace = (name, namespace, manifest) => (existingDeployment) => {
 };
 
 function getDeployment(name, namespace) {
-  return axios.get(`${getDeploymentUrl(namespace)}/${name}`)
+  return axios.get(`${getDeploymentUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -36,7 +39,7 @@ function createDeployment(name, namespace, manifest) {
 
 function updateDeployment(name, namespace, manifest) {
   logger.info('Updating deployment: %s in namespace: %s', name, namespace);
-  return axios.put(`${getDeploymentUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
+  return axios.put(`${getDeploymentUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
@@ -48,7 +51,7 @@ function deleteDeployment(name, namespace) {
     propagationPolicy: 'Foreground',
   };
 
-  return axios.delete(`${getDeploymentUrl(namespace)}/${name}`, { data: deleteOptions })
+  return axios.delete(`${getDeploymentUrl(namespace, name)}`, { data: deleteOptions })
     .then(response => response.data)
     .catch(handleDeleteError('deployment', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
@@ -62,8 +62,9 @@ describe('Kubernetes Deployment API', () => {
 
       try {
         await deploymentApi.createDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes deployment \'test-deployment\' - error-message');
       }
     });
   });
@@ -86,8 +87,9 @@ describe('Kubernetes Deployment API', () => {
 
       try {
         await deploymentApi.updateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes deployment \'test-deployment\' - error-message');
       }
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
@@ -7,10 +7,11 @@ import deploymentApi from './deploymentApi';
 const mock = new MockAdapter(axios);
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
+const NAMESPACE = 'namespace';
 
 const DEPLOYMENT_URL = `${API_BASE}/apis/apps/v1beta1/namespaces/${NAMESPACE}/deployments`;
 const DEPLOYMENT_NAME = 'test-deployment';
+
 beforeEach(() => {
   mock.reset();
 });
@@ -27,7 +28,7 @@ describe('Kubernetes Deployment API', () => {
     it('should return the deployment if it exists', () => {
       mock.onGet(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(200, deployment);
 
-      return deploymentApi.getDeployment(DEPLOYMENT_NAME)
+      return deploymentApi.getDeployment(DEPLOYMENT_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toEqual(deployment);
         });
@@ -36,7 +37,7 @@ describe('Kubernetes Deployment API', () => {
     it('should return undefined it the deployment does not exist', () => {
       mock.onGet(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(404, deployment);
 
-      return deploymentApi.getDeployment(DEPLOYMENT_NAME)
+      return deploymentApi.getDeployment(DEPLOYMENT_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toBeUndefined();
         });
@@ -50,7 +51,7 @@ describe('Kubernetes Deployment API', () => {
         return [200, deployment];
       });
 
-      return deploymentApi.createDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.createDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(deployment);
         });
@@ -59,7 +60,7 @@ describe('Kubernetes Deployment API', () => {
     it('should return an error if creation fails', () => {
       mock.onPost(DEPLOYMENT_URL).reply(400, { message: 'error-message' });
 
-      return deploymentApi.createDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.createDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
         });
@@ -73,7 +74,7 @@ describe('Kubernetes Deployment API', () => {
         return [200, deployment];
       });
 
-      return deploymentApi.updateDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.updateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(deployment);
         });
@@ -82,7 +83,7 @@ describe('Kubernetes Deployment API', () => {
     it('should return an error if creation fails', () => {
       mock.onPut(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(400, { message: 'error-message' });
 
-      return deploymentApi.updateDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.updateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
         });
@@ -94,7 +95,7 @@ describe('Kubernetes Deployment API', () => {
       mock.onGet(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(404);
       mock.onPost().reply(204, deployment);
 
-      return deploymentApi.createOrUpdateDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.createOrUpdateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(deployment);
         });
@@ -104,7 +105,7 @@ describe('Kubernetes Deployment API', () => {
       mock.onGet(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(200, deployment);
       mock.onPut().reply(204, deployment);
 
-      return deploymentApi.createOrUpdateDeployment(DEPLOYMENT_NAME, manifest)
+      return deploymentApi.createOrUpdateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(deployment);
         });
@@ -115,19 +116,19 @@ describe('Kubernetes Deployment API', () => {
     it('should DELETE resource URL', () => {
       mock.onDelete(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(204);
 
-      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME)).resolves.toBeUndefined();
+      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return successfully if deployment does not exist', () => {
       mock.onDelete(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(404);
 
-      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME)).resolves.toBeUndefined();
+      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return error if server errors', () => {
       mock.onDelete(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(500, { message: 'error-message' });
 
-      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME))
+      return expect(deploymentApi.deleteDeployment(DEPLOYMENT_NAME, NAMESPACE))
         .rejects.toEqual(new Error('Kubernetes API: Request failed with status code 500'));
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
@@ -57,13 +57,14 @@ describe('Kubernetes Deployment API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPost(DEPLOYMENT_URL).reply(400, { message: 'error-message' });
 
-      return deploymentApi.createDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
-        });
+      try {
+        await deploymentApi.createDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
+      }
     });
   });
 
@@ -80,13 +81,14 @@ describe('Kubernetes Deployment API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPut(`${DEPLOYMENT_URL}/${DEPLOYMENT_NAME}`).reply(400, { message: 'error-message' });
 
-      return deploymentApi.updateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
-        });
+      try {
+        await deploymentApi.updateDeployment(DEPLOYMENT_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes deployment error-message');
+      }
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
@@ -5,7 +5,10 @@ import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
 
-const getIngressUrl = namespace => `${API_BASE}/apis/extensions/v1beta1/namespaces/${namespace}/ingresses`;
+const getIngressUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/apis/extensions/v1beta1/namespaces/${namespace}/ingresses${nameComponent}`;
+};
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
@@ -23,7 +26,7 @@ const createOrReplace = (name, namespace, manifest) => (existingIngress) => {
 };
 
 function getIngress(name, namespace) {
-  return axios.get(`${getIngressUrl(namespace)}/${name}`)
+  return axios.get(`${getIngressUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -36,13 +39,13 @@ function createIngress(name, namespace, manifest) {
 
 function updateIngress(name, namespace, manifest) {
   logger.info('Updating ingress: %s in namespace %s', name, namespace);
-  return axios.put(`${getIngressUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
+  return axios.put(`${getIngressUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function deleteIngress(name, namespace) {
   logger.info('Deleting ingress: %s in namespace %s', name, namespace);
-  return axios.delete(`${getIngressUrl(namespace)}/${name}`)
+  return axios.delete(`${getIngressUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(handleDeleteError('ingress', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
@@ -4,46 +4,45 @@ import config from '../config/config';
 import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
 
-const INGRESS_URL = `${API_BASE}/apis/extensions/v1beta1/namespaces/${NAMESPACE}/ingresses`;
+const getIngressUrl = namespace => `${API_BASE}/apis/extensions/v1beta1/namespaces/${namespace}/ingresses`;
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
-function createOrUpdateIngress(name, manifest) {
-  return getIngress(name, manifest)
-    .then(createOrReplace(name, manifest));
+function createOrUpdateIngress(name, namespace, manifest) {
+  return getIngress(name, namespace)
+    .then(createOrReplace(name, namespace, manifest));
 }
 
-const createOrReplace = (name, manifest) => (existingIngress) => {
+const createOrReplace = (name, namespace, manifest) => (existingIngress) => {
   if (existingIngress) {
-    return updateIngress(name, manifest);
+    return updateIngress(name, namespace, manifest);
   }
 
-  return createIngress(name, manifest);
+  return createIngress(name, namespace, manifest);
 };
 
-function getIngress(name) {
-  return axios.get(`${INGRESS_URL}/${name}`)
+function getIngress(name, namespace) {
+  return axios.get(`${getIngressUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
 
-function createIngress(name, manifest) {
+function createIngress(name, namespace, manifest) {
   logger.info('Creating ingress: %s', name);
-  return axios.post(INGRESS_URL, manifest, YAML_CONTENT_HEADER)
+  return axios.post(getIngressUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
-function updateIngress(name, manifest) {
+function updateIngress(name, namespace, manifest) {
   logger.info('Updating ingress: %s', name);
-  return axios.put(`${INGRESS_URL}/${name}`, manifest, YAML_CONTENT_HEADER)
+  return axios.put(`${getIngressUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
-function deleteIngress(name) {
+function deleteIngress(name, namespace) {
   logger.info('Deleting ingress: %s', name);
-  return axios.delete(`${INGRESS_URL}/${name}`)
+  return axios.delete(`${getIngressUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('ingress', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
@@ -26,7 +26,7 @@ const createOrReplace = (name, namespace, manifest) => (existingIngress) => {
 };
 
 function getIngress(name, namespace) {
-  return axios.get(`${getIngressUrl(namespace, name)}`)
+  return axios.get(getIngressUrl(namespace, name))
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -34,18 +34,18 @@ function getIngress(name, namespace) {
 function createIngress(name, namespace, manifest) {
   logger.info('Creating ingress: %s in namespace %s', name, namespace);
   return axios.post(getIngressUrl(namespace), manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+    .catch(handleCreateError('ingress', name));
 }
 
 function updateIngress(name, namespace, manifest) {
   logger.info('Updating ingress: %s in namespace %s', name, namespace);
-  return axios.put(`${getIngressUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+  return axios.put(getIngressUrl(namespace, name), manifest, YAML_CONTENT_HEADER)
+    .catch(handleCreateError('ingress', name));
 }
 
 function deleteIngress(name, namespace) {
   logger.info('Deleting ingress: %s in namespace %s', name, namespace);
-  return axios.delete(`${getIngressUrl(namespace, name)}`)
+  return axios.delete(getIngressUrl(namespace, name))
     .then(response => response.data)
     .catch(handleDeleteError('ingress', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.js
@@ -29,19 +29,19 @@ function getIngress(name, namespace) {
 }
 
 function createIngress(name, namespace, manifest) {
-  logger.info('Creating ingress: %s', name);
+  logger.info('Creating ingress: %s in namespace %s', name, namespace);
   return axios.post(getIngressUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function updateIngress(name, namespace, manifest) {
-  logger.info('Updating ingress: %s', name);
+  logger.info('Updating ingress: %s in namespace %s', name, namespace);
   return axios.put(`${getIngressUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function deleteIngress(name, namespace) {
-  logger.info('Deleting ingress: %s', name);
+  logger.info('Deleting ingress: %s in namespace %s', name, namespace);
   return axios.delete(`${getIngressUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('ingress', name));

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
@@ -61,8 +61,9 @@ describe('Kubernetes Ingress API', () => {
 
       try {
         await ingressApi.createIngress(INGRESS_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes ingress \'test-ingress\' - error-message');
       }
     });
   });
@@ -85,8 +86,9 @@ describe('Kubernetes Ingress API', () => {
 
       try {
         await ingressApi.updateIngress(INGRESS_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes ingress \'test-ingress\' - error-message');
       }
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
@@ -7,7 +7,7 @@ import ingressApi from './ingressApi';
 const mock = new MockAdapter(axios);
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
+const NAMESPACE = 'namespace';
 
 const INGRESS_URL = `${API_BASE}/apis/extensions/v1beta1/namespaces/${NAMESPACE}/ingresses`;
 const INGRESS_NAME = 'test-ingress';
@@ -27,7 +27,7 @@ describe('Kubernetes Ingress API', () => {
     it('should return the ingress if it exists', () => {
       mock.onGet(`${INGRESS_URL}/${INGRESS_NAME}`).reply(200, ingress);
 
-      return ingressApi.getIngress(INGRESS_NAME)
+      return ingressApi.getIngress(INGRESS_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toEqual(ingress);
         });
@@ -36,7 +36,7 @@ describe('Kubernetes Ingress API', () => {
     it('should return undefined it the ingress does not exist', () => {
       mock.onGet(`${INGRESS_URL}/${INGRESS_NAME}`).reply(404, ingress);
 
-      return ingressApi.getIngress(INGRESS_NAME)
+      return ingressApi.getIngress(INGRESS_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toBeUndefined();
         });
@@ -50,7 +50,7 @@ describe('Kubernetes Ingress API', () => {
         return [200, ingress];
       });
 
-      return ingressApi.createIngress(INGRESS_NAME, manifest)
+      return ingressApi.createIngress(INGRESS_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(ingress);
         });
@@ -59,7 +59,7 @@ describe('Kubernetes Ingress API', () => {
     it('should return an error if creation fails', () => {
       mock.onPost(INGRESS_URL).reply(400, { message: 'error-message' });
 
-      return ingressApi.createIngress(INGRESS_NAME, manifest)
+      return ingressApi.createIngress(INGRESS_NAME, NAMESPACE, manifest)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
         });
@@ -73,7 +73,7 @@ describe('Kubernetes Ingress API', () => {
         return [200, ingress];
       });
 
-      return ingressApi.updateIngress(INGRESS_NAME, manifest)
+      return ingressApi.updateIngress(INGRESS_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(ingress);
         });
@@ -82,7 +82,7 @@ describe('Kubernetes Ingress API', () => {
     it('should return an error if creation fails', () => {
       mock.onPut(`${INGRESS_URL}/${INGRESS_NAME}`).reply(400, { message: 'error-message' });
 
-      return ingressApi.updateIngress(INGRESS_NAME, manifest)
+      return ingressApi.updateIngress(INGRESS_NAME, NAMESPACE, manifest)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
         });
@@ -94,7 +94,7 @@ describe('Kubernetes Ingress API', () => {
       mock.onGet(`${INGRESS_URL}/${INGRESS_NAME}`).reply(404);
       mock.onPost().reply(204, ingress);
 
-      return ingressApi.createOrUpdateIngress(INGRESS_NAME, manifest)
+      return ingressApi.createOrUpdateIngress(INGRESS_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(ingress);
         });
@@ -104,7 +104,7 @@ describe('Kubernetes Ingress API', () => {
       mock.onGet(`${INGRESS_URL}/${INGRESS_NAME}`).reply(200, ingress);
       mock.onPut().reply(204, ingress);
 
-      return ingressApi.createOrUpdateIngress(INGRESS_NAME, manifest)
+      return ingressApi.createOrUpdateIngress(INGRESS_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(ingress);
         });
@@ -115,19 +115,19 @@ describe('Kubernetes Ingress API', () => {
     it('should DELETE resource URL', () => {
       mock.onDelete(`${INGRESS_URL}/${INGRESS_NAME}`).reply(204);
 
-      return expect(ingressApi.deleteIngress(INGRESS_NAME)).resolves.toBeUndefined();
+      return expect(ingressApi.deleteIngress(INGRESS_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return successfully if ingress does not exist', () => {
       mock.onDelete(`${INGRESS_URL}/${INGRESS_NAME}`).reply(404);
 
-      return expect(ingressApi.deleteIngress(INGRESS_NAME)).resolves.toBeUndefined();
+      return expect(ingressApi.deleteIngress(INGRESS_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return error if server errors', () => {
       mock.onDelete(`${INGRESS_URL}/${INGRESS_NAME}`).reply(500, { message: 'error-message' });
 
-      return expect(ingressApi.deleteIngress(INGRESS_NAME))
+      return expect(ingressApi.deleteIngress(INGRESS_NAME, NAMESPACE))
         .rejects.toEqual(new Error('Kubernetes API: Request failed with status code 500'));
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressApi.spec.js
@@ -56,13 +56,14 @@ describe('Kubernetes Ingress API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPost(INGRESS_URL).reply(400, { message: 'error-message' });
 
-      return ingressApi.createIngress(INGRESS_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
-        });
+      try {
+        await ingressApi.createIngress(INGRESS_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
+      }
     });
   });
 
@@ -79,13 +80,14 @@ describe('Kubernetes Ingress API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPut(`${INGRESS_URL}/${INGRESS_NAME}`).reply(400, { message: 'error-message' });
 
-      return ingressApi.updateIngress(INGRESS_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
-        });
+      try {
+        await ingressApi.updateIngress(INGRESS_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes ingress error-message');
+      }
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/kubeConfig.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/kubeConfig.js
@@ -2,7 +2,6 @@ import * as k8s from '@kubernetes/client-node';
 import config from '../config/config';
 
 const kubeApi = config.get('kubernetesApi');
-const kubeNamespace = config.get('podNamespace');
 
 // Using loadFromOptions method rather than loadFromDefault as loadFromDefault does not
 // work inside a docker container in the development environment.
@@ -27,7 +26,6 @@ const context = {
   name: 'default-context',
   user: user.name,
   cluster: cluster.name,
-  namespace: kubeNamespace,
 };
 
 const kubeConfig = new k8s.KubeConfig();

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
@@ -24,7 +24,7 @@ const createOrReplace = (name, namespace, value) => (existingSecret) => {
 };
 
 function getSecret(name, namespace) {
-  return axios.get(`${getSecretUrl(namespace, name)}`)
+  return axios.get(getSecretUrl(namespace, name))
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -37,7 +37,7 @@ function createSecret(name, namespace, value) {
 
 function updateSecret(name, namespace, value) {
   logger.info('Updating secret: %s in namespace %s', name, namespace);
-  return axios.put(`${getSecretUrl(namespace, name)}`, createPayload(name, value))
+  return axios.put(getSecretUrl(namespace, name), createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }
 
@@ -52,7 +52,7 @@ function createPayload(name, value) {
 
 function deleteSecret(name, namespace) {
   logger.info('Deleting secret: %s', name);
-  return axios.delete(`${getSecretUrl(namespace, name)}`)
+  return axios.delete(getSecretUrl(namespace, name))
     .then(response => response.data)
     .catch(handleDeleteError('secret', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
@@ -5,7 +5,10 @@ import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
 
-const getSecretUrl = namespace => `${API_BASE}/api/v1/namespaces/${namespace}/secrets`;
+const getSecretUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/api/v1/namespaces/${namespace}/secrets${nameComponent}`;
+};
 
 function createOrUpdateSecret(name, namespace, value) {
   return getSecret(name, namespace)
@@ -21,7 +24,7 @@ const createOrReplace = (name, namespace, value) => (existingSecret) => {
 };
 
 function getSecret(name, namespace) {
-  return axios.get(`${getSecretUrl(namespace)}/${name}`)
+  return axios.get(`${getSecretUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -34,7 +37,7 @@ function createSecret(name, namespace, value) {
 
 function updateSecret(name, namespace, value) {
   logger.info('Updating secret: %s in namespace %s', name, namespace);
-  return axios.put(`${getSecretUrl(namespace)}/${name}`, createPayload(name, value))
+  return axios.put(`${getSecretUrl(namespace, name)}`, createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }
 
@@ -49,7 +52,7 @@ function createPayload(name, value) {
 
 function deleteSecret(name, namespace) {
   logger.info('Deleting secret: %s', name);
-  return axios.delete(`${getSecretUrl(namespace)}/${name}`)
+  return axios.delete(`${getSecretUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(handleDeleteError('secret', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
@@ -4,38 +4,37 @@ import config from '../config/config';
 import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
 
-const SECRET_URL = `${API_BASE}/api/v1/namespaces/${NAMESPACE}/secrets`;
+const getSecretUrl = namespace => `${API_BASE}/api/v1/namespaces/${namespace}/secrets`;
 
-function createOrUpdateSecret(name, value) {
-  return getSecret(name)
-    .then(createOrReplace(name, value));
+function createOrUpdateSecret(name, namespace, value) {
+  return getSecret(name, namespace)
+    .then(createOrReplace(name, namespace, value));
 }
 
-const createOrReplace = (name, value) => (existingSecret) => {
+const createOrReplace = (name, namespace, value) => (existingSecret) => {
   if (existingSecret) {
-    return updateSecret(name, value);
+    return updateSecret(name, namespace, value);
   }
 
-  return createSecret(name, value);
+  return createSecret(name, namespace, value);
 };
 
-function getSecret(name) {
-  return axios.get(`${SECRET_URL}/${name}`)
+function getSecret(name, namespace) {
+  return axios.get(`${getSecretUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
 
-function createSecret(name, value) {
+function createSecret(name, namespace, value) {
   logger.info('Creating secret: %s', name);
-  return axios.post(SECRET_URL, createPayload(name, value))
+  return axios.post(getSecretUrl(namespace), createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }
 
-function updateSecret(name, value) {
+function updateSecret(name, namespace, value) {
   logger.info('Updating secret: %s', name);
-  return axios.put(`${SECRET_URL}/${name}`, createPayload(name, value))
+  return axios.put(`${getSecretUrl(namespace)}/${name}`, createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }
 
@@ -48,9 +47,9 @@ function createPayload(name, value) {
   };
 }
 
-function deleteSecret(name) {
+function deleteSecret(name, namespace) {
   logger.info('Deleting secret: %s', name);
-  return axios.delete(`${SECRET_URL}/${name}`)
+  return axios.delete(`${getSecretUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('secret', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.js
@@ -27,13 +27,13 @@ function getSecret(name, namespace) {
 }
 
 function createSecret(name, namespace, value) {
-  logger.info('Creating secret: %s', name);
+  logger.info('Creating secret: %s in namespace %s', name, namespace);
   return axios.post(getSecretUrl(namespace), createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }
 
 function updateSecret(name, namespace, value) {
-  logger.info('Updating secret: %s', name);
+  logger.info('Updating secret: %s in namespace %s', name, namespace);
   return axios.put(`${getSecretUrl(namespace)}/${name}`, createPayload(name, value))
     .catch(handleCreateError('secret', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
@@ -82,6 +82,7 @@ describe('Kubernetes Secret API', () => {
       mock.onPost(SECRET_URL).reply(400, { message: 'error-message' });
 
       return secretApi.createSecret('test', NAMESPACE, 'testvalue')
+        .then(() => expect(true).toBe(false))
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
         });
@@ -99,13 +100,14 @@ describe('Kubernetes Secret API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPut(`${SECRET_URL}/${SECRET_NAME}`).reply(400, { message: 'error-message' });
 
-      return secretApi.updateSecret('test', NAMESPACE, 'testvalue')
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
-        });
+      try {
+        await secretApi.updateSecret('test', NAMESPACE, 'testvalue');
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
+      }
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
@@ -7,7 +7,7 @@ import secretApi from './secretApi';
 const mock = new MockAdapter(axios);
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
+const NAMESPACE = 'namespace';
 
 const SECRET_URL = `${API_BASE}/api/v1/namespaces/${NAMESPACE}/secrets`;
 const SECRET_NAME = 'test';
@@ -27,7 +27,7 @@ describe('Kubernetes Secret API', () => {
       mock.onGet(`${SECRET_URL}/${SECRET_NAME}`).reply(404);
       mock.onPost().reply(204, secret);
 
-      return secretApi.createOrUpdateSecret('test', 'testvalue')
+      return secretApi.createOrUpdateSecret('test', NAMESPACE, 'testvalue')
         .then((response) => {
           expect(response.data).toEqual(secret);
         });
@@ -38,7 +38,7 @@ describe('Kubernetes Secret API', () => {
       mock.onGet(`${SECRET_URL}/${SECRET_NAME}`).reply(200, secret);
       mock.onPut().reply(204, secret);
 
-      return secretApi.createOrUpdateSecret('test', 'testvalue')
+      return secretApi.createOrUpdateSecret('test', NAMESPACE, 'testvalue')
         .then((response) => {
           expect(response.data).toEqual(secret);
         });
@@ -50,7 +50,7 @@ describe('Kubernetes Secret API', () => {
       const secret = createSecret();
       mock.onGet(`${SECRET_URL}/${SECRET_NAME}`).reply(200, secret);
 
-      return secretApi.getSecret('test')
+      return secretApi.getSecret('test', NAMESPACE)
         .then((response) => {
           expect(response).toEqual(secret);
         });
@@ -60,7 +60,7 @@ describe('Kubernetes Secret API', () => {
       const secret = createSecret();
       mock.onGet(`${SECRET_URL}/${SECRET_NAME}`).reply(404, secret);
 
-      return secretApi.getSecret('test')
+      return secretApi.getSecret('test', NAMESPACE)
         .then((response) => {
           expect(response).toBeUndefined();
         });
@@ -72,7 +72,7 @@ describe('Kubernetes Secret API', () => {
       const secret = createSecret();
       mock.onPost(SECRET_URL, secret).reply(204, secret);
 
-      return secretApi.createSecret('test', 'testvalue')
+      return secretApi.createSecret('test', NAMESPACE, 'testvalue')
         .then((response) => {
           expect(response.data).toEqual(secret);
         });
@@ -81,7 +81,7 @@ describe('Kubernetes Secret API', () => {
     it('should return an error if creation fails', () => {
       mock.onPost(SECRET_URL).reply(400, { message: 'error-message' });
 
-      return secretApi.createSecret('test', 'testvalue')
+      return secretApi.createSecret('test', NAMESPACE, 'testvalue')
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
         });
@@ -93,7 +93,7 @@ describe('Kubernetes Secret API', () => {
       const secret = createSecret();
       mock.onPut(`${SECRET_URL}/${SECRET_NAME}`, secret).reply(204, secret);
 
-      return secretApi.updateSecret('test', 'testvalue')
+      return secretApi.updateSecret('test', NAMESPACE, 'testvalue')
         .then((response) => {
           expect(response.data).toEqual(secret);
         });
@@ -102,7 +102,7 @@ describe('Kubernetes Secret API', () => {
     it('should return an error if creation fails', () => {
       mock.onPut(`${SECRET_URL}/${SECRET_NAME}`).reply(400, { message: 'error-message' });
 
-      return secretApi.updateSecret('test', 'testvalue')
+      return secretApi.updateSecret('test', NAMESPACE, 'testvalue')
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
         });
@@ -113,19 +113,19 @@ describe('Kubernetes Secret API', () => {
     it('should DELETE resource URL', () => {
       mock.onDelete(`${SECRET_URL}/${SECRET_NAME}`).reply(204);
 
-      return expect(secretApi.deleteSecret(SECRET_NAME)).resolves.toBeUndefined();
+      return expect(secretApi.deleteSecret(SECRET_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return successfully if secret does not exist', () => {
       mock.onDelete(`${SECRET_URL}/${SECRET_NAME}`).reply(404);
 
-      return expect(secretApi.deleteSecret(SECRET_NAME)).resolves.toBeUndefined();
+      return expect(secretApi.deleteSecret(SECRET_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return error if server errors', () => {
       mock.onDelete(`${SECRET_URL}/${SECRET_NAME}`).reply(500, { message: 'error-message' });
 
-      return expect(secretApi.deleteSecret(SECRET_NAME))
+      return expect(secretApi.deleteSecret(SECRET_NAME, NAMESPACE))
         .rejects.toEqual(new Error('Kubernetes API: Request failed with status code 500'));
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/secretApi.spec.js
@@ -78,14 +78,15 @@ describe('Kubernetes Secret API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPost(SECRET_URL).reply(400, { message: 'error-message' });
 
-      return secretApi.createSecret('test', NAMESPACE, 'testvalue')
-        .then(() => expect(true).toBe(false))
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
-        });
+      try {
+        await secretApi.createSecret('test', NAMESPACE, 'testvalue');
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
+      }
     });
   });
 
@@ -105,6 +106,7 @@ describe('Kubernetes Secret API', () => {
 
       try {
         await secretApi.updateSecret('test', NAMESPACE, 'testvalue');
+        expect(true).toBe(false);
       } catch (error) {
         expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes secret \'test\' - error-message');
       }

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
@@ -28,7 +28,7 @@ const createOrReplace = (name, namespace, manifest) => (existingService) => {
 };
 
 function getService(name, namespace) {
-  return axios.get(`${getServiceUrl(namespace)}/${name}`)
+  return axios.get(getServiceUrl(namespace, name))
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -48,7 +48,7 @@ function replaceService(name, namespace, manifest) {
 function updateService(name, namespace, manifest, existingService) {
   logger.info('Updating service: %s in namespace %s', name, namespace);
   const jsonManifest = copyRequiredFieldsToJsonManfiest(manifest, existingService);
-  return axios.put(`${getServiceUrl(namespace, name)}`, jsonManifest)
+  return axios.put(getServiceUrl(namespace, name), jsonManifest)
     .catch(handleCreateError('service', name));
 }
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
@@ -31,26 +31,26 @@ function getService(name, namespace) {
 }
 
 function createService(name, namespace, manifest) {
-  logger.info('Creating service: %s', name);
+  logger.info('Creating service: %s in namespace %s', name, namespace);
   return axios.post(getServiceUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError('service', name));
 }
 
 function replaceService(name, namespace, manifest) {
-  logger.info('Replacing service: %s', name);
+  logger.info('Replacing service: %s in namespace %s', name, namespace);
   return deleteService(name)
     .then(() => createService(name, manifest));
 }
 
 function updateService(name, namespace, manifest, existingService) {
-  logger.info('Updating service: %s', name);
+  logger.info('Updating service: %s in namespace %s', name, namespace);
   const jsonManifest = copyRequiredFieldsToJsonManfiest(manifest, existingService);
   return axios.put(`${getServiceUrl(namespace)}/${name}`, jsonManifest)
     .catch(handleCreateError('service', name));
 }
 
 function deleteService(name, namespace) {
-  logger.info('Deleting service: %s', name);
+  logger.info('Deleting service: %s in namespace %s', name, namespace);
   return axios.delete(`${getServiceUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('service', name));

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
@@ -5,54 +5,53 @@ import config from '../config/config';
 import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
 
-const SERVICE_URL = `${API_BASE}/api/v1/namespaces/${NAMESPACE}/services`;
+const getServiceUrl = namespace => `${API_BASE}/api/v1/namespaces/${namespace}/services`;
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
-function createOrUpdateService(name, manifest) {
-  return getService(name)
-    .then(createOrReplace(name, manifest))
+function createOrUpdateService(name, namespace, manifest) {
+  return getService(name, namespace)
+    .then(createOrReplace(name, namespace, manifest))
     .then(response => response.data);
 }
 
-const createOrReplace = (name, manifest) => (existingService) => {
+const createOrReplace = (name, namespace, manifest) => (existingService) => {
   if (existingService) {
-    return replaceService(name, manifest);
+    return replaceService(name, namespace, manifest);
   }
 
-  return createService(name, manifest);
+  return createService(name, namespace, manifest);
 };
 
-function getService(name) {
-  return axios.get(`${SERVICE_URL}/${name}`)
+function getService(name, namespace) {
+  return axios.get(`${getServiceUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
 
-function createService(name, manifest) {
+function createService(name, namespace, manifest) {
   logger.info('Creating service: %s', name);
-  return axios.post(SERVICE_URL, manifest, YAML_CONTENT_HEADER)
+  return axios.post(getServiceUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError('service', name));
 }
 
-function replaceService(name, manifest) {
+function replaceService(name, namespace, manifest) {
   logger.info('Replacing service: %s', name);
   return deleteService(name)
     .then(() => createService(name, manifest));
 }
 
-function updateService(name, manifest, existingService) {
+function updateService(name, namespace, manifest, existingService) {
   logger.info('Updating service: %s', name);
   const jsonManifest = copyRequiredFieldsToJsonManfiest(manifest, existingService);
-  return axios.put(`${SERVICE_URL}/${name}`, jsonManifest)
+  return axios.put(`${getServiceUrl(namespace)}/${name}`, jsonManifest)
     .catch(handleCreateError('service', name));
 }
 
-function deleteService(name) {
+function deleteService(name, namespace) {
   logger.info('Deleting service: %s', name);
-  return axios.delete(`${SERVICE_URL}/${name}`)
+  return axios.delete(`${getServiceUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('service', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.js
@@ -6,7 +6,10 @@ import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
 
-const getServiceUrl = namespace => `${API_BASE}/api/v1/namespaces/${namespace}/services`;
+const getServiceUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/api/v1/namespaces/${namespace}/services${nameComponent}`;
+};
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
@@ -45,13 +48,13 @@ function replaceService(name, namespace, manifest) {
 function updateService(name, namespace, manifest, existingService) {
   logger.info('Updating service: %s in namespace %s', name, namespace);
   const jsonManifest = copyRequiredFieldsToJsonManfiest(manifest, existingService);
-  return axios.put(`${getServiceUrl(namespace)}/${name}`, jsonManifest)
+  return axios.put(`${getServiceUrl(namespace, name)}`, jsonManifest)
     .catch(handleCreateError('service', name));
 }
 
 function deleteService(name, namespace) {
   logger.info('Deleting service: %s in namespace %s', name, namespace);
-  return axios.delete(`${getServiceUrl(namespace)}/${name}`)
+  return axios.delete(`${getServiceUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(handleDeleteError('service', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
@@ -62,6 +62,7 @@ describe('Kubernetes Service API', () => {
 
       try {
         await serviceApi.createService(SERVICE_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
         expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
       }
@@ -83,6 +84,7 @@ describe('Kubernetes Service API', () => {
 
       try {
         await serviceApi.updateService(SERVICE_NAME, NAMESPACE, manifest, service);
+        expect(true).toBe(false);
       } catch (error) {
         expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
       }

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
@@ -57,13 +57,14 @@ describe('Kubernetes Service API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPost(SERVICE_URL).reply(400, { message: 'error-message' });
 
-      return serviceApi.createService(SERVICE_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
-        });
+      try {
+        await serviceApi.createService(SERVICE_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
+      }
     });
   });
 
@@ -77,13 +78,14 @@ describe('Kubernetes Service API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPut(`${SERVICE_URL}/${SERVICE_NAME}`).reply(400, { message: 'error-message' });
 
-      return serviceApi.updateService(SERVICE_NAME, NAMESPACE, manifest, service)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
-        });
+      try {
+        await serviceApi.updateService(SERVICE_NAME, NAMESPACE, manifest, service);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
+      }
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/serviceApi.spec.js
@@ -7,7 +7,7 @@ import serviceApi from './serviceApi';
 const mock = new MockAdapter(axios);
 
 const API_BASE = config.get('kubernetesApi');
-const NAMESPACE = config.get('podNamespace');
+const NAMESPACE = 'namespace';
 
 const SERVICE_URL = `${API_BASE}/api/v1/namespaces/${NAMESPACE}/services`;
 const SERVICE_NAME = 'test-service';
@@ -28,7 +28,7 @@ describe('Kubernetes Service API', () => {
     it('should return the service if it exists', () => {
       mock.onGet(`${SERVICE_URL}/${SERVICE_NAME}`).reply(200, service);
 
-      return serviceApi.getService(SERVICE_NAME)
+      return serviceApi.getService(SERVICE_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toEqual(service);
         });
@@ -37,7 +37,7 @@ describe('Kubernetes Service API', () => {
     it('should return undefined it the service does not exist', () => {
       mock.onGet(`${SERVICE_URL}/${SERVICE_NAME}`).reply(404, service);
 
-      return serviceApi.getService(SERVICE_NAME)
+      return serviceApi.getService(SERVICE_NAME, NAMESPACE)
         .then((response) => {
           expect(response).toBeUndefined();
         });
@@ -51,7 +51,7 @@ describe('Kubernetes Service API', () => {
         return [200, service];
       });
 
-      return serviceApi.createService(SERVICE_NAME, manifest)
+      return serviceApi.createService(SERVICE_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response.data).toEqual(service);
         });
@@ -60,7 +60,7 @@ describe('Kubernetes Service API', () => {
     it('should return an error if creation fails', () => {
       mock.onPost(SERVICE_URL).reply(400, { message: 'error-message' });
 
-      return serviceApi.createService(SERVICE_NAME, manifest)
+      return serviceApi.createService(SERVICE_NAME, NAMESPACE, manifest)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
         });
@@ -71,7 +71,7 @@ describe('Kubernetes Service API', () => {
     it('should PUT payload to resource URL', () => {
       mock.onPut(`${SERVICE_URL}/${SERVICE_NAME}`).reply(200, service);
 
-      return serviceApi.updateService(SERVICE_NAME, manifest, service)
+      return serviceApi.updateService(SERVICE_NAME, NAMESPACE, manifest, service)
         .then((response) => {
           expect(response.data).toEqual(service);
         });
@@ -80,7 +80,7 @@ describe('Kubernetes Service API', () => {
     it('should return an error if creation fails', () => {
       mock.onPut(`${SERVICE_URL}/${SERVICE_NAME}`).reply(400, { message: 'error-message' });
 
-      return serviceApi.updateService(SERVICE_NAME, manifest, service)
+      return serviceApi.updateService(SERVICE_NAME, NAMESPACE, manifest, service)
         .catch((error) => {
           expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes service \'test-service\' - error-message');
         });
@@ -92,7 +92,7 @@ describe('Kubernetes Service API', () => {
       mock.onGet(`${SERVICE_URL}/${SERVICE_NAME}`).reply(404);
       mock.onPost().reply(204, service);
 
-      return serviceApi.createOrUpdateService(SERVICE_NAME, manifest)
+      return serviceApi.createOrUpdateService(SERVICE_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response).toEqual(service);
         });
@@ -103,7 +103,7 @@ describe('Kubernetes Service API', () => {
       mock.onDelete().reply(204);
       mock.onPost().reply(204, service);
 
-      return serviceApi.createOrUpdateService(SERVICE_NAME, manifest)
+      return serviceApi.createOrUpdateService(SERVICE_NAME, NAMESPACE, manifest)
         .then((response) => {
           expect(response).toEqual(service);
         });
@@ -114,19 +114,19 @@ describe('Kubernetes Service API', () => {
     it('should DELETE resource URL', () => {
       mock.onDelete(`${SERVICE_URL}/${SERVICE_NAME}`).reply(204);
 
-      return expect(serviceApi.deleteService(SERVICE_NAME)).resolves.toBeUndefined();
+      return expect(serviceApi.deleteService(SERVICE_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return successfully if service does not exist', () => {
       mock.onDelete(`${SERVICE_URL}/${SERVICE_NAME}`).reply(404);
 
-      return expect(serviceApi.deleteService(SERVICE_NAME)).resolves.toBeUndefined();
+      return expect(serviceApi.deleteService(SERVICE_NAME, NAMESPACE)).resolves.toBeUndefined();
     });
 
     it('should return error if server errors', () => {
       mock.onDelete(`${SERVICE_URL}/${SERVICE_NAME}`).reply(500, { message: 'error-message' });
 
-      return expect(serviceApi.deleteService(SERVICE_NAME))
+      return expect(serviceApi.deleteService(SERVICE_NAME, NAMESPACE))
         .rejects.toEqual(new Error('Kubernetes API: Request failed with status code 500'));
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
@@ -27,7 +27,7 @@ const createOrReplace = (name, namespace, manifest) => (existingPersistentVolume
 };
 
 function getPersistentVolumeClaim(name, namespace) {
-  return axios.get(`${getPVCUrl(namespace, name)}`)
+  return axios.get(getPVCUrl(namespace, name))
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -35,18 +35,18 @@ function getPersistentVolumeClaim(name, namespace) {
 function createPersistentVolumeClaim(name, namespace, manifest) {
   logger.info('Creating persistent volume claim: %s in namespace %s', name, namespace);
   return axios.post(getPVCUrl(namespace), manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+    .catch(handleCreateError('persistent volume claim', name));
 }
 
 function updatePersistentVolumeClaim(name, namespace, manifest) {
   logger.info('Updating persistent volume claim: %s in namespace %s', name, namespace);
-  return axios.put(`${getPVCUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
-    .catch(handleCreateError);
+  return axios.put(getPVCUrl(namespace, name), manifest, YAML_CONTENT_HEADER)
+    .catch(handleCreateError('persistent volume claim', name));
 }
 
 function deletePersistentVolumeClaim(name, namespace) {
   logger.info('Deleting persistent volume claim: %s in namespace %s', name, namespace);
-  return axios.delete(`${getPVCUrl(namespace, name)}`)
+  return axios.delete(getPVCUrl(namespace, name))
     .then(response => response.data)
     .catch(handleDeleteError('persistent volume claim', name));
 }
@@ -61,7 +61,7 @@ function queryPersistentVolumeClaim(name, namespace) {
 function listPersistentVolumeClaims(namespace) {
   // List only visible volumes (ie not internal volumes)
   logger.info('Getting visible volume claims');
-  return axios.get(`${getPVCUrl(namespace)}`, { params: { labelSelector: 'user-created' } })
+  return axios.get(getPVCUrl(namespace), { params: { labelSelector: 'user-created' } })
     .then(processPVCs)
     .catch(() => []);
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
@@ -30,26 +30,26 @@ function getPersistentVolumeClaim(name, namespace) {
 }
 
 function createPersistentVolumeClaim(name, namespace, manifest) {
-  logger.info('Creating persistent volume claim: %s', name);
+  logger.info('Creating persistent volume claim: %s in namespace %s', name, namespace);
   return axios.post(getPVCUrl(namespace), manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function updatePersistentVolumeClaim(name, namespace, manifest) {
-  logger.info('Updating persistent volume claim: %s', name);
+  logger.info('Updating persistent volume claim: %s in namespace %s', name, namespace);
   return axios.put(`${getPVCUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function deletePersistentVolumeClaim(name, namespace) {
-  logger.info('Deleting persistent volume claim: %s', name);
+  logger.info('Deleting persistent volume claim: %s in namespace %s', name, namespace);
   return axios.delete(`${getPVCUrl(namespace)}/${name}`)
     .then(response => response.data)
     .catch(handleDeleteError('persistent volume claim', name));
 }
 
 function queryPersistentVolumeClaim(name, namespace) {
-  logger.info('Getting volume claim: %s', name);
+  logger.info('Getting volume claim: %s in namespace %s', name, namespace);
   return getPersistentVolumeClaim(name, namespace)
     .then(processVolumeDetails)
     .catch(() => {});

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
@@ -6,7 +6,10 @@ import { handleCreateError, handleDeleteError } from './core';
 
 const API_BASE = config.get('kubernetesApi');
 
-const getPVCUrl = namespace => `${API_BASE}/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
+const getPVCUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/api/v1/namespaces/${namespace}/persistentvolumeclaims${nameComponent}`;
+};
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
@@ -24,7 +27,7 @@ const createOrReplace = (name, namespace, manifest) => (existingPersistentVolume
 };
 
 function getPersistentVolumeClaim(name, namespace) {
-  return axios.get(`${getPVCUrl(namespace)}/${name}`)
+  return axios.get(`${getPVCUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(() => undefined);
 }
@@ -37,13 +40,13 @@ function createPersistentVolumeClaim(name, namespace, manifest) {
 
 function updatePersistentVolumeClaim(name, namespace, manifest) {
   logger.info('Updating persistent volume claim: %s in namespace %s', name, namespace);
-  return axios.put(`${getPVCUrl(namespace)}/${name}`, manifest, YAML_CONTENT_HEADER)
+  return axios.put(`${getPVCUrl(namespace, name)}`, manifest, YAML_CONTENT_HEADER)
     .catch(handleCreateError);
 }
 
 function deletePersistentVolumeClaim(name, namespace) {
   logger.info('Deleting persistent volume claim: %s in namespace %s', name, namespace);
-  return axios.delete(`${getPVCUrl(namespace)}/${name}`)
+  return axios.delete(`${getPVCUrl(namespace, name)}`)
     .then(response => response.data)
     .catch(handleDeleteError('persistent volume claim', name));
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
@@ -60,13 +60,14 @@ describe('Kubernetes Persistent Volume API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPost(PVC_URL).reply(400, { message: 'error-message' });
 
-      return volumeApi.createPersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
-        });
+      try {
+        await volumeApi.createPersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
+      }
     });
   });
 
@@ -83,13 +84,14 @@ describe('Kubernetes Persistent Volume API', () => {
         });
     });
 
-    it('should return an error if creation fails', () => {
+    it('should return an error if creation fails', async () => {
       mock.onPut(`${PVC_URL}/${PVC_NAME}`).reply(400, { message: 'error-message' });
 
-      return volumeApi.updatePersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest)
-        .catch((error) => {
-          expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
-        });
+      try {
+        await volumeApi.updatePersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest);
+      } catch (error) {
+        expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
+      }
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
@@ -65,8 +65,9 @@ describe('Kubernetes Persistent Volume API', () => {
 
       try {
         await volumeApi.createPersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes persistent volume claim \'test-pvc\' - error-message');
       }
     });
   });
@@ -89,8 +90,9 @@ describe('Kubernetes Persistent Volume API', () => {
 
       try {
         await volumeApi.updatePersistentVolumeClaim(PVC_NAME, NAMESPACE, manifest);
+        expect(true).toBe(false);
       } catch (error) {
-        expect(error.toString()).toEqual('Error: Unable to create kubernetes persistent volume claim error-message');
+        expect(error.toString()).toEqual('Error: Kubernetes API: Unable to create kubernetes persistent volume claim \'test-pvc\' - error-message');
       }
     });
   });

--- a/code/workspaces/infrastructure-api/src/stacks/jupyterlabStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/jupyterlabStack.js
@@ -8,24 +8,24 @@ import ingressApi from '../kubernetes/ingressApi';
 import { createDeployment, createService, createIngressRule } from './stackBuilders';
 
 function createJupyterLab(params) {
-  const { datalabInfo, projectKey, name, type } = params;
+  const { projectKey, name, type } = params;
   const secretStrategy = secretManager.createNewJupyterCredentials;
 
   return secretManager.storeCredentialsInVault(projectKey, name, secretStrategy)
-    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, secret))
+    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, projectKey, secret))
     .then(createDeployment(params, deploymentGenerator.createJupyterlabDeployment))
-    .then(createService(name, type, deploymentGenerator.createJupyterlabService))
-    .then(createIngressRule(name, type, datalabInfo, projectKey, ingressGenerator.createIngress));
+    .then(createService(params, deploymentGenerator.createJupyterlabService))
+    .then(createIngressRule(params, ingressGenerator.createIngress));
 }
 
 function deleteJupyterLab(params) {
-  const { datalabInfo, projectKey, name, type } = params;
+  const { projectKey, name, type } = params;
   const k8sName = `${type}-${name}`;
 
-  return ingressApi.deleteIngress(k8sName, datalabInfo)
-    .then(() => serviceApi.deleteService(k8sName))
-    .then(() => deploymentApi.deleteDeployment(k8sName))
-    .then(() => k8sSecretApi.deleteSecret(k8sName))
+  return ingressApi.deleteIngress(k8sName, projectKey)
+    .then(() => serviceApi.deleteService(k8sName, projectKey))
+    .then(() => deploymentApi.deleteDeployment(k8sName, projectKey))
+    .then(() => k8sSecretApi.deleteSecret(k8sName, projectKey))
     .then(() => secretManager.deleteSecret(projectKey, name));
 }
 

--- a/code/workspaces/infrastructure-api/src/stacks/nbviewerStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/nbviewerStack.js
@@ -6,11 +6,9 @@ import ingressApi from '../kubernetes/ingressApi';
 import { createDeployment, createService, createIngressRule } from './stackBuilders';
 
 function createNbViewerStack(params) {
-  const { datalabInfo, projectKey, name, type } = params;
-
   return createDeployment(params, deploymentGenerator.createNbViewerDeployment)()
-    .then(createService(name, type, deploymentGenerator.createNbViewerService))
-    .then(createIngressRule(name, type, datalabInfo, projectKey, ingressGenerator.createIngress));
+    .then(createService(params, deploymentGenerator.createNbViewerService))
+    .then(createIngressRule(params, ingressGenerator.createIngress));
 }
 
 function deleteNbViewerStack(params) {

--- a/code/workspaces/infrastructure-api/src/stacks/rshinyStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rshinyStack.js
@@ -6,20 +6,18 @@ import ingressApi from '../kubernetes/ingressApi';
 import { createDeployment, createService, createIngressRule } from './stackBuilders';
 
 function createRShinyStack(params) {
-  const { datalabInfo, projectKey, name, type } = params;
-
   return createDeployment(params, deploymentGenerator.createRShinyDeployment)()
-    .then(createService(name, type, deploymentGenerator.createRShinyService))
-    .then(createIngressRule(name, type, datalabInfo, projectKey, ingressGenerator.createIngress));
+    .then(createService(params, deploymentGenerator.createRShinyService))
+    .then(createIngressRule(params, ingressGenerator.createIngress));
 }
 
 function deleteRShinyStack(params) {
-  const { datalabInfo, name, type } = params;
+  const { name, type, projectKey } = params;
   const k8sName = `${type}-${name}`;
 
-  return ingressApi.deleteIngress(k8sName, datalabInfo)
-    .then(() => serviceApi.deleteService(k8sName))
-    .then(() => deploymentApi.deleteDeployment(k8sName));
+  return ingressApi.deleteIngress(k8sName, projectKey)
+    .then(() => serviceApi.deleteService(k8sName, projectKey))
+    .then(() => deploymentApi.deleteDeployment(k8sName, projectKey));
 }
 
 export default { createRShinyStack, deleteRShinyStack };

--- a/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
@@ -13,20 +13,20 @@ function createRStudioStack(params) {
   const proxyTimeout = '1800';
 
   return secretManager.storeCredentialsInVault(projectKey, name, secretStrategy)
-    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, secret))
+    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, projectKey, secret))
     .then(createDeployment(params, deploymentGenerator.createRStudioDeployment))
-    .then(createService(name, type, deploymentGenerator.createRStudioService))
+    .then(createService(params, deploymentGenerator.createRStudioService))
     .then(createIngressRuleWithConnect({ ...params, proxyTimeout }, ingressGenerator.createIngress));
 }
 
 function deleteRStudioStack(params) {
-  const { datalabInfo, projectKey, name, type } = params;
+  const { projectKey, name, type } = params;
   const k8sName = `${type}-${name}`;
 
-  return ingressApi.deleteIngress(k8sName, datalabInfo)
-    .then(() => serviceApi.deleteService(k8sName))
-    .then(() => deploymentApi.deleteDeployment(k8sName))
-    .then(() => k8sSecretApi.deleteSecret(k8sName))
+  return ingressApi.deleteIngress(k8sName, projectKey)
+    .then(() => serviceApi.deleteService(k8sName, projectKey))
+    .then(() => deploymentApi.deleteDeployment(k8sName, projectKey))
+    .then(() => k8sSecretApi.deleteSecret(k8sName, projectKey))
     .then(() => secretManager.deleteSecret(projectKey, name));
 }
 

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -6,62 +6,65 @@ import ingressApi from '../kubernetes/ingressApi';
 import volumeApi from '../kubernetes/volumeApi';
 
 export const createDeployment = (params, generator) => () => {
-  const { name, type } = params;
+  const { name, projectKey, type } = params;
   const deploymentName = `${type}-${name}`;
 
   return generator({ ...params, deploymentName })
     .then((manifest) => {
       logger.info(`Creating deployment ${chalk.blue(deploymentName)} with manifest:`);
       logger.debug(manifest.toString());
-      return deploymentApi.createOrUpdateDeployment(deploymentName, manifest);
+      return deploymentApi.createOrUpdateDeployment(deploymentName, projectKey, manifest);
     });
 };
 
-export const createService = (name, type, generator) => () => {
+export const createService = (params, generator) => () => {
+  const { name, projectKey, type } = params;
   const serviceName = `${type}-${name}`;
   return generator(serviceName)
     .then((manifest) => {
       logger.info(`Creating service ${chalk.blue(serviceName)} with manifest:`);
       logger.debug(manifest.toString());
-      return serviceApi.createOrUpdateService(serviceName, manifest);
+      return serviceApi.createOrUpdateService(serviceName, projectKey, manifest);
     });
 };
 
-export const createIngressRule = (name, type, datalabInfo, projectKey, generator) => (service) => {
+export const createIngressRule = (params, generator) => (service) => {
+  const { name, projectKey, type } = params;
   const ingressName = `${type}-${name}`;
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];
 
-  return generator({ name, datalabInfo, projectKey, ingressName, serviceName, port })
+  return generator({ ...params, ingressName, serviceName, port })
     .then((manifest) => {
       logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with manifest:`);
       logger.debug(manifest.toString());
-      return ingressApi.createOrUpdateIngress(ingressName, manifest);
+      return ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
     });
 };
 
 export const createIngressRuleWithConnect = (params, generator) => (service) => {
-  const { name, type, datalabInfo, projectKey, rewriteTarget, proxyTimeout } = params;
+  const { name, projectKey, type } = params;
   const ingressName = `${type}-${name}`;
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];
   const connectPort = service.spec.ports[1].port;
 
-  return generator({ name, datalabInfo, projectKey, ingressName, serviceName, port, connectPort, rewriteTarget, proxyTimeout })
+  return generator({ ...params, ingressName, serviceName, port, connectPort })
     .then((manifest) => {
       logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with connect port from manifest:`);
       logger.debug(manifest.toString());
-      return ingressApi.createOrUpdateIngress(ingressName, manifest);
+      return ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
     });
 };
 
-export const createPersistentVolume = (name, volumeSize, generator) => () => {
+export const createPersistentVolume = (params, generator) => () => {
+  const { name, volumeSize, projectKey } = params;
   const volumeName = `${name}-claim`;
 
   return generator(volumeName, volumeSize)
     .then((manifest) => {
       logger.info(`Creating persistent volume ${chalk.blue(volumeName)} with manifest:`);
       logger.debug(manifest.toString());
-      return volumeApi.createOrUpdatePersistentVolumeClaim(volumeName, manifest);
+      return volumeApi.createOrUpdatePersistentVolumeClaim(volumeName, projectKey, manifest);
     });
 };

--- a/code/workspaces/infrastructure-api/src/stacks/zeppelinStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/zeppelinStack.js
@@ -16,20 +16,20 @@ function createZeppelinStack(params) {
 
   return secretManager.storeCredentialsInVault(projectKey, name, secretStrategy)
     .then(generateNewShiroIni)
-    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, secret))
+    .then(secret => k8sSecretApi.createOrUpdateSecret(`${type}-${name}`, projectKey, secret))
     .then(createDeployment(params, deploymentGenerator.createZeppelinDeployment))
-    .then(createService(name, type, deploymentGenerator.createZeppelinService))
+    .then(createService(params, deploymentGenerator.createZeppelinService))
     .then(createIngressRuleWithConnect(params, ingressGenerator.createIngress));
 }
 
 function deleteZeppelinStack(params) {
-  const { datalabInfo, projectKey, name, type } = params;
+  const { projectKey, name, type } = params;
   const k8sName = `${type}-${name}`;
 
-  return ingressApi.deleteIngress(k8sName, datalabInfo)
-    .then(() => serviceApi.deleteService(k8sName))
-    .then(() => deploymentApi.deleteDeployment(k8sName))
-    .then(() => k8sSecretApi.deleteSecret(k8sName))
+  return ingressApi.deleteIngress(k8sName, projectKey)
+    .then(() => serviceApi.deleteService(k8sName, projectKey))
+    .then(() => deploymentApi.deleteDeployment(k8sName, projectKey))
+    .then(() => k8sSecretApi.deleteSecret(k8sName, projectKey))
     .then(() => secretManager.deleteSecret(projectKey, name));
 }
 


### PR DESCRIPTION
Update Kubernetes api client files to allow target namespace to be configured
Update stack builders to target `projectKey` namespace
Update volume manager to target `projectKey` namespace
Tidy parameters passing to avoid unpacking and repacking the a `params` object