### PR TITLE
feat(web app): make multiline inputs visibly larger than single line

### DIFF
--- a/code/workspaces/web-app/src/components/common/form/controlStyles.js
+++ b/code/workspaces/web-app/src/components/common/form/controlStyles.js
@@ -10,3 +10,11 @@ export const fieldStyleProps = {
   variant: 'outlined',
   fullWidth: true,
 };
+
+export const multilineFieldStyleProps = {
+  ...fieldStyleProps,
+  InputProps: {
+    rows: 3,
+    rowsMax: 10,
+  },
+};

--- a/code/workspaces/web-app/src/components/common/form/controls.js
+++ b/code/workspaces/web-app/src/components/common/form/controls.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import MenuItem from '@material-ui/core/MenuItem';
-import { fieldStyle, fieldStyleProps } from './controlStyles';
+import { fieldStyle, fieldStyleProps, multilineFieldStyleProps } from './controlStyles';
 import theme from '../../../theme';
 import PrimaryActionButton from '../buttons/PrimaryActionButton';
 import SecondaryActionButton from '../buttons/SecondaryActionButton';
@@ -25,7 +25,7 @@ export const renderTextArea = ({ input, label, meta: { touched, error }, ...cust
     multiline
     {...input}
     {...custom}
-    {...fieldStyleProps}
+    {...multilineFieldStyleProps}
   />;
 
 export const renderSelectField = ({ input, label, meta: { touched, error }, options, ...custom }) => (

--- a/code/workspaces/web-app/src/components/modal/CreateProjectDialog.js
+++ b/code/workspaces/web-app/src/components/modal/CreateProjectDialog.js
@@ -6,7 +6,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import CreateProjectForm from '../projects/CreateProjectForm';
 
 const CreateProjectDialog = ({ onSubmit, onCancel }) => (
-  <Dialog open={true}>
+  <Dialog open={true} fullWidth>
     <DialogTitle>Create New Project</DialogTitle>
     <DialogContent>
       <CreateProjectForm onSubmit={onSubmit} onCancel={onCancel} />

--- a/code/workspaces/web-app/src/components/modal/__snapshots__/CreateProjectDialog.spec.js.snap
+++ b/code/workspaces/web-app/src/components/modal/__snapshots__/CreateProjectDialog.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`CreateProjectDialog renders to match snapshot passing function props to form 1`] = `
 <WithStyles(ForwardRef(Dialog))
+  fullWidth={true}
   open={true}
 >
   <WithStyles(ForwardRef(DialogTitle))>


### PR DESCRIPTION
* Update project creation dialog so that it is larger, especially the Description field. 

* Update the style of multiline input fields so they are visibly distinct from single line inputs.