### PR TITLE
feat: ensure options are visible while stacks are building

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -99,7 +99,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
           {typeName === 'Project' ? <ProjectKey>({stack.key})</ProjectKey> : null}
         </div>
         <Tooltip title={getDescription(stack, typeName)} placement='bottom-start'>
-          <Typography varient="body1" noWrap>{getDescription(stack, typeName)}</Typography>
+          <Typography variant="body1" noWrap>{getDescription(stack, typeName)}</Typography>
         </Tooltip>
         {renderShareInfo(typeName, stack) && <Typography variant="body1" className={classes.shareStatus}>Shared by {getUserEmail(stack.users, users)}</Typography>}
       </div>

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import { statusTypes } from 'common';
 import ProjectKey from '../common/typography/ProjectKey';
 import StackCardActions from './StackCardActions';
 import stackDescriptions from './stackDescriptions';
 import StackStatus from './StackStatus';
 import { useUsers } from '../../hooks/usersHooks';
-
-const { READY } = statusTypes;
 
 function styles(theme) {
   return {
@@ -108,8 +105,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
       </div>
       <div className={classes.actionsDiv}>
         {typeName !== 'Data Store' && typeName !== 'Project' && stack.status && <div className={classes.statusDiv}><StackStatus status={stack.status}/></div>}
-        {stack.status === READY
-          && <StackCardActions
+        <StackCardActions
             stack={stack}
             openStack={openStack}
             deleteStack={deleteStack}
@@ -118,7 +114,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
             openPermission={openPermission}
             deletePermission={deletePermission}
             editPermission={editPermission}
-          />}
+          />
       </div>
     </div>
   );

--- a/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
@@ -55,21 +55,6 @@ describe('StackCard', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should provide defaults and hide actions if no stack is provided', () => {
-    // Arrange
-    const props = {
-      stack: {},
-      typeName: 'typeName',
-      ...permissionProps,
-    };
-
-    // Act
-    const output = shallowRender(props);
-
-    // Assert
-    expect(output).toMatchSnapshot();
-  });
-
   it('should show status ad buttons when status is ready', () => {
     // Arrange
     const props = generateProps('jupyter', 'ready');

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions.js
@@ -48,7 +48,7 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
 
   return (
     <div className={classes.cardActions}>
-      {openStack && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={openPermission}>
+      {openStack && stack.status === READY && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={openPermission}>
         <PrimaryActionButton
           disabled={!isReady(stack)}
           onClick={() => openStack(stack)}
@@ -57,12 +57,12 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
           Open
         </PrimaryActionButton>
       </PermissionWrapper>}
-      {ownsStack && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={deletePermission}>
+      {ownsStack && stack.status && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={deletePermission}>
         <SecondaryActionButton
-          disabled={!isReady(stack)}
           aria-controls="more-menu"
           aria-haspopup="true"
           onClick={handleClick}
+          fullWidth
         >
           <Icon style={{ color: 'inherit' }}>{MORE_ICON}</Icon>
         </SecondaryActionButton>
@@ -76,18 +76,12 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
         onClose={handleClose}
       >
         {editStack && ownsStack && <PermissionWrapper userPermissions={userPermissions} permission={editPermission}>
-          <MenuItem
-            disabled={!isReady(stack)}
-            onClick={() => editStack(stack)}
-          >
+          <MenuItem onClick={() => editStack(stack)}>
             Edit
           </MenuItem>
         </PermissionWrapper>}
         {deleteStack && ownsStack && <PermissionWrapper userPermissions={userPermissions} permission={deletePermission}>
-          <MenuItem
-            disabled={!isReady(stack)}
-            onClick={() => deleteStack(stack)}
-          >
+          <MenuItem onClick={() => deleteStack(stack)}>
             Delete
           </MenuItem>
         </PermissionWrapper>}

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions.js
@@ -2,6 +2,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Icon from '@material-ui/core/Icon';
+import Tooltip from '@material-ui/core/Tooltip';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { statusTypes } from 'common';
@@ -46,16 +47,25 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
     setAnchorEl(null);
   };
 
+  const OpenButton = React.forwardRef((props, ref) => <PrimaryActionButton innerRef={ref} {...props} />);
+
   return (
     <div className={classes.cardActions}>
-      {openStack && stack.status === READY && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={openPermission}>
-        <PrimaryActionButton
-          disabled={!isReady(stack)}
-          onClick={() => openStack(stack)}
-          fullWidth
+      {openStack && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={openPermission}>
+        <Tooltip
+          title='Cannot be opened until resource is ready' placement='bottom-start'
+          disableHoverListener={isReady(stack)}
         >
-          Open
-        </PrimaryActionButton>
+          <div>
+            <OpenButton
+              disabled={!isReady(stack)}
+              onClick={() => openStack(stack)}
+              fullWidth
+            >
+              Open
+            </OpenButton>
+          </div>
+        </Tooltip>
       </PermissionWrapper>}
       {ownsStack && stack.status && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={deletePermission}>
         <SecondaryActionButton

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions.spec.js
@@ -73,6 +73,17 @@ describe('PureStackCardActions', () => {
     expect(output).toMatchSnapshot();
   });
 
+  it('Should not render Open if stack is not ready', () => {
+    // Arrange
+    const baseProps = generateProps();
+    const props = { ...baseProps, stack: { status: 'requested' } };
+    // Act
+    const output = shallowRender(props);
+
+    // Assert
+    expect(output).toMatchSnapshot();
+  });
+
   it('Open button onClick function calls openStack with correct props', () => {
     // Arrange
     const props = generateProps();

--- a/code/workspaces/web-app/src/components/stacks/StackStatus.js
+++ b/code/workspaces/web-app/src/components/stacks/StackStatus.js
@@ -6,28 +6,21 @@ import { statusTypes } from 'common';
 
 const { getStatusKeys, getStatusProps } = statusTypes;
 
-const styles = (theme) => {
-  const stackStatus = {
+const styles = theme => ({
+  stackStatus: {
     padding: `${theme.spacing(0.5)}px 0`,
     borderRadius: 50, // make round
     userSelect: 'none',
-  };
-
-  return ({
-    stackStatus,
-    stackStatusReady: {
-      ...stackStatus,
-      marginBottom: theme.spacing(2), // only ready has buttons under it
-    },
-  });
-};
+    marginBottom: theme.spacing(2),
+  },
+});
 
 const StackStatus = ({ classes, status }) => {
   const { displayName, backgroundColor, color } = getStatusProps(status);
 
   return (
     <Typography
-      className={status === 'ready' ? classes.stackStatusReady : classes.stackStatus}
+      className={classes.stackStatus}
       style={{ backgroundColor, color }}
       type="caption"
       align="center"

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -46,7 +46,30 @@ exports[`StackCard creates correct snapshot for Jupyer stack type 1`] = `
   </div>
   <div
     className="StackCard-actionsDiv-6"
-  />
+  >
+    <WithStyles(StackCardActions)
+      deletePermission="delete"
+      deleteStack={[Function]}
+      editPermission="edit"
+      openPermission="open"
+      openStack={[Function]}
+      stack={
+        Object {
+          "displayName": "name1",
+          "id": "100",
+          "status": undefined,
+          "type": "jupyter",
+        }
+      }
+      userPermissions={
+        Array [
+          "open",
+          "delete",
+          "edit",
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -96,52 +119,30 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
   </div>
   <div
     className="StackCard-actionsDiv-6"
-  />
-</div>
-`;
-
-exports[`StackCard should provide defaults and hide actions if no stack is provided 1`] = `
-<div
-  className="StackCard-cardDiv-1"
->
-  <div
-    className="StackCard-imageDiv-2"
   >
-    <WithStyles(ForwardRef(Icon))
-      className="StackCard-cardIcon-9"
-    >
-      create
-    </WithStyles(ForwardRef(Icon))>
+    <WithStyles(StackCardActions)
+      deletePermission="delete"
+      deleteStack={[Function]}
+      editPermission="edit"
+      openPermission="open"
+      openStack={[Function]}
+      stack={
+        Object {
+          "displayName": "name1",
+          "id": "100",
+          "status": undefined,
+          "type": "zeppelin",
+        }
+      }
+      userPermissions={
+        Array [
+          "open",
+          "delete",
+          "edit",
+        ]
+      }
+    />
   </div>
-  <div
-    className="StackCard-textDiv-3"
-  >
-    <div
-      className="StackCard-displayNameContainer-5"
-    >
-      <WithStyles(ForwardRef(Typography))
-        className="StackCard-displayName-4"
-        noWrap={true}
-        variant="h5"
-      >
-        Display Name
-      </WithStyles(ForwardRef(Typography))>
-    </div>
-    <WithStyles(Tooltip)
-      placement="bottom-start"
-      title="A description of the typeName purpose"
-    >
-      <WithStyles(ForwardRef(Typography))
-        noWrap={true}
-        varient="body1"
-      >
-        A description of the typeName purpose
-      </WithStyles(ForwardRef(Typography))>
-    </WithStyles(Tooltip)>
-  </div>
-  <div
-    className="StackCard-actionsDiv-6"
-  />
 </div>
 `;
 

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -38,7 +38,7 @@ exports[`StackCard creates correct snapshot for Jupyer stack type 1`] = `
     >
       <WithStyles(ForwardRef(Typography))
         noWrap={true}
-        varient="body1"
+        variant="body1"
       >
         Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.
       </WithStyles(ForwardRef(Typography))>
@@ -111,7 +111,7 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
     >
       <WithStyles(ForwardRef(Typography))
         noWrap={true}
-        varient="body1"
+        variant="body1"
       >
         Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
       </WithStyles(ForwardRef(Typography))>
@@ -184,7 +184,7 @@ exports[`StackCard should show status ad buttons when status is ready 1`] = `
     >
       <WithStyles(ForwardRef(Typography))
         noWrap={true}
-        varient="body1"
+        variant="body1"
       >
         Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.
       </WithStyles(ForwardRef(Typography))>

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCardActions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCardActions.spec.js.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PureStackCardActions Should not render Open if stack is not ready 1`] = `
+<div
+  className="cardActions"
+>
+  <ComponentWrapper
+    className="buttonWrapper"
+    permission="delete"
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "edit",
+      ]
+    }
+  >
+    <SecondaryActionButton
+      aria-controls="more-menu"
+      aria-haspopup="true"
+      fullWidth={true}
+      onClick={[Function]}
+    >
+      <WithStyles(ForwardRef(Icon))
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        more_vert
+      </WithStyles(ForwardRef(Icon))>
+    </SecondaryActionButton>
+  </ComponentWrapper>
+  <WithStyles(ForwardRef(Menu))
+    anchorEl={null}
+    id="more-menu"
+    keepMounted={true}
+    onClose={[Function]}
+    open={false}
+    transformOrigin={
+      Object {
+        "horizontal": "right",
+        "vertical": "top",
+      }
+    }
+  >
+    <ComponentWrapper
+      permission="edit"
+      userPermissions={
+        Array [
+          "open",
+          "delete",
+          "edit",
+        ]
+      }
+    >
+      <WithStyles(ForwardRef(MenuItem))
+        onClick={[Function]}
+      >
+        Edit
+      </WithStyles(ForwardRef(MenuItem))>
+    </ComponentWrapper>
+    <ComponentWrapper
+      permission="delete"
+      userPermissions={
+        Array [
+          "open",
+          "delete",
+          "edit",
+        ]
+      }
+    >
+      <WithStyles(ForwardRef(MenuItem))
+        onClick={[Function]}
+      >
+        Delete
+      </WithStyles(ForwardRef(MenuItem))>
+    </ComponentWrapper>
+  </WithStyles(ForwardRef(Menu))>
+</div>
+`;
+
 exports[`PureStackCardActions Should not render edit and delete buttons if current user is not the owner 1`] = `
 <div
   className="cardActions"
@@ -76,7 +157,7 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
     <SecondaryActionButton
       aria-controls="more-menu"
       aria-haspopup="true"
-      disabled={false}
+      fullWidth={true}
       onClick={[Function]}
     >
       <WithStyles(ForwardRef(Icon))
@@ -114,7 +195,6 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
       }
     >
       <WithStyles(ForwardRef(MenuItem))
-        disabled={false}
         onClick={[Function]}
       >
         Edit
@@ -131,7 +211,6 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
       }
     >
       <WithStyles(ForwardRef(MenuItem))
-        disabled={false}
         onClick={[Function]}
       >
         Delete

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCardActions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCardActions.spec.js.snap
@@ -6,6 +6,33 @@ exports[`PureStackCardActions Should not render Open if stack is not ready 1`] =
 >
   <ComponentWrapper
     className="buttonWrapper"
+    permission="open"
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "edit",
+      ]
+    }
+  >
+    <WithStyles(Tooltip)
+      disableHoverListener={false}
+      placement="bottom-start"
+      title="Cannot be opened until resource is ready"
+    >
+      <div>
+        <ForwardRef
+          disabled={true}
+          fullWidth={true}
+          onClick={[Function]}
+        >
+          Open
+        </ForwardRef>
+      </div>
+    </WithStyles(Tooltip)>
+  </ComponentWrapper>
+  <ComponentWrapper
+    className="buttonWrapper"
     permission="delete"
     userPermissions={
       Array [
@@ -96,13 +123,21 @@ exports[`PureStackCardActions Should not render edit and delete buttons if curre
       ]
     }
   >
-    <PrimaryActionButton
-      disabled={false}
-      fullWidth={true}
-      onClick={[Function]}
+    <WithStyles(Tooltip)
+      disableHoverListener={true}
+      placement="bottom-start"
+      title="Cannot be opened until resource is ready"
     >
-      Open
-    </PrimaryActionButton>
+      <div>
+        <ForwardRef
+          disabled={false}
+          fullWidth={true}
+          onClick={[Function]}
+        >
+          Open
+        </ForwardRef>
+      </div>
+    </WithStyles(Tooltip)>
   </ComponentWrapper>
   <WithStyles(ForwardRef(Menu))
     anchorEl={null}
@@ -135,13 +170,21 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
       ]
     }
   >
-    <PrimaryActionButton
-      disabled={false}
-      fullWidth={true}
-      onClick={[Function]}
+    <WithStyles(Tooltip)
+      disableHoverListener={true}
+      placement="bottom-start"
+      title="Cannot be opened until resource is ready"
     >
-      Open
-    </PrimaryActionButton>
+      <div>
+        <ForwardRef
+          disabled={false}
+          fullWidth={true}
+          onClick={[Function]}
+        >
+          Open
+        </ForwardRef>
+      </div>
+    </WithStyles(Tooltip)>
   </ComponentWrapper>
   <ComponentWrapper
     className="buttonWrapper"

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackStatus.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackStatus.spec.js.snap
@@ -35,7 +35,7 @@ exports[`StackStatus creates correct snapshot for status types 2`] = `
 exports[`StackStatus creates correct snapshot for status types 3`] = `
 <WithStyles(ForwardRef(Typography))
   align="center"
-  className="StackStatus-stackStatusReady-2"
+  className="StackStatus-stackStatus-1"
   style={
     Object {
       "backgroundColor": "hsl(120, 55%, 80%)",


### PR DESCRIPTION
The logic behind this is that;

a) Sometimes users create a stack and want to delete it (named incorrectly etc) without having to wait for it to be provisioned.
b) When checking logs for RShiny instances (+ potentially other actions in future), it's entirely possible you'll want to take an action when the stack is requested/creating/unavailable, currently you can't view logs or delete a stack that's unavailable at all as the button isn't visible.