### PR TITLE
fix: mount entire datastore so users can access data

### DIFF
--- a/code/workspaces/infrastructure-api/resources/rshiny.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rshiny.deployment.template.yml
@@ -13,8 +13,6 @@ spec:
         name: {{ name }}
         user-pod: {{ type }}
     spec:
-      # No init container need as the subPath variable only mounts the required directory. If the directory is missing
-      # this is automatically created.
       containers:
         - image: {{ &rshiny.imageName }}:{{ rshiny.version }}
           imagePullPolicy: "IfNotPresent"
@@ -37,6 +35,9 @@ spec:
             periodSeconds: 10
 {{#volumeMount}}
           volumeMounts:
+            - name: glusterfsvol
+              mountPath: /data
+              readOnly: true
             - name: glusterfsvol
               mountPath: /srv/shiny-server
               subPath: {{ &sourcePath }}


### PR DESCRIPTION
Mounting the entire Datastore to be visible to RShiny so that Data can be accessed when required. 