### PR TITLE
fix: handle roleBinding deletion gracefully

### DIFF
--- a/code/workspaces/infrastructure-api/src/kubernetes/roleBindingApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/roleBindingApi.js
@@ -1,6 +1,17 @@
 import logger from '../config/logger';
 import { getRbacV1Api } from './kubeConfig';
 
+async function namespacedRoleBindingExists(name, namespace) {
+  const k8sApi = getRbacV1Api();
+  logger.debug(`Checking roleBinding ${name} exists in ${namespace}`);
+  try {
+    await k8sApi.readNamespacedRoleBinding(name, namespace);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 async function createNamespacedRoleBinding(bindingDefinition, namespace) {
   const k8sApi = getRbacV1Api();
 
@@ -15,6 +26,10 @@ async function createNamespacedRoleBinding(bindingDefinition, namespace) {
 }
 
 async function deleteNamespacedRoleBinding(name, namespace) {
+  if (!(await namespacedRoleBindingExists(name, namespace))) {
+    logger.debug(`RoleBinding ${name} does not exist in namespace ${namespace}`);
+    return;
+  }
   const k8sApi = getRbacV1Api();
 
   try {

--- a/code/workspaces/infrastructure-api/src/kubernetes/roleBindingApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/roleBindingApi.spec.js
@@ -6,6 +6,7 @@ jest.mock('./kubeConfig');
 const k8sApiMock = {
   createNamespacedRoleBinding: jest.fn(),
   deleteNamespacedRoleBinding: jest.fn(),
+  readNamespacedRoleBinding: jest.fn(),
 };
 
 getRbacV1Api.mockReturnValue(k8sApiMock);
@@ -34,10 +35,23 @@ describe('createNamespacedRoleBinding', () => {
 });
 
 describe('deleteNamespacedRoleBinding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('calls k8s api to delete a namespaced roleBinding', async () => {
     const bindingName = 'binding-name';
     await roleBindingApi.deleteNamespacedRoleBinding(bindingName, projectKey);
     expect(k8sApiMock.deleteNamespacedRoleBinding)
       .toHaveBeenCalledWith(bindingName, projectKey);
+  });
+
+  it('does not call k8s api to delete a namespaced roleBinding if it does not exist', async () => {
+    const bindingName = ' binding-name';
+    k8sApiMock.readNamespacedRoleBinding.mockImplementationOnce(() => { throw new Error('expected test error'); });
+
+    await roleBindingApi.deleteNamespacedRoleBinding(bindingName, projectKey);
+    expect(k8sApiMock.deleteNamespacedRoleBinding)
+      .not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Previously we couldn't delete old projects as the project deletion process gets rid of the "project-compute-submission-account-role-binding", from the compute namespace. Since this doesn't exist for older projects, it's not possible to delete them as this step fails.

Changing it to delete gracefully (doesn't stop if it doesn't exist).