### PR TITLE
fix: correct grantSudo parameter for Jupyter

### DIFF
--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -9,7 +9,7 @@ const containerInfo = yaml.safeLoad(fs.readFileSync(config.get('containerInfoPat
 function createJupyterDeployment({ projectKey, deploymentName, notebookName, type, volumeMount }) {
   const context = {
     name: deploymentName,
-    grantSudo: true,
+    grantSudo: 'yes',
     domain: `${projectKey}-${notebookName}.${config.get('datalabDomain')}`,
     jupyter: {
       imageName: containerInfo.JUPYTER_IMAGE,
@@ -27,7 +27,7 @@ function createJupyterDeployment({ projectKey, deploymentName, notebookName, typ
 function createJupyterlabDeployment({ projectKey, deploymentName, notebookName, type, volumeMount }) {
   const context = {
     name: deploymentName,
-    grantSudo: true,
+    grantSudo: 'yes',
     domain: `${projectKey}-${notebookName}.${config.get('datalabDomain')}`,
     jupyterlab: {
       imageName: containerInfo.JUPYTERLAB_IMAGE,


### PR DESCRIPTION
We had this setting incorrectly configured as per the documentation [https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html](url)