### PR TITLE
feat(web app): update stack card to fix rendering problems

### DIFF
--- a/code/workspaces/web-app/src/actions/stackActions.js
+++ b/code/workspaces/web-app/src/actions/stackActions.js
@@ -2,6 +2,8 @@ import stackService from '../api/stackService';
 
 export const LOAD_STACKS_ACTION = 'LOAD_STACKS';
 export const LOAD_STACKS_BY_CATEGORY_ACTION = 'LOAD_STACKS_BY_CATEGORY';
+export const UPDATE_STACKS_ACTION = 'UPDATE_STACKS';
+export const UPDATE_STACKS_BY_CATEGORY_ACTION = 'UPDATE_STACKS_BY_CATEGORY';
 export const GET_STACK_URL_ACTION = 'GET_STACK_URL';
 export const OPEN_STACK_ACTION = 'OPEN_STACK';
 export const CREATE_STACK_ACTION = 'CREATE_STACK';
@@ -14,6 +16,16 @@ const loadStacks = () => ({
 
 const loadStacksByCategory = (projectKey, category) => ({
   type: LOAD_STACKS_BY_CATEGORY_ACTION,
+  payload: stackService.loadStacksByCategory(projectKey, category),
+});
+
+const updateStacks = () => ({
+  type: UPDATE_STACKS_ACTION,
+  payload: stackService.loadStacks(),
+});
+
+const updateStacksByCategory = (projectKey, category) => ({
+  type: UPDATE_STACKS_BY_CATEGORY_ACTION,
   payload: stackService.loadStacksByCategory(projectKey, category),
 });
 
@@ -40,6 +52,8 @@ const deleteStack = ({ projectKey, name, type }) => ({
 export default {
   loadStacks,
   loadStacksByCategory,
+  updateStacks,
+  updateStacksByCategory,
   getUrl,
   openStack,
   createStack,

--- a/code/workspaces/web-app/src/components/app/ProjectSwitcher.js
+++ b/code/workspaces/web-app/src/components/app/ProjectSwitcher.js
@@ -63,7 +63,7 @@ function ProjectSwitcher({ classes }) {
   const switcherProjects = getSwitcherProjects(projects, currentProject);
 
   return (
-    <PromisedContentWrapper className={classes.promisedContent} promise={currentProject}>
+    <PromisedContentWrapper fetchingClassName={classes.promisedContent} completeClassName={classes.promisedContent} promise={currentProject}>
       <Switcher
         switcherProjects={switcherProjects}
         currentProject={currentProject}

--- a/code/workspaces/web-app/src/components/app/__snapshots__/ProjectSwitcher.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/ProjectSwitcher.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`ProjectSwitcher renders to match snapshot passing correct parameters to children 1`] = `
 <PromisedContentWrapper
-  className="ProjectSwitcher-promisedContent-2"
+  completeClassName="ProjectSwitcher-promisedContent-2"
+  fetchingClassName="ProjectSwitcher-promisedContent-2"
   promise={
     Object {
       "error": null,

--- a/code/workspaces/web-app/src/components/common/PromisedContentWrapper.js
+++ b/code/workspaces/web-app/src/components/common/PromisedContentWrapper.js
@@ -2,14 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-const PromisedContentWrapper = ({ children, promise, className }) => {
-  const isFetching = promise.fetching;
-  return (
-    <div className={className}>
-      {isFetching ? <CircularProgress /> : children}
-    </div>
-  );
-};
+const PromisedContentWrapper = ({ children, promise, fetchingClassName, completeClassName }) => (
+  promise.fetching
+    ? <div className={fetchingClassName}><CircularProgress /></div>
+    : <div className={completeClassName}>{children}</div>
+);
 
 PromisedContentWrapper.propTypes = {
   children: PropTypes.element.isRequired,

--- a/code/workspaces/web-app/src/components/stacks/StackCards.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.js
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import StackCard from './StackCard';
 import NewStackButton from './NewStackButton';
 import PermissionWrapper from '../common/ComponentPermissionWrapper';
+import PromisedContentWrapper from '../common/PromisedContentWrapper';
 
 const styles = theme => ({
   stackDiv: {
@@ -15,38 +16,42 @@ const styles = theme => ({
     display: 'flex',
     justifyContent: 'flex-end',
   },
-  noItemsMessage: {
+  placeholderCard: {
+    width: '100%',
+    height: 70,
     display: 'flex',
     justifyContent: 'center',
+    alignItems: 'center',
     borderTop: `1px solid ${theme.palette.divider}`,
     borderBottom: `1px solid ${theme.palette.divider}`,
-    padding: `${theme.spacing(3)}px 0`,
   },
 });
 
 const StackCards = ({ stacks, typeName, typeNamePlural, openStack, deleteStack, editStack, openCreationForm,
   userPermissions, createPermission, openPermission, deletePermission, editPermission, classes }) => (
   <div className={classes.stackDiv}>
-    <div> {/* extra div enables working css styling of stack card */}
-      {stacks && stacks.length > 0
-        ? stacks.map(stack => (
-          <StackCard
-            key={stack.id}
-            stack={stack}
-            typeName={typeName}
-            openStack={openStack}
-            deleteStack={deleteStack}
-            editStack={editStack}
-            userPermissions={userPermissions(stack)}
-            openPermission={openPermission}
-            deletePermission={deletePermission}
-            editPermission={editPermission}
-          />))
-        : <div className={classes.noItemsMessage}>
-            <Typography variant="body1">{`No ${typeNamePlural || 'items'} to display.`}</Typography>
-          </div>
-      }
-    </div>
+    <PromisedContentWrapper fetchingClassName={classes.placeholderCard} promise={stacks}>
+      <div> {/* extra div enables working css styling of stack card */}
+        {stacks.value && stacks.value.length > 0
+          ? stacks.value.map(stack => (
+            <StackCard
+              key={stack.id}
+              stack={stack}
+              typeName={typeName}
+              openStack={openStack}
+              deleteStack={deleteStack}
+              editStack={editStack}
+              userPermissions={userPermissions(stack)}
+              openPermission={openPermission}
+              deletePermission={deletePermission}
+              editPermission={editPermission}
+            />))
+          : <div className={classes.placeholderCard}>
+              <Typography variant="body1">{`No ${typeNamePlural || 'items'} to display.`}</Typography>
+            </div>
+        }
+      </div>
+    </PromisedContentWrapper>
     <PermissionWrapper style={{ width: '100%' }} userPermissions={userPermissions()} permission={createPermission}>
       <div className={classes.bottomControlDiv}>
         <NewStackButton onClick={openCreationForm} typeName={typeName} />
@@ -58,7 +63,11 @@ const StackCards = ({ stacks, typeName, typeNamePlural, openStack, deleteStack, 
 export default withStyles(styles)(StackCards);
 
 StackCards.propTypes = {
-  stacks: PropTypes.arrayOf(PropTypes.object).isRequired,
+  stacks: PropTypes.shape({
+    fetching: PropTypes.bool.isRequired,
+    value: PropTypes.array.isRequired,
+    error: PropTypes.object,
+  }).isRequired,
   typeName: PropTypes.string.isRequired,
   openStack: PropTypes.func.isRequired,
   deleteStack: PropTypes.func.isRequired,

--- a/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
@@ -8,11 +8,14 @@ describe('StackCards', () => {
   }
 
   const generateProps = () => ({
-    stacks: [
-      { displayName: 'name1', id: '1', type: 'type1' },
-      { displayName: 'name2', id: '2', type: 'type2' },
-      { displayName: 'name3', id: '3', type: 'type3' },
-    ],
+    stacks: {
+      fetching: false,
+      value: [
+        { displayName: 'name1', id: '1', type: 'type1' },
+        { displayName: 'name2', id: '2', type: 'type2' },
+        { displayName: 'name3', id: '3', type: 'type3' },
+      ],
+    },
     typeName: 'expectedTypeName',
     openStack: () => {},
     deleteStack: () => {},
@@ -24,12 +27,12 @@ describe('StackCards', () => {
     editPermission: 'edit',
   });
 
-  it('creates correct snapshot for an array of notebooks', () => {
+  it('creates correct snapshot for an array of stacks', () => {
     // Arrange
     const props = generateProps();
 
     // Act
-    const output = shallowRender(props);
+    const output = shallowRender(props).dive();
 
     // Assert
     expect(output).toMatchSnapshot();
@@ -37,10 +40,10 @@ describe('StackCards', () => {
 
   it('creates correct snapshot for an empty array', () => {
     // Arrange
-    const props = { ...generateProps(), stacks: [] };
+    const props = { ...generateProps(), stacks: { fetching: false, value: [] } };
 
     // Act
-    const output = shallowRender(props);
+    const output = shallowRender(props).dive();
 
     // Assert
     expect(output).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
@@ -1,63 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StackCards creates correct snapshot for an array of notebooks 1`] = `
-<StackCards
-  classes={
-    Object {
-      "bottomControlDiv": "StackCards-bottomControlDiv-2",
-      "noItemsMessage": "StackCards-noItemsMessage-3",
-      "stackDiv": "StackCards-stackDiv-1",
+exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
+<div
+  className="StackCards-stackDiv-1"
+>
+  <PromisedContentWrapper
+    fetchingClassName="StackCards-placeholderCard-3"
+    promise={
+      Object {
+        "fetching": false,
+        "value": Array [
+          Object {
+            "displayName": "name1",
+            "id": "1",
+            "type": "type1",
+          },
+          Object {
+            "displayName": "name2",
+            "id": "2",
+            "type": "type2",
+          },
+          Object {
+            "displayName": "name3",
+            "id": "3",
+            "type": "type3",
+          },
+        ],
+      }
     }
-  }
-  createPermission="create"
-  deletePermission="delete"
-  deleteStack={[Function]}
-  editPermission="edit"
-  openCreationForm={[Function]}
-  openPermission="open"
-  openStack={[Function]}
-  stacks={
-    Array [
+  >
+    <div>
+       
+      <WithStyles(StackCard)
+        deletePermission="delete"
+        deleteStack={[Function]}
+        editPermission="edit"
+        key="1"
+        openPermission="open"
+        openStack={[Function]}
+        stack={
+          Object {
+            "displayName": "name1",
+            "id": "1",
+            "type": "type1",
+          }
+        }
+        typeName="expectedTypeName"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "create",
+            "edit",
+          ]
+        }
+      />
+      <WithStyles(StackCard)
+        deletePermission="delete"
+        deleteStack={[Function]}
+        editPermission="edit"
+        key="2"
+        openPermission="open"
+        openStack={[Function]}
+        stack={
+          Object {
+            "displayName": "name2",
+            "id": "2",
+            "type": "type2",
+          }
+        }
+        typeName="expectedTypeName"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "create",
+            "edit",
+          ]
+        }
+      />
+      <WithStyles(StackCard)
+        deletePermission="delete"
+        deleteStack={[Function]}
+        editPermission="edit"
+        key="3"
+        openPermission="open"
+        openStack={[Function]}
+        stack={
+          Object {
+            "displayName": "name3",
+            "id": "3",
+            "type": "type3",
+          }
+        }
+        typeName="expectedTypeName"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "create",
+            "edit",
+          ]
+        }
+      />
+    </div>
+  </PromisedContentWrapper>
+  <ComponentWrapper
+    permission="create"
+    style={
       Object {
-        "displayName": "name1",
-        "id": "1",
-        "type": "type1",
-      },
-      Object {
-        "displayName": "name2",
-        "id": "2",
-        "type": "type2",
-      },
-      Object {
-        "displayName": "name3",
-        "id": "3",
-        "type": "type3",
-      },
-    ]
-  }
-  typeName="expectedTypeName"
-  userPermissions={[Function]}
-/>
+        "width": "100%",
+      }
+    }
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "create",
+        "edit",
+      ]
+    }
+  >
+    <div
+      className="StackCards-bottomControlDiv-2"
+    >
+      <WithStyles(NewStackButton)
+        onClick={[Function]}
+        typeName="expectedTypeName"
+      />
+    </div>
+  </ComponentWrapper>
+</div>
 `;
 
 exports[`StackCards creates correct snapshot for an empty array 1`] = `
-<StackCards
-  classes={
-    Object {
-      "bottomControlDiv": "StackCards-bottomControlDiv-2",
-      "noItemsMessage": "StackCards-noItemsMessage-3",
-      "stackDiv": "StackCards-stackDiv-1",
+<div
+  className="StackCards-stackDiv-1"
+>
+  <PromisedContentWrapper
+    fetchingClassName="StackCards-placeholderCard-3"
+    promise={
+      Object {
+        "fetching": false,
+        "value": Array [],
+      }
     }
-  }
-  createPermission="create"
-  deletePermission="delete"
-  deleteStack={[Function]}
-  editPermission="edit"
-  openCreationForm={[Function]}
-  openPermission="open"
-  openStack={[Function]}
-  stacks={Array []}
-  typeName="expectedTypeName"
-  userPermissions={[Function]}
-/>
+  >
+    <div>
+       
+      <div
+        className="StackCards-placeholderCard-3"
+      >
+        <WithStyles(ForwardRef(Typography))
+          variant="body1"
+        >
+          No items to display.
+        </WithStyles(ForwardRef(Typography))>
+      </div>
+    </div>
+  </PromisedContentWrapper>
+  <ComponentWrapper
+    permission="create"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "create",
+        "edit",
+      ]
+    }
+  >
+    <div
+      className="StackCards-bottomControlDiv-2"
+    >
+      <WithStyles(NewStackButton)
+        onClick={[Function]}
+        typeName="expectedTypeName"
+      />
+    </div>
+  </ComponentWrapper>
+</div>
 `;

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -16,7 +16,6 @@ import dataStorageActions from '../../actions/dataStorageActions';
 import modalDialogActions from '../../actions/modalDialogActions';
 import projectSelectors from '../../selectors/projectsSelectors';
 import notify from '../../components/common/notify';
-import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 import StackCards from '../../components/stacks/StackCards';
 
 const { projectPermissions: { PROJECT_KEY_STORAGE_CREATE, PROJECT_KEY_STORAGE_DELETE, PROJECT_KEY_STORAGE_OPEN, PROJECT_KEY_STORAGE_EDIT }, projectKeyPermission } = permissionTypes;
@@ -36,12 +35,6 @@ class DataStorageContainer extends Component {
     this.prohibitDeletion = this.prohibitDeletion.bind(this);
     this.chooseDialogue = this.chooseDialogue.bind(this);
     this.editDataStore = this.editDataStore.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps) {
-    const isFetching = nextProps.dataStorage.fetching;
-    const projectKeyChange = this.props.projectKey !== nextProps.projectKey;
-    return !isFetching || projectKeyChange;
   }
 
   componentDidUpdate(prevProps) {
@@ -119,22 +112,20 @@ class DataStorageContainer extends Component {
 
   render() {
     return (
-      <PromisedContentWrapper promise={this.props.dataStorage}>
-        <StackCards
-          stacks={this.props.dataStorage.value}
-          typeName={TYPE_NAME}
-          typeNamePlural={TYPE_NAME_PLURAL}
-          openStack={this.openDataStore}
-          deleteStack={this.chooseDialogue}
-          editStack={this.editDataStore}
-          openCreationForm={this.openCreationForm}
-          userPermissions={() => this.props.userPermissions}
-          createPermission={projectKeyPermission(PROJECT_KEY_STORAGE_CREATE, this.props.projectKey)}
-          openPermission={projectKeyPermission(PROJECT_KEY_STORAGE_OPEN, this.props.projectKey)}
-          deletePermission={projectKeyPermission(PROJECT_KEY_STORAGE_DELETE, this.props.projectKey)}
-          editPermission={projectKeyPermission(PROJECT_KEY_STORAGE_EDIT, this.props.projectKey)}
-        />
-      </PromisedContentWrapper>
+      <StackCards
+        stacks={this.props.dataStorage}
+        typeName={TYPE_NAME}
+        typeNamePlural={TYPE_NAME_PLURAL}
+        openStack={this.openDataStore}
+        deleteStack={this.chooseDialogue}
+        editStack={this.editDataStore}
+        openCreationForm={this.openCreationForm}
+        userPermissions={() => this.props.userPermissions}
+        createPermission={projectKeyPermission(PROJECT_KEY_STORAGE_CREATE, this.props.projectKey)}
+        openPermission={projectKeyPermission(PROJECT_KEY_STORAGE_OPEN, this.props.projectKey)}
+        deletePermission={projectKeyPermission(PROJECT_KEY_STORAGE_DELETE, this.props.projectKey)}
+        editPermission={projectKeyPermission(PROJECT_KEY_STORAGE_EDIT, this.props.projectKey)}
+      />
     );
   }
 }

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
@@ -128,7 +128,7 @@ describe('DataStorageContainer', () => {
       getCredentialsMock.mockReturnValue(Promise.resolve({ value: { url: 'expectedUrl', accessKey: 'expectedKey' } }));
       const props = generateProps();
       const output = shallowRenderPure(props);
-      const openStack = output.childAt(0).prop('openStack');
+      const openStack = output.prop('openStack');
 
       // Act/Assert
       expect(getCredentialsMock).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe('DataStorageContainer', () => {
 
       // Act/Assert
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       deleteStack(stack);
       expect(openModalDialogMock).toHaveBeenCalledTimes(1);
@@ -164,7 +164,7 @@ describe('DataStorageContainer', () => {
 
       // Act/Assert
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       deleteStack(stack);
       expect(openModalDialogMock).toHaveBeenCalledTimes(1);
@@ -179,7 +179,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       deleteStack(stack);
 
       // Assert
@@ -196,7 +196,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       deleteStack(stack);
 
       // Assert
@@ -213,7 +213,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       deleteStack(stack);
       const { onSubmit } = openModalDialogMock.mock.calls[0][1];
 
@@ -233,7 +233,7 @@ describe('DataStorageContainer', () => {
 
       // Act/Assert
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       openCreationForm(stack);
       expect(openModalDialogMock).toHaveBeenCalledTimes(1);
@@ -248,7 +248,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       openCreationForm(stack);
 
@@ -266,7 +266,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       openCreationForm();
       const { onSubmit } = openModalDialogMock.mock.calls[0][1];
 
@@ -289,7 +289,7 @@ describe('DataStorageContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const editStack = output.childAt(0).prop('editStack');
+      const editStack = output.prop('editStack');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       editStack(stack);
 

--- a/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
@@ -48,8 +48,16 @@ Object {
 `;
 
 exports[`DataStorageContainer is a container which passes correct props to StackCard 1`] = `
-<PromisedContentWrapper
-  promise={
+<WithStyles(StackCards)
+  createPermission="projects:project99:storage:create"
+  deletePermission="projects:project99:storage:delete"
+  deleteStack={[Function]}
+  editPermission="projects:project99:storage:edit"
+  editStack={[Function]}
+  openCreationForm={[Function]}
+  openPermission="projects:project99:storage:open"
+  openStack={[Function]}
+  stacks={
     Object {
       "fetching": false,
       "value": Array [
@@ -59,26 +67,8 @@ exports[`DataStorageContainer is a container which passes correct props to Stack
       ],
     }
   }
->
-  <WithStyles(StackCards)
-    createPermission="projects:project99:storage:create"
-    deletePermission="projects:project99:storage:delete"
-    deleteStack={[Function]}
-    editPermission="projects:project99:storage:edit"
-    editStack={[Function]}
-    openCreationForm={[Function]}
-    openPermission="projects:project99:storage:open"
-    openStack={[Function]}
-    stacks={
-      Array [
-        Object {
-          "props": "expectedPropValue",
-        },
-      ]
-    }
-    typeName="Data Store"
-    typeNamePlural="Data Stores"
-    userPermissions={[Function]}
-  />
-</PromisedContentWrapper>
+  typeName="Data Store"
+  typeNamePlural="Data Stores"
+  userPermissions={[Function]}
+/>
 `;

--- a/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
+++ b/code/workspaces/web-app/src/containers/projects/ProjectsContainer.js
@@ -10,7 +10,6 @@ import theme from '../../theme';
 import projectActions from '../../actions/projectActions';
 import projectSelectors from '../../selectors/projectsSelectors';
 import modalDialogActions from '../../actions/modalDialogActions';
-import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
 import StackCards from '../../components/stacks/StackCards';
 import { MODAL_TYPE_CREATE_PROJECT, MODAL_TYPE_ROBUST_CONFIRMATION } from '../../constants/modaltypes';
 import notify from '../../components/common/notify';
@@ -84,10 +83,18 @@ class ProjectsContainer extends Component {
     this.props.actions.loadProjects();
   }
 
-  adaptProjectsToStacks() {
-    return this.props.projects.value
-      ? this.props.projects.value.map(projectToStack)
-      : [];
+  adaptProjectsToStacks(projects) {
+    return {
+      ...projects,
+      value: projects.value ? projects.value.map(projectToStack) : [],
+    };
+  }
+
+  filterProjectStacks(projectStacks, searchText) {
+    return {
+      ...projectStacks,
+      value: projectStacks.value.filter(stack => stackMatchesFilter(stack, searchText)),
+    };
   }
 
   projectUserPermissions(project) {
@@ -165,25 +172,27 @@ class ProjectsContainer extends Component {
 
   render() {
     const { projects, history } = this.props;
+    const filteredStacks = this.filterProjectStacks(
+      this.adaptProjectsToStacks(projects),
+      this.state.searchText,
+    );
     return (
-      <PromisedContentWrapper promise={projects}>
-        <div>
-          {this.renderControls()}
-          <StackCards
-            stacks={this.adaptProjectsToStacks().filter(stack => stackMatchesFilter(stack, this.state.searchText))}
-            typeName={TYPE_NAME}
-            typeNamePlural={TYPE_NAME_PLURAL}
-            openStack={project => history.push(`/projects/${project.key}/info`)}
-            deleteStack={this.confirmDeleteProject}
-            openCreationForm={this.openCreationForm}
-            userPermissions={project => [...this.projectUserPermissions(project), ...this.props.userPermissions]}
-            createPermission={SYSTEM_INSTANCE_ADMIN}
-            openPermission={PROJECT_OPEN_PERMISSION}
-            deletePermission=""
-            editPermission=""
-          />
-        </div>
-      </PromisedContentWrapper>
+      <div>
+        {this.renderControls()}
+        <StackCards
+          stacks={filteredStacks}
+          typeName={TYPE_NAME}
+          typeNamePlural={TYPE_NAME_PLURAL}
+          openStack={project => history.push(`/projects/${project.key}/info`)}
+          deleteStack={this.confirmDeleteProject}
+          openCreationForm={this.openCreationForm}
+          userPermissions={project => [...this.projectUserPermissions(project), ...this.props.userPermissions]}
+          createPermission={SYSTEM_INSTANCE_ADMIN}
+          openPermission={PROJECT_OPEN_PERMISSION}
+          deletePermission=""
+          editPermission=""
+        />
+      </div>
     );
   }
 }

--- a/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
@@ -30,58 +30,44 @@ Array [
 `;
 
 exports[`ProjectsContainer is a container which passes correct props to StackCard 1`] = `
-<PromisedContentWrapper
-  promise={
-    Object {
-      "fetching": false,
-      "value": Array [
+<div>
+  <div
+    className="controlContainer"
+  >
+    <WithStyles(ForwardRef(TextField))
+      InputProps={
         Object {
-          "accessible": true,
-          "description": "A project description",
-          "id": 123,
-          "key": "project2",
-          "name": "A project name",
-        },
-      ],
-    }
-  }
->
-  <div>
-    <div
-      className="controlContainer"
-    >
-      <WithStyles(ForwardRef(TextField))
-        InputProps={
-          Object {
-            "disableUnderline": true,
-            "style": Object {
-              "backgroundColor": "rgba(47, 62, 70, 0.2)",
-              "borderRadius": 5,
-            },
-          }
+          "disableUnderline": true,
+          "style": Object {
+            "backgroundColor": "rgba(47, 62, 70, 0.2)",
+            "borderRadius": 5,
+          },
         }
-        autoFocus={true}
-        className="searchTextField"
-        hiddenLabel={true}
-        id="search"
-        margin="dense"
-        onChange={[Function]}
-        placeholder="Filter projects..."
-        type="search"
-        value=""
-        variant="filled"
-      />
-    </div>
-    <WithStyles(StackCards)
-      createPermission="system:instance:admin"
-      deletePermission=""
-      deleteStack={[Function]}
-      editPermission=""
-      openCreationForm={[Function]}
-      openPermission="project.open"
-      openStack={[Function]}
-      stacks={
-        Array [
+      }
+      autoFocus={true}
+      className="searchTextField"
+      hiddenLabel={true}
+      id="search"
+      margin="dense"
+      onChange={[Function]}
+      placeholder="Filter projects..."
+      type="search"
+      value=""
+      variant="filled"
+    />
+  </div>
+  <WithStyles(StackCards)
+    createPermission="system:instance:admin"
+    deletePermission=""
+    deleteStack={[Function]}
+    editPermission=""
+    openCreationForm={[Function]}
+    openPermission="project.open"
+    openStack={[Function]}
+    stacks={
+      Object {
+        "fetching": false,
+        "value": Array [
           Object {
             "accessible": true,
             "description": "A project description",
@@ -91,12 +77,12 @@ exports[`ProjectsContainer is a container which passes correct props to StackCar
             "status": "ready",
             "type": "project",
           },
-        ]
+        ],
       }
-      typeName="Project"
-      typeNamePlural="Projects"
-      userPermissions={[Function]}
-    />
-  </div>
-</PromisedContentWrapper>
+    }
+    typeName="Project"
+    typeNamePlural="Projects"
+    userPermissions={[Function]}
+  />
+</div>
 `;

--- a/code/workspaces/web-app/src/containers/stacks/StacksContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/stacks/StacksContainer.spec.js
@@ -109,7 +109,7 @@ describe('StacksContainer', () => {
         closeModalDialog: closeModalDialogMock,
         resetForm: restFormMock,
       },
-      projectKey: 'projtest',
+      projectKey: { fetching: false, value: 'projtest' },
     });
 
     beforeEach(() => jest.clearAllMocks());
@@ -154,7 +154,7 @@ describe('StacksContainer', () => {
       getUrlMock.mockReturnValue(Promise.resolve({ value: { redirectUrl: 'expectedUrl' } }));
       const props = generateProps();
       const output = shallowRenderPure(props);
-      const openStack = output.childAt(0).prop('openStack');
+      const openStack = output.prop('openStack');
 
       // Act/Assert
       expect(getUrlMock).not.toHaveBeenCalled();
@@ -173,7 +173,7 @@ describe('StacksContainer', () => {
       getUrlMock.mockReturnValue(Promise.reject(new Error('no url')));
       const props = generateProps();
       const output = shallowRenderPure(props);
-      const openStack = output.childAt(0).prop('openStack');
+      const openStack = output.prop('openStack');
 
       // Act/Assert
       expect(getUrlMock).not.toHaveBeenCalled();
@@ -194,7 +194,7 @@ describe('StacksContainer', () => {
 
       // Act/Assert
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       deleteStack(stack);
       expect(openModalDialogMock).toHaveBeenCalledTimes(1);
@@ -209,7 +209,7 @@ describe('StacksContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       deleteStack(stack);
 
       // Assert
@@ -226,7 +226,7 @@ describe('StacksContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const deleteStack = output.childAt(0).prop('deleteStack');
+      const deleteStack = output.prop('deleteStack');
       deleteStack(stack);
       const { onSubmit } = openModalDialogMock.mock.calls[0][1];
 
@@ -246,7 +246,7 @@ describe('StacksContainer', () => {
 
       // Act/Assert
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       openCreationForm(stack);
       expect(openModalDialogMock).toHaveBeenCalledTimes(1);
@@ -261,7 +261,7 @@ describe('StacksContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       expect(openModalDialogMock).not.toHaveBeenCalled();
       openCreationForm(stack);
 
@@ -279,7 +279,7 @@ describe('StacksContainer', () => {
 
       // Act
       const output = shallowRenderPure(props);
-      const openCreationForm = output.childAt(0).prop('openCreationForm');
+      const openCreationForm = output.prop('openCreationForm');
       openCreationForm();
       const { onSubmit } = openModalDialogMock.mock.calls[0][1];
 

--- a/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
@@ -4,6 +4,8 @@ exports[`StacksContainer is a connected component which binds correct actions 1`
 Array [
   "loadStacks",
   "loadStacksByCategory",
+  "updateStacks",
+  "updateStacksByCategory",
   "getUrl",
   "openStack",
   "createStack",
@@ -29,8 +31,15 @@ Object {
 `;
 
 exports[`StacksContainer is a container which passes correct props to StackCard 1`] = `
-<PromisedContentWrapper
-  promise={
+<WithStyles(StackCards)
+  createPermission="projects:projtest:stacks:create"
+  deletePermission="projects:projtest:stacks:delete"
+  deleteStack={[Function]}
+  editPermission="projects:projtest:stacks:edit"
+  openCreationForm={[Function]}
+  openPermission="projects:projtest:stacks:open"
+  openStack={[Function]}
+  stacks={
     Object {
       "fetching": false,
       "value": Array [
@@ -43,27 +52,7 @@ exports[`StacksContainer is a container which passes correct props to StackCard 
       ],
     }
   }
->
-  <WithStyles(StackCards)
-    createPermission="projects:projtest:stacks:create"
-    deletePermission="projects:projtest:stacks:delete"
-    deleteStack={[Function]}
-    editPermission="projects:projtest:stacks:edit"
-    openCreationForm={[Function]}
-    openPermission="projects:projtest:stacks:open"
-    openStack={[Function]}
-    stacks={
-      Array [
-        Object {
-          "prop": "prop1",
-        },
-        Object {
-          "prop": "prop2",
-        },
-      ]
-    }
-    typeName="Notebook"
-    userPermissions={[Function]}
-  />
-</PromisedContentWrapper>
+  typeName="Notebook"
+  userPermissions={[Function]}
+/>
 `;

--- a/code/workspaces/web-app/src/reducers/stacksReducer.js
+++ b/code/workspaces/web-app/src/reducers/stacksReducer.js
@@ -5,11 +5,12 @@ import {
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
 import {
-  LOAD_STACKS_ACTION, LOAD_STACKS_BY_CATEGORY_ACTION,
+  LOAD_STACKS_ACTION, LOAD_STACKS_BY_CATEGORY_ACTION, UPDATE_STACKS_ACTION, UPDATE_STACKS_BY_CATEGORY_ACTION,
 } from '../actions/stackActions';
 
 const initialState = {
-  fetching: false,
+  fetching: false, // for calling query for first time
+  updating: false, // for calling query again to get updated statuses
   value: [],
   error: null,
 };
@@ -22,6 +23,16 @@ export default typeToReducer({
   },
   [LOAD_STACKS_BY_CATEGORY_ACTION]: {
     [PROMISE_TYPE_PENDING]: () => ({ ...initialState, fetching: true }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
+  },
+  [UPDATE_STACKS_ACTION]: {
+    [PROMISE_TYPE_PENDING]: () => ({ ...initialState, updating: true }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
+  },
+  [UPDATE_STACKS_BY_CATEGORY_ACTION]: {
+    [PROMISE_TYPE_PENDING]: () => ({ ...initialState, updating: true }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
   },

--- a/code/workspaces/web-app/src/reducers/stacksReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/stacksReducer.spec.js
@@ -1,48 +1,175 @@
 import stacksReducer from './stacksReducer';
 import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
-import { LOAD_STACKS_ACTION } from '../actions/stackActions';
+import {
+  LOAD_STACKS_ACTION,
+  LOAD_STACKS_BY_CATEGORY_ACTION,
+  UPDATE_STACKS_ACTION,
+  UPDATE_STACKS_BY_CATEGORY_ACTION,
+} from '../actions/stackActions';
 
 describe('stacksReducer', () => {
-  it('should return the initial state', () => {
+  it('should return the initial state when previous state undefined', () => {
     // Act/Assert
-    expect(stacksReducer(undefined, {})).toEqual({ fetching: false, value: [], error: null });
+    expect(stacksReducer(undefined, {})).toEqual({ fetching: false, updating: false, value: [], error: null });
   });
 
-  it('should handle LOAD_NOTEBOOKS_PENDING', () => {
-    // Arrange
-    const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_PENDING}`;
-    const action = { type };
+  describe('it should handle LOAD_STACKS', () => {
+    it('PENDING', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
 
-    // Act
-    const nextstate = stacksReducer({ error: null, fetching: false, value: undefined }, action);
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: null, fetching: true, value: [] });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: true, updating: false, value: [] });
+    });
+
+    it('SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ notebook: 'firstStore' }, { notebook: 'secondStore' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: payload });
+    });
+
+    it('FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+    });
   });
 
-  it('should handle LOAD_NOTEBOOKS_SUCCESS', () => {
-    // Arrange
-    const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
-    const payload = [{ notebook: 'firstStore' }, { notebook: 'secondStore' }];
-    const action = { type, payload };
+  describe('it should handle LOAD_STACKS_BY_CATEGORY', () => {
+    it('PENDING', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
 
-    // Act
-    const nextstate = stacksReducer({ error: null, fetching: false, value: undefined }, action);
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: null, fetching: false, value: payload });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: true, updating: false, value: [] });
+    });
+
+    it('SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ notebook: 'firstStore' }, { notebook: 'secondStore' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: payload });
+    });
+
+    it('FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+    });
   });
 
-  it('should handle LOAD_NOTEBOOKS_FAILURE', () => {
-    // Arrange
-    const type = `${LOAD_STACKS_ACTION}_${PROMISE_TYPE_FAILURE}`;
-    const payload = 'example error';
-    const action = { type, payload };
+  describe('should handle UPDATE_STACKS', () => {
+    it('PENDING', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
 
-    // Act
-    const nextstate = stacksReducer({ error: null, fetching: false, value: undefined }, action);
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
 
-    // Assert
-    expect(nextstate).toEqual({ error: payload, fetching: false, value: [] });
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: true, value: [] });
+    });
+
+    it('SUCCESS', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ notebook: 'firstStore' }, { notebook: 'secondStore' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: payload });
+    });
+
+    it('FAILURE', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+    });
+  });
+
+  describe('should handle UPDATE_STACKS_BY_CATEGORY', () => {
+    it('PENDING', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: true, value: [] });
+    });
+
+    it('SUCCESS', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ notebook: 'firstStore' }, { notebook: 'secondStore' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: payload });
+    });
+
+    it('FAILURE', () => {
+      // Arrange
+      const type = `${UPDATE_STACKS_BY_CATEGORY_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = stacksReducer({ error: null, fetching: false, updating: false, value: undefined }, action);
+
+      // Assert
+      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+    });
   });
 });


### PR DESCRIPTION
* Fix problem where stacks for previously selected project displayed before they are updated.
* Fix problem when `no stacks to show` message being shown on first stack load.
* These issues fixed by splitting out the polling action into an `updating` action rather than a `fetching` action. This enables separate handling of the two events allowing the UI to properly handle the events.

* Move promised content wrapper into `StackCards` component so the spinner is in the area the stacks are loaded into. This means the stack cards structure remains in the same place and any buttons/filtering components are always in place. This makes the loading process much less jarring.
