### PR TITLE
fix: remove tls-secret from dynamic ingress rules

### DIFF
--- a/code/workspaces/infrastructure-api/resources/default.ingress.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.ingress.template.yml
@@ -20,7 +20,6 @@ spec:
   tls:
   - hosts:
     - {{ service.host }}
-    secretName: tls-secret
   rules:
   - host: {{ service.host }}
     http:

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
@@ -18,7 +18,6 @@ spec:
   tls:
   - hosts:
     - project-name.datalabs.localhost
-    secretName: tls-secret
   rules:
   - host: project-name.datalabs.localhost
     http:
@@ -49,7 +48,6 @@ spec:
   tls:
   - hosts:
     - project-name.datalabs.localhost
-    secretName: tls-secret
   rules:
   - host: project-name.datalabs.localhost
     http:
@@ -79,7 +77,6 @@ spec:
   tls:
   - hosts:
     - project-name.datalabs.localhost
-    secretName: tls-secret
   rules:
   - host: project-name.datalabs.localhost
     http:
@@ -105,7 +102,6 @@ spec:
   tls:
   - hosts:
     - project-name.datalabs.localhost
-    secretName: tls-secret
   rules:
   - host: project-name.datalabs.localhost
     http:


### PR DESCRIPTION
The secret won't exist in project namespaces and to allow use of the default certificate it must be left unspecified