### PR TITLE
feat: ensure no auth-url is in ingress annotation for public sites

### DIFF
--- a/code/workspaces/infrastructure-api/resources/default.ingress.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.ingress.template.yml
@@ -4,7 +4,9 @@ kind: Ingress
 metadata:
   name: {{ name }}
   annotations:
+{{#privateEndpoint}}
     nginx.ingress.kubernetes.io/auth-url: {{ &authServiceUrl }}
+{{/privateEndpoint}}
     nginx.ingress.kubernetes.io/auth-signin: {{ &authSigninUrl }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ &maxBodySize }}
 {{#rewriteTarget}}

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Ingress generator should add auth-url for privateEndpoints 1`] = `
+"---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: name-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 500m
+spec:
+  tls:
+  - hosts:
+    - project-name.datalabs.localhost
+  rules:
+  - host: project-name.datalabs.localhost
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: name-service
+          servicePort: 80
+"
+`;
+
 exports[`Ingress generator should add proxy-timeout options if supplied 1`] = `
 "---
 apiVersion: extensions/v1beta1
@@ -114,5 +139,30 @@ spec:
         backend:
           serviceName: name-service
           servicePort: 8000
+"
+`;
+
+exports[`Ingress generator should not add auth-url for a non-private endpoints 1`] = `
+"---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: name-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 500m
+spec:
+  tls:
+  - hosts:
+    - project-name.datalabs.localhost
+  rules:
+  - host: project-name.datalabs.localhost
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: name-service
+          servicePort: 80
 "
 `;

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
@@ -149,7 +149,6 @@ kind: Ingress
 metadata:
   name: name-ingress
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
     nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
     nginx.ingress.kubernetes.io/proxy-body-size: 500m
 spec:

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.js
@@ -1,9 +1,10 @@
 import config from '../config/config';
 import { IngressTemplates, generateManifest } from './manifestGenerator';
 
-function createIngress({ name, projectKey, ingressName, serviceName, port, connectPort, rewriteTarget, proxyTimeout }) {
+function createIngress({ name, projectKey, ingressName, serviceName, port, connectPort, rewriteTarget, proxyTimeout, visible }) {
   const host = createSniInfo(name, projectKey);
   const paths = createPathInfo(serviceName, port, connectPort);
+  const privateEndpoint = visible !== 'public';
   const context = {
     name: ingressName,
     authServiceUrl: `${config.get('authorisationService')}/auth`,
@@ -12,6 +13,7 @@ function createIngress({ name, projectKey, ingressName, serviceName, port, conne
     rewriteTarget,
     proxyTimeout,
     service: { host, paths },
+    privateEndpoint,
   };
 
   return generateManifest(context, IngressTemplates.DEFAULT_INGRESS);

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
@@ -65,7 +65,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
-      privateEndpoint: true,
+      visible: 'private',
     };
     const template = ingressGenerator.createIngress(options);
 
@@ -79,7 +79,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
-      privateEndpoint: false,
+      visible: 'public',
     };
     const template = ingressGenerator.createIngress(options);
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
@@ -57,4 +57,32 @@ describe('Ingress generator', () => {
 
     return expect(template).resolves.toMatchSnapshot();
   });
+
+  it('should add auth-url for privateEndpoints', () => {
+    const options = {
+      name: 'name',
+      projectKey: 'project',
+      ingressName: 'name-ingress',
+      serviceName: 'name-service',
+      port: 80,
+      privateEndpoint: true,
+    };
+    const template = ingressGenerator.createIngress(options);
+
+    return expect(template).resolves.toMatchSnapshot();
+  });
+
+  it('should not add auth-url for a non-private endpoints', () => {
+    const options = {
+      name: 'name',
+      projectKey: 'project',
+      ingressName: 'name-ingress',
+      serviceName: 'name-service',
+      port: 80,
+      privateEndpoint: false,
+    };
+    const template = ingressGenerator.createIngress(options);
+
+    return expect(template).resolves.toMatchSnapshot();
+  });
 });

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -55,7 +55,7 @@ export const createPySparkConfigMap = params => () => {
 };
 
 export const createIngressRule = (params, generator) => (service) => {
-  const { name, projectKey, type } = params;
+  const { name, projectKey, type, visible } = params; // eslint-disable-line no-unused-vars
   const ingressName = nameGenerator.deploymentName(name, type);
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -55,7 +55,7 @@ export const createPySparkConfigMap = params => () => {
 };
 
 export const createIngressRule = (params, generator) => (service) => {
-  const { name, projectKey, type, visible } = params; // eslint-disable-line no-unused-vars
+  const { name, projectKey, type } = params;
   const ingressName = nameGenerator.deploymentName(name, type);
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];


### PR DESCRIPTION
This is to ensure that when users select `public` for a site, the auth-url annotation is not used on the ingress and external users can access it without going through authentication