### PR TITLE
NERCDL-536 Backend for Logs Extraction

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/logsService.js
+++ b/code/workspaces/client-api/src/dataaccess/logsService.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import config from '../config';
+
+const infraServiceUrl = `${config.get('infrastructureApi')}`;
+
+async function getLogsByName(projectKey, name, token) {
+  const response = await axios.get(`${infraServiceUrl}/logs/${projectKey}/${name}`, generateOptions(token));
+  return response.data;
+}
+
+const generateOptions = token => ({
+  headers: {
+    authorization: token,
+  },
+});
+
+export default {
+  getLogsByName,
+};

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -12,6 +12,7 @@ import minioTokenService from '../dataaccess/minioTokenService';
 import stackUrlService from '../dataaccess/stackUrlService';
 import projectService from '../dataaccess/projectService';
 import storageService from '../infrastructure/storageService';
+import logsService from '../dataaccess/logsService';
 
 const { elementPermissions: { STORAGE_CREATE, STORAGE_DELETE, STORAGE_LIST, STORAGE_EDIT, STORAGE_OPEN } } = permissionTypes;
 const { elementPermissions: { STACKS_CREATE, STACKS_DELETE, STACKS_LIST, STACKS_OPEN } } = permissionTypes;
@@ -39,6 +40,7 @@ const resolvers = {
     projects: (obj, args, { token }) => projectService.listProjects(token),
     project: (obj, args, { token }) => projectService.getProjectByKey(args.projectKey, token),
     checkProjectKeyUniqueness: (obj, { projectKey }, { user, token }) => instanceAdminWrapper(user, () => projectService.isProjectKeyUnique(projectKey, token)),
+    logs: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_CREATE, user, () => logsService.getLogsByName(args.projectKey, args.name, token)),
   },
 
   Mutation: {

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -30,6 +30,9 @@ type Query {
     # Checks internal name is unique.
     checkNameUniqueness(projectKey: String!, name: String!): Boolean
 
+    # Retrieve pod logs 
+    logs(projectKey: String!, name: String!): String
+
     # List of users within the current DataLab
     users: [User]
 

--- a/code/workspaces/infrastructure-api/src/config/routes.js
+++ b/code/workspaces/infrastructure-api/src/config/routes.js
@@ -5,6 +5,7 @@ import stackRouter from '../routers/stackRouter';
 import stacksRouter from '../routers/stacksRouter';
 import volumeRouter from '../routers/volumeRouter';
 import volumesRouter from '../routers/volumesRouter';
+import logsRouter from '../routers/logsRouter';
 
 function configureRoutes(app) {
   app.get('/status', status.status);
@@ -14,6 +15,7 @@ function configureRoutes(app) {
   app.use('/stacks', stacksRouter);
   app.use('/volume', volumeRouter);
   app.use('/volumes', volumesRouter);
+  app.use('/logs', logsRouter);
 }
 
 export default { configureRoutes };

--- a/code/workspaces/infrastructure-api/src/controllers/logsController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/logsController.js
@@ -1,0 +1,43 @@
+import { service } from 'service-chassis';
+import { check, matchedData } from 'express-validator';
+import logsApi from '../kubernetes/logsApi';
+import logger from '../config/logger';
+import podsApi from '../kubernetes/podsApi';
+import stackRepository from '../dataaccess/stacksRepository';
+
+// Logs are only exposed for sites initially, not notebooks
+const CATEGORY = 'publish';
+
+async function getByName(request, response) {
+  const { user } = request;
+  const { projectKey, name } = matchedData(request);
+
+  return stackRepository.getOneByNameUserAndCategory(projectKey, user, name, CATEGORY)
+    .then(stack => podsApi.getPodName(`${stack[0].type}-${stack[0].name}`, stack[0].projectKey))
+    .then(podName => logsApi.readNamespacedPodLog(projectKey, podName))
+    .then(logs => response.send(logs))
+    .catch((err) => {
+      logger.error(`Error retrieving logs for ${name}: ${JSON.stringify(err)}`);
+      response.status(404).send();
+    });
+}
+
+const existsCheck = fieldName => check(fieldName)
+  .exists()
+  .withMessage(`${fieldName} must be specified`)
+  .trim()
+  .isLength({ min: 1 })
+  .withMessage(`${fieldName} must have content`);
+
+const projectKeyCheck = existsCheck('projectKey');
+
+const getByNameValidator = service.middleware.validator([
+  projectKeyCheck,
+  check('name')
+    .exists(),
+], logger);
+
+export default {
+  getByNameValidator,
+  getByName,
+};

--- a/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.js
@@ -51,6 +51,15 @@ function getOneByName(projectKey, user, name) {
     .exec();
 }
 
+function getOneByNameUserAndCategory(projectKey, user, name, category) {
+  return Stack()
+    .find({ category })
+    .findOne({ name })
+    .filterOneByProject(projectKey)
+    .filterByUser(user)
+    .exec();
+}
+
 function createOrUpdate(projectKey, user, stack) {
   return Stack()
     .find()
@@ -94,6 +103,7 @@ export default {
   getAllByCategory,
   getOneById,
   getOneByName,
+  getOneByNameUserAndCategory,
   getAllByVolumeMount,
   createOrUpdate,
   deleteStack,

--- a/code/workspaces/infrastructure-api/src/kubernetes/logsApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/logsApi.js
@@ -1,0 +1,19 @@
+import { getCoreV1Api } from './kubeConfig';
+import logger from '../config/logger';
+
+async function readNamespacedPodLog(namespaceName, podName) {
+  const k8sApi = getCoreV1Api();
+
+  try {
+    const response = await k8sApi.readNamespacedPodLog(podName, namespaceName);
+
+    return response.body;
+  } catch (error) {
+    logger.error(`Unable to retrieve pod logs for ${podName}: ${error}`);
+    return null;
+  }
+}
+
+export default {
+  readNamespacedPodLog,
+};

--- a/code/workspaces/infrastructure-api/src/kubernetes/podsApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/podsApi.js
@@ -20,11 +20,21 @@ function getStacks() {
     .then(pods => pods.filter(({ type }) => stackNames.includes(type)));
 }
 
+async function getPodName(deploymentName, namespaceName) {
+  const pods = await getPods();
+  try {
+    return pods.find(pod => pod.name === deploymentName && pod.namespace === namespaceName).podName;
+  } catch (error) {
+    return undefined;
+  }
+}
+
 const handlePodlist = ({ items }) => items.map(pod => ({
   name: get(pod, 'metadata.labels.name'),
   namespace: get(pod, 'metadata.namespace'),
   type: get(pod, `metadata.labels.${SELECTOR_LABEL}`),
   status: handlePodStatus(pod),
+  podName: get(pod, 'metadata.name'),
 }));
 
 const handlePodStatus = (pod) => {
@@ -43,4 +53,4 @@ const getContainerStateReason = (containers, targetState) => {
   return undefined;
 };
 
-export default { getStacks };
+export default { getStacks, getPodName };

--- a/code/workspaces/infrastructure-api/src/routers/logsRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/logsRouter.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import { service } from 'service-chassis';
+import { permissionTypes } from 'common';
+import { projectPermissionWrapper } from '../auth/permissionMiddleware';
+import logs from '../controllers/logsController';
+
+const { errorWrapper: ew } = service.middleware;
+
+const {
+  projectPermissions: { PROJECT_KEY_STACKS_CREATE },
+} = permissionTypes;
+
+const logsRouter = express.Router();
+
+logsRouter.get(
+  '/:projectKey/:name',
+  projectPermissionWrapper(PROJECT_KEY_STACKS_CREATE),
+  logs.getByNameValidator,
+  ew(logs.getByName),
+);
+
+export default logsRouter;


### PR DESCRIPTION
Would be good to get your views on these changes at the moment - this adds another graphql/infrastructure API route to extract logs from sites. 

Particularly how this endpoint is secured doesn't really fit into the permissions scheme, would the right approach be to add a whole new permission level for site logs? I've used stack create for the moment as you need to have created it/own it anyway to view the logs.