### PR TITLE
fix: increase character limit on creation forms

### DIFF
--- a/code/workspaces/infrastructure-api/src/controllers/stackController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.js
@@ -95,9 +95,9 @@ const withNameValidator = [
   checkExistsWithMsg('projectKey'),
   checkExistsWithMsg('name')
     .isAscii()
-    .withMessage('Name must only use the characters a-z')
-    .isLength({ min: 4, max: 12 })
-    .withMessage('Name must be 4-12 characters long'),
+    .withMessage('Name must only use the characters a-z, 0-9')
+    .isLength({ min: 4, max: 16 })
+    .withMessage('Name must be 4-16 characters long'),
 ];
 
 const deleteStackValidator = [

--- a/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
@@ -73,14 +73,14 @@ describe('Stack Controller', () => {
       const requestBody = mutationRequestBody();
       requestBody.name = '';
       return createValidatedRequest(requestBody, stackController.createStackValidator)
-        .then(() => expectValidationError('name', 'Name must only use the characters a-z'));
+        .then(() => expectValidationError('name', 'Name must only use the characters a-z, 0-9'));
     });
 
     it('should validate the name field is at least 4 characters', () => {
       const requestBody = mutationRequestBody();
       requestBody.name = 'abc';
       return createValidatedRequest(requestBody, stackController.createStackValidator)
-        .then(() => expectValidationError('name', 'Name must be 4-12 characters long'));
+        .then(() => expectValidationError('name', 'Name must be 4-16 characters long'));
     });
 
     it('should validate the datalabInfo.domain field exists', () => {

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -100,9 +100,9 @@ const existsCheck = fieldName => check(fieldName)
 
 const nameCheck = existsCheck('name')
   .isAscii()
-  .withMessage('Name must only use the characters a-z')
-  .isLength({ min: 4, max: 12 })
-  .withMessage('Name must be 4-12 characters long');
+  .withMessage('Name must only use the characters a-z, 0-9')
+  .isLength({ min: 4, max: 16 })
+  .withMessage('Name must be 4-16 characters long');
 
 const projectKeyCheck = existsCheck('projectKey');
 

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -80,7 +80,7 @@ describe('Volume Controller', () => {
       const requestBody = createRequestBody();
       requestBody.name = 'abc';
       await executeCreateValidator(requestBody);
-      expectValidationError('name', 'Name must be 4-12 characters long');
+      expectValidationError('name', 'Name must be 4-16 characters long');
     });
 
     it('should validate the volume size is greater than 5', async () => {

--- a/code/workspaces/web-app/src/components/dataStorage/newDataStoreFormValidator.js
+++ b/code/workspaces/web-app/src/components/dataStorage/newDataStoreFormValidator.js
@@ -23,12 +23,12 @@ const constraints = {
   name: {
     presence: true,
     format: {
-      pattern: '^[a-z]*$',
+      pattern: '^[a-z0-9]+$',
       message: 'must be lower case characters without a space',
     },
     length: {
       minimum: 4,
-      maximum: 12,
+      maximum: 16,
     },
   },
   description: {

--- a/code/workspaces/web-app/src/components/notebooks/newNotebookFormValidator.js
+++ b/code/workspaces/web-app/src/components/notebooks/newNotebookFormValidator.js
@@ -15,12 +15,12 @@ const constraints = {
   name: {
     presence: true,
     format: {
-      pattern: '^[a-z]*$',
+      pattern: '^[a-z0-9]+$',
       message: 'must be lower case characters without a space',
     },
     length: {
       minimum: 4,
-      maximum: 12,
+      maximum: 16,
     },
   },
   volumeMount: {

--- a/code/workspaces/web-app/src/components/sites/newSiteFormValidator.js
+++ b/code/workspaces/web-app/src/components/sites/newSiteFormValidator.js
@@ -15,7 +15,7 @@ const constraints = {
   name: {
     presence: true,
     format: {
-      pattern: '^[a-z]*$',
+      pattern: '^[a-z0-9]+$',
       message: 'must be lower case characters without a space',
     },
     length: {


### PR DESCRIPTION
Relax the rules on the Stack/Storage names so users can be a bit more free, researched and there's no reason this won't work for Kubernetes etc.