### PR TITLE
docs(dev env): strike through missing link and add new minikube step

### DIFF
--- a/code/development-env/README.md
+++ b/code/development-env/README.md
@@ -36,7 +36,8 @@
   * `minikube start`
 * (Recommended) [Install `kubectx` and `kubens`](https://github.com/ahmetb/kubectx)
   for easy context and namespace switching.
-* When creating a new minikube cluster follow these [instructions](../manifests/README.md).
+* ~~When creating a new minikube cluster follow these [instructions](../manifests/README.md).~~
+* Create a gluster storage class by running `kubectl apply -f ./config/manifests/minikube-storage.yml`
 
 ### Install NodeJS packages
 


### PR DESCRIPTION
Crossed through mistake as it points to directory with other manifests that might be useful to future readers.