### PR TITLE
Nercdl 380 project switcher – refactor state 

### DIFF
--- a/code/workspaces/web-app/src/actions/projectActions.js
+++ b/code/workspaces/web-app/src/actions/projectActions.js
@@ -1,7 +1,7 @@
 import projectsService from '../api/projectsService';
 
 export const LOAD_PROJECTS_ACTION = 'LOAD_PROJECTS';
-export const LOAD_PROJECTINFO_ACTION = 'LOAD_PROJECTINFO';
+export const SET_CURRENT_PROJECT_ACTION = 'SET_CURRENT_PROJECT_ACTION';
 export const CREATE_PROJECT_ACTION = 'CREATE_PROJECT_ACTION';
 export const CHECK_PROJECT_KEY_UNIQUE_ACTION = 'CHECK_PROJECT_KEY_UNIQUE_ACTION';
 
@@ -10,8 +10,8 @@ const loadProjects = () => ({
   payload: projectsService.loadProjects(),
 });
 
-const loadProjectInfo = projectKey => ({
-  type: LOAD_PROJECTINFO_ACTION,
+const setCurrentProject = projectKey => ({
+  type: SET_CURRENT_PROJECT_ACTION,
   payload: projectsService.loadProjectInfo(projectKey),
 });
 
@@ -26,5 +26,5 @@ const checkProjectKeyUniqueness = projectKey => ({
 });
 
 export default {
-  loadProjects, loadProjectInfo, createProject, checkProjectKeyUniqueness,
+  loadProjects, setCurrentProject, createProject, checkProjectKeyUniqueness,
 };

--- a/code/workspaces/web-app/src/actions/projectActions.spec.js
+++ b/code/workspaces/web-app/src/actions/projectActions.spec.js
@@ -1,6 +1,6 @@
 import projectActions, {
   LOAD_PROJECTS_ACTION,
-  LOAD_PROJECTINFO_ACTION,
+  SET_CURRENT_PROJECT_ACTION,
   CREATE_PROJECT_ACTION,
   CHECK_PROJECT_KEY_UNIQUE_ACTION,
 } from './projectActions';
@@ -22,21 +22,21 @@ describe('projectActions', () => {
 
       // Assert
       expect(loadProjectsMock).toHaveBeenCalledTimes(1);
-      expect(output.type).toBe('LOAD_PROJECTS');
+      expect(output.type).toBe(LOAD_PROJECTS_ACTION);
       expect(output.payload).toBe('expectedProjectsPayload');
     });
 
-    it('loadProjectInfo', () => {
+    it('setCurrentProject', () => {
       // Arrange
       const loadProjectInfoMock = jest.fn().mockReturnValue('expectedProjectsPayload');
       projectsService.loadProjectInfo = loadProjectInfoMock;
 
       // Act
-      const output = projectActions.loadProjectInfo('project99');
+      const output = projectActions.setCurrentProject('project99');
 
       // Assert
       expect(loadProjectInfoMock).toHaveBeenCalledTimes(1);
-      expect(output.type).toBe('LOAD_PROJECTINFO');
+      expect(output.type).toBe(SET_CURRENT_PROJECT_ACTION);
       expect(output.payload).toBe('expectedProjectsPayload');
     });
 
@@ -70,8 +70,8 @@ describe('projectActions', () => {
       expect(LOAD_PROJECTS_ACTION).toBe('LOAD_PROJECTS');
     });
 
-    it('LOAD_PROJECTINFO_ACTION', () => {
-      expect(LOAD_PROJECTINFO_ACTION).toBe('LOAD_PROJECTINFO');
+    it('SET_CURRENT_PROJECT_ACTION', () => {
+      expect(SET_CURRENT_PROJECT_ACTION).toBe('SET_CURRENT_PROJECT_ACTION');
     });
 
     it('CREATE_PROJECT_ACTION', () => {

--- a/code/workspaces/web-app/src/containers/projectInfo/ProjectInfoContainer.js
+++ b/code/workspaces/web-app/src/containers/projectInfo/ProjectInfoContainer.js
@@ -2,28 +2,29 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import projectActions from '../../actions/projectActions';
+import projectSelectors from '../../selectors/projectsSelectors';
 import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 import ProjectInfoContent from '../../components/projectInfo/ProjectInfoContent';
 
 class ProjectInfoContainer extends Component {
   render() {
     return (
-      <PromisedContentWrapper promise={this.props.projects}>
-        {this.props.projects.value.currentProject ? (
-          <ProjectInfoContent projectInfo={this.props.projects.value.currentProject} />
+      <PromisedContentWrapper promise={this.props.currentProject}>
+        {this.props.currentProject.value ? (
+          <ProjectInfoContent projectInfo={this.props.currentProject.value} />
         ) : (<div/>)}
       </PromisedContentWrapper>
     );
   }
 
   shouldComponentUpdate(nextProps) {
-    const isFetching = nextProps.projects.fetching;
-    return !isFetching || this.props.projects.isFetching !== isFetching;
+    const isFetching = nextProps.currentProject.fetching;
+    return !isFetching || this.props.currentProject.isFetching !== isFetching;
   }
 }
 
-function mapStateToProps({ projects }) {
-  return { projects };
+function mapStateToProps(state) {
+  return { currentProject: projectSelectors.currentProject(state) };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/code/workspaces/web-app/src/containers/projectInfo/ProjectInfoContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/projectInfo/ProjectInfoContainer.spec.js
@@ -21,25 +21,25 @@ describe('ProjectInfoContainer', () => {
       return shallow(<ProjectInfoContainer {...props} />).find('ProjectInfoContainer');
     }
 
-    const projects = { fetching: false, value: { currentProject: { id: 'expectedId' } } };
+    const currentProject = { fetching: false, value: { id: 'expectedId' } };
 
     it('extracts the correct props from the redux state', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
       const output = shallowRenderConnected(store);
 
       // Assert
-      expect(output.prop('projects')).toBe(projects);
+      expect(output.prop('currentProject')).toBe(currentProject);
     });
 
     it('binds correct actions', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
@@ -49,10 +49,10 @@ describe('ProjectInfoContainer', () => {
       expect(Object.keys(output)).toMatchSnapshot();
     });
 
-    it('loadProjectInfo function dispatch correct action', () => {
+    it('setCurrentProject function dispatch correct action', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
@@ -60,9 +60,9 @@ describe('ProjectInfoContainer', () => {
 
       // Assert
       expect(store.getActions().length).toBe(0);
-      output.prop('actions').loadProjectInfo();
+      output.prop('actions').setCurrentProject();
       const { type, payload } = store.getActions()[0];
-      expect(type).toBe('LOAD_PROJECTINFO');
+      expect(type).toBe('SET_CURRENT_PROJECT_ACTION');
       return payload.then(value => expect(value).toBe('expectedPayload'));
     });
   });
@@ -72,19 +72,19 @@ describe('ProjectInfoContainer', () => {
       return shallow(<PureProjectInfoContainer {...props} />);
     }
 
-    const projects = { fetching: false, value: { currentProject: { id: 'expectedId' } } };
+    const currentProject = { fetching: false, value: { id: 'expectedId' } };
 
     const generateProps = () => ({
-      projects,
+      currentProject,
       userPermissions: ['expectedPermission'],
       actions: {
-        loadProjectInfo: loadProjectInfoMock,
+        setCurrentProject: loadProjectInfoMock,
       },
     });
 
     beforeEach(() => jest.clearAllMocks());
 
-    it('does not call loadProjectInfo action when mounted', () => {
+    it('does not call setCurrentProject action when mounted', () => {
       // Arrange
       const props = generateProps();
 

--- a/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.js
+++ b/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.js
@@ -3,27 +3,28 @@ import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import projectActions from '../../actions/projectActions';
+import projectSelectors from '../../selectors/projectsSelectors';
 import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 
 class ProjectTitleContainer extends Component {
   render() {
     return (
-      <PromisedContentWrapper promise={this.props.projects}>
-        {this.props.projects.value.currentProject ? (
-          <span>{this.props.projects.value.currentProject.name}</span>
+      <PromisedContentWrapper promise={this.props.currentProject}>
+        {this.props.currentProject.value ? (
+          <span>{this.props.currentProject.value.name}</span>
         ) : (<div/>)}
       </PromisedContentWrapper>
     );
   }
 
   shouldComponentUpdate(nextProps) {
-    const isFetching = nextProps.projects.fetching;
-    return !isFetching || this.props.projects.isFetching !== isFetching;
+    const isFetching = nextProps.currentProject.fetching;
+    return !isFetching || this.props.currentProject.isFetching !== isFetching;
   }
 
   componentWillMount() {
     // Added .catch to prevent unhandled promise error, when lacking permission to view content
-    this.props.actions.loadProjectInfo(this.props.projectKey)
+    this.props.actions.setCurrentProject(this.props.projectKey)
       .catch((() => { }));
   }
 }
@@ -32,8 +33,8 @@ ProjectTitleContainer.propTypes = {
   projectKey: PropTypes.string.isRequired,
 };
 
-function mapStateToProps({ projects }) {
-  return { projects };
+function mapStateToProps(state) {
+  return { currentProject: projectSelectors.currentProject(state) };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/projectInfo/ProjectTitleContainer.spec.js
@@ -5,8 +5,8 @@ import ProjectTitleContainer, { PureProjectTitleContainer } from './ProjectTitle
 import projectsService from '../../api/projectsService';
 
 jest.mock('../../api/projectsService');
-const loadProjectInfoMock = jest.fn().mockReturnValue(Promise.resolve('expectedPayload'));
-projectsService.loadProjectInfo = loadProjectInfoMock;
+const setCurrentProjectMock = jest.fn().mockReturnValue(Promise.resolve('expectedPayload'));
+projectsService.loadProjectInfo = setCurrentProjectMock;
 
 describe('ProjectTitleContainer', () => {
   describe('is a connected component which', () => {
@@ -22,25 +22,25 @@ describe('ProjectTitleContainer', () => {
       return shallow(<ProjectTitleContainer {...props} />).find('ProjectTitleContainer');
     }
 
-    const projects = { fetching: false, value: { currentProject: { id: 'expectedId' } } };
+    const currentProject = { fetching: false, value: { id: 'expectedId' } };
 
     it('extracts the correct props from the redux state', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
       const output = shallowRenderConnected(store);
 
       // Assert
-      expect(output.prop('projects')).toBe(projects);
+      expect(output.prop('currentProject')).toBe(currentProject);
     });
 
     it('binds correct actions', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
@@ -53,7 +53,7 @@ describe('ProjectTitleContainer', () => {
     it('loadProjectInfo function dispatch correct action', () => {
       // Arrange
       const store = createStore()({
-        projects,
+        currentProject,
       });
 
       // Act
@@ -61,9 +61,9 @@ describe('ProjectTitleContainer', () => {
 
       // Assert
       expect(store.getActions().length).toBe(0);
-      output.prop('actions').loadProjectInfo();
+      output.prop('actions').setCurrentProject();
       const { type, payload } = store.getActions()[0];
-      expect(type).toBe('LOAD_PROJECTINFO');
+      expect(type).toBe('SET_CURRENT_PROJECT_ACTION');
       return payload.then(value => expect(value).toBe('expectedPayload'));
     });
   });
@@ -73,14 +73,14 @@ describe('ProjectTitleContainer', () => {
       return shallow(<PureProjectTitleContainer {...props} />);
     }
 
-    const projects = { fetching: false, value: { currentProject: { id: 'expectedId' } } };
+    const currentProject = { fetching: false, value: { id: 'expectedId' } };
 
     const generateProps = () => ({
-      projects,
+      currentProject,
       projectKey: 'project99',
       userPermissions: ['expectedPermission'],
       actions: {
-        loadProjectInfo: loadProjectInfoMock,
+        setCurrentProject: setCurrentProjectMock,
       },
     });
 
@@ -94,7 +94,7 @@ describe('ProjectTitleContainer', () => {
       shallowRenderPure(props);
 
       // Assert
-      expect(loadProjectInfoMock).toHaveBeenCalledTimes(1);
+      expect(setCurrentProjectMock).toHaveBeenCalledTimes(1);
     });
 
     it('passes correct props', () => {

--- a/code/workspaces/web-app/src/containers/projectInfo/__snapshots__/ProjectInfoContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projectInfo/__snapshots__/ProjectInfoContainer.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ProjectInfoContainer is a connected component which binds correct actions 1`] = `
 Array [
   "loadProjects",
-  "loadProjectInfo",
+  "setCurrentProject",
   "createProject",
   "checkProjectKeyUniqueness",
 ]
@@ -15,9 +15,7 @@ exports[`ProjectInfoContainer is a container which passes correct props 1`] = `
     Object {
       "fetching": false,
       "value": Object {
-        "currentProject": Object {
-          "id": "expectedId",
-        },
+        "id": "expectedId",
       },
     }
   }

--- a/code/workspaces/web-app/src/containers/projectInfo/__snapshots__/ProjectTitleContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projectInfo/__snapshots__/ProjectTitleContainer.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ProjectTitleContainer is a connected component which binds correct actions 1`] = `
 Array [
   "loadProjects",
-  "loadProjectInfo",
+  "setCurrentProject",
   "createProject",
   "checkProjectKeyUniqueness",
 ]
@@ -15,9 +15,7 @@ exports[`ProjectTitleContainer is a container which passes correct props 1`] = `
     Object {
       "fetching": false,
       "value": Object {
-        "currentProject": Object {
-          "id": "expectedId",
-        },
+        "id": "expectedId",
       },
     }
   }

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
@@ -8,6 +8,7 @@ import TextField from '@material-ui/core/TextField';
 import { permissionTypes } from 'common';
 import theme from '../../theme';
 import projectActions from '../../actions/projectActions';
+import projectSelectors from '../../selectors/projectsSelectors';
 import modalDialogActions from '../../actions/modalDialogActions';
 import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 import StackCards from '../../components/stacks/StackCards';
@@ -82,8 +83,8 @@ class ProjectsContainer extends Component {
   }
 
   adaptProjectsToStacks() {
-    return this.props.projects.value.projectArray
-      ? this.props.projects.value.projectArray.map(projectToStack)
+    return this.props.projects.value
+      ? this.props.projects.value.map(projectToStack)
       : [];
   }
 
@@ -165,7 +166,7 @@ ProjectsContainer.propTypes = {
   projects: PropTypes.shape({
     error: PropTypes.any,
     fetching: PropTypes.bool.isRequired,
-    value: PropTypes.object.isRequired,
+    value: PropTypes.array.isRequired,
   }).isRequired,
   actions: PropTypes.shape({
     loadProjects: PropTypes.func.isRequired,
@@ -173,8 +174,8 @@ ProjectsContainer.propTypes = {
   userPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-function mapStateToProps({ projects }) {
-  return { projects };
+function mapStateToProps(state) {
+  return { projects: projectSelectors.projectArray(state) };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.spec.js
@@ -6,7 +6,7 @@ import projectsService from '../../api/projectsService';
 
 jest.mock('../../api/projectsService');
 const projectsPayload = {
-  projectArray: [{
+  value: [{
     id: 123,
     key: 'project2',
     name: 'A project name',
@@ -20,7 +20,7 @@ projectsService.loadProjects = loadProjectsMock;
 describe('ProjectsContainer', () => {
   describe('is a component which', () => {
     it('can filter projects', () => {
-      const stacks = projectsPayload.projectArray.map(projectToStack);
+      const stacks = projectsPayload.value.map(projectToStack);
       expect(stacks.length).toBe(1);
       const stack = stacks[0];
       expect(stackMatchesFilter(stack, '')).toBe(true);
@@ -42,7 +42,7 @@ describe('ProjectsContainer', () => {
       return shallow(<ConnectedProjectsContainer {...props} />).find('ProjectsContainer');
     }
 
-    const projects = { fetching: false, value: { projectArray: ['expectedArray'] } };
+    const projects = { fetching: false, value: { value: ['expectedArray'] } };
 
     it('extracts the correct props from the redux state', () => {
       // Arrange
@@ -93,7 +93,7 @@ describe('ProjectsContainer', () => {
       return shallow(<PureProjectsContainer {...props} />);
     }
 
-    const projects = { fetching: false, value: projectsPayload };
+    const projects = { fetching: false, value: projectsPayload.value };
 
     const generateProps = () => ({
       projects,

--- a/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`ProjectsContainer is a connected component which binds correct actions 1`] = `
 Array [
   "loadProjects",
-  "loadProjectInfo",
+  "setCurrentProject",
   "createProject",
   "checkProjectKeyUniqueness",
   "openModalDialog",
@@ -16,17 +16,15 @@ exports[`ProjectsContainer is a container which passes correct props to StackCar
   promise={
     Object {
       "fetching": false,
-      "value": Object {
-        "projectArray": Array [
-          Object {
-            "accessible": true,
-            "description": "A project description",
-            "id": 123,
-            "key": "project2",
-            "name": "A project name",
-          },
-        ],
-      },
+      "value": Array [
+        Object {
+          "accessible": true,
+          "description": "A project description",
+          "id": 123,
+          "key": "project2",
+          "name": "A project name",
+        },
+      ],
     }
   }
 >

--- a/code/workspaces/web-app/src/reducers/currentProjectReducer.js
+++ b/code/workspaces/web-app/src/reducers/currentProjectReducer.js
@@ -5,19 +5,19 @@ import {
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
 import {
-  LOAD_PROJECTS_ACTION,
+  SET_CURRENT_PROJECT_ACTION,
 } from '../actions/projectActions';
 
 const initialState = {
   fetching: false,
-  value: [],
+  value: {},
   error: null,
 };
 
 export default typeToReducer({
-  [LOAD_PROJECTS_ACTION]: {
-    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: [...state.value] }),
-    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: [...state.value] }),
+  [SET_CURRENT_PROJECT_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: { ...state.value } }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: { ...state.value } }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
   },
-}, { ...initialState });
+}, initialState);

--- a/code/workspaces/web-app/src/reducers/currentProjectReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/currentProjectReducer.spec.js
@@ -1,0 +1,45 @@
+import { SET_CURRENT_PROJECT_ACTION } from '../actions/projectActions';
+import { PROMISE_TYPE_FAILURE, PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS } from '../actions/actionTypes';
+import currentProjectsReducer from './currentProjectReducer';
+
+describe('currentProjectReducers', () => {
+  describe('SET_CURRENT_PROJECT', () => {
+    it('should handle SET_CURRENT_PROJECT_PENDING', () => {
+      // Arrange
+      const type = `${SET_CURRENT_PROJECT_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextstate = currentProjectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
+    });
+
+    it('should handle SET_CURRENT_PROJECT_SUCCESS', () => {
+      // Arrange
+      const type = `${SET_CURRENT_PROJECT_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = { project: 'secondProject' };
+      const action = { type, payload };
+
+      // Act
+      const nextstate = currentProjectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, value: action.payload });
+    });
+
+    it('should handle SET_CURRENT_PROJECT_FAILURE', () => {
+      // Arrange
+      const type = `${SET_CURRENT_PROJECT_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = currentProjectsReducer({ error: null, fetching: false, value: {} }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
+    });
+  });
+});

--- a/code/workspaces/web-app/src/reducers/index.js
+++ b/code/workspaces/web-app/src/reducers/index.js
@@ -8,6 +8,7 @@ import stacks from './stacksReducer';
 import modal from './modelDialogReducer';
 import users from './usersReducer';
 import projectUsers from './projectSettingsReducers';
+import currentProject from './currentProjectReducer';
 
 const rootReducer = history => combineReducers({
   authentication,
@@ -17,6 +18,7 @@ const rootReducer = history => combineReducers({
   modal,
   users,
   projectUsers,
+  currentProject,
   router: connectRouter(history),
   form: formReducer,
 });

--- a/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
@@ -1,11 +1,15 @@
 import projectsReducer from './projectsReducer';
 import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
-import { LOAD_PROJECTS_ACTION, LOAD_PROJECTINFO_ACTION } from '../actions/projectActions';
+import { LOAD_PROJECTS_ACTION } from '../actions/projectActions';
 
 describe('projectsReducer', () => {
   it('should return the initial state', () => {
     // Act/Assert
-    expect(projectsReducer(undefined, {})).toEqual({ fetching: false, value: {}, error: null });
+    expect(projectsReducer(undefined, {})).toEqual({
+      fetching: false,
+      value: [],
+      error: null,
+    });
   });
 
   describe('LOAD_PROJECTS', () => {
@@ -15,10 +19,10 @@ describe('projectsReducer', () => {
       const action = { type };
 
       // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      const nextstate = projectsReducer({ error: null, fetching: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
+      expect(nextstate).toEqual({ error: null, fetching: true, value: [] });
     });
 
     it('should handle LOAD_PROJECTS_SUCCESS', () => {
@@ -28,10 +32,10 @@ describe('projectsReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      const nextstate = projectsReducer({ error: null, fetching: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, value: { projectArray: action.payload } });
+      expect(nextstate).toEqual({ error: null, fetching: false, value: action.payload });
     });
 
     it('should handle LOAD_PROJECTS_FAILURE', () => {
@@ -41,50 +45,10 @@ describe('projectsReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
+      const nextstate = projectsReducer({ error: null, fetching: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
-    });
-  });
-
-  describe('LOAD_PROJECTINFO', () => {
-    it('should handle LOAD_PROJECTINFO_PENDING', () => {
-      // Arrange
-      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_PENDING}`;
-      const action = { type };
-
-      // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
-
-      // Assert
-      expect(nextstate).toEqual({ error: null, fetching: true, value: {} });
-    });
-
-    it('should handle LOAD_PROJECTINFO_SUCCESS', () => {
-      // Arrange
-      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_SUCCESS}`;
-      const payload = { project: 'secondProject' };
-      const action = { type, payload };
-
-      // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
-
-      // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, value: { currentProject: action.payload } });
-    });
-
-    it('should handle LOAD_PROJECTINFOFAILURE', () => {
-      // Arrange
-      const type = `${LOAD_PROJECTINFO_ACTION}_${PROMISE_TYPE_FAILURE}`;
-      const payload = 'example error';
-      const action = { type, payload };
-
-      // Act
-      const nextstate = projectsReducer({ error: null, fetching: false, value: {} }, action);
-
-      // Assert
-      expect(nextstate).toEqual({ error: payload, fetching: false, value: {} });
+      expect(nextstate).toEqual({ error: payload, fetching: false, value: [] });
     });
   });
 });

--- a/code/workspaces/web-app/src/selectors/projectsSelectors.js
+++ b/code/workspaces/web-app/src/selectors/projectsSelectors.js
@@ -1,0 +1,13 @@
+const selectCurrentProject = ({ currentProject }) => currentProject;
+const selectCurrentProjectKey = ({ currentProject }) => ({
+  ...currentProject,
+  value: currentProject.value.key,
+});
+
+const selectProjectArray = ({ projects }) => projects;
+
+export default {
+  currentProject: selectCurrentProject,
+  currentProjectKey: selectCurrentProjectKey,
+  projectArray: selectProjectArray,
+};

--- a/code/workspaces/web-app/src/selectors/projectsSelectors.spec.js
+++ b/code/workspaces/web-app/src/selectors/projectsSelectors.spec.js
@@ -1,0 +1,44 @@
+import projectsSelectors from './projectsSelectors';
+
+const testProj = { key: 'testproj', name: 'Test Project' };
+
+const state = {
+  projects: {
+    fetching: false,
+    error: null,
+    value: [testProj],
+  },
+  currentProject: {
+    error: null,
+    fetching: false,
+    value: testProj,
+  },
+};
+
+describe('currentProject', () => {
+  it('returns value of currentProject from state', () => {
+    const currentProject = projectsSelectors.currentProject(state);
+    expect(currentProject).toEqual(state.currentProject);
+    expect(currentProject).not.toBeUndefined();
+  });
+});
+
+describe('currentProjectKey', () => {
+  it('returns value as project key from state when it is defined', () => {
+    expect(projectsSelectors.currentProjectKey(state).value).toEqual('testproj');
+  });
+
+  it('returns value as undefined when project key not defined', () => {
+    const missingState = { ...state };
+    missingState.currentProject.value = {};
+    expect(projectsSelectors.currentProjectKey(missingState).value).toBeUndefined();
+  });
+});
+
+describe('projectArray', () => {
+  it('returns value of projects from state', () => {
+    const projectArray = projectsSelectors.projectArray(state);
+    expect(projectArray).toEqual(state.projects);
+    expect(projectArray).not.toBeUndefined();
+  });
+});


### PR DESCRIPTION
This is the first in a series of PRs to implement the project switcher. In this PR the state is refactored to split the state for the current project and for the array of projects. These are now two distinct parts of state with the projects array being under `projects` and the information about the current project being under `currentProject`. This makes more sense when in the future components will be accessing the current project information more. 