### PR TITLE
WIP: specify namespace in internalEndpoint

### DIFF
--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/stackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/stackManager.spec.js.snap
@@ -25,7 +25,7 @@ Array [
         "domain": "expectedDatalabDomain",
         "name": "expectedDatalabName",
       },
-      "internalEndpoint": "http://expectedType-expectedName",
+      "internalEndpoint": "http://expectedType-expectedName.project",
       "name": "expectedName",
       "projectKey": "project",
       "status": "requested",

--- a/code/workspaces/infrastructure-api/src/stacks/stackManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackManager.js
@@ -23,7 +23,7 @@ function createStack(user, params) {
         category: stack.category,
         status: REQUESTED,
         url: `https://${projectKey}-${name}.${config.get('datalabDomain')}`,
-        internalEndpoint: `http://${params.type}-${name}`,
+        internalEndpoint: `http://${params.type}-${name}.${projectKey}`,
       },
     )
       .then(() => response));


### PR DESCRIPTION
As per https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/ the internal address needs to be addressable from the infrastructure-api which is in a different namespace hence the namespace must be specified.