### PR TITLE
fix: enable listing of > 100 users using auth0 API

### DIFF
--- a/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
+++ b/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
@@ -33,8 +33,11 @@ export async function asyncGetUsers() {
       const bearer = await requestAccessToken(tokenRequest);
 
       // Below approach is required as the auth0 API results are paginated, with a maximum
-      // overall limit, as well as a maximum per_page limit. This approach (non-async) is
-      // taken to prevent excessive API calls which impact performance.
+      // overall limit, as well as a maximum per_page limit. This approach is taken instead
+      // of requesting multiple pages simultaneously (e.g Promise.all).
+      // Additionally extractUsers no longer filters for auth0 'active' users as the raw
+      // return number is required to determine whether return page is full or not hence
+      // this logic is moved into the loop.
       /* eslint-disable no-await-in-loop */
       do {
         users = await fetchUsers(bearer, page);
@@ -68,8 +71,6 @@ const fetchUsers = (bearer, page) => axios.get(`${authZeroManagementApi}/users`,
   },
 });
 
-// Pending users are users with an account but have not logged in; these users do not have a populated name field.
-// This function filters pending users and returns only active users.
 const extractUsers = response => get(response, 'data', []);
 
 const processUsers = users => users.map(user => mapKeys(user, (value, key) => authKeyMapping[key]));

--- a/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
+++ b/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
@@ -6,6 +6,8 @@ import requestAccessToken from '../auth/accessToken';
 import { getOrSetCacheAsyncWrapper } from '../cache/cache';
 
 export const authZeroManagementApi = 'https://mjbr.eu.auth0.com/api/v2';
+const PAGE_LIMIT = 100;
+const AUTH0_MAXIMUM = 1000;
 
 const accessTokenRequest = () => ({
   audience: `https://${config.get('authZeroDomain')}/api/v2/`,
@@ -18,30 +20,57 @@ const authKeyMapping = {
   user_id: 'userId',
 };
 
-export function asyncGetUsers() {
-  return requestAccessToken(accessTokenRequest())
-    .then(bearer => axios.get(`${authZeroManagementApi}/users`, {
-      params: {
-        fields: 'name,user_id',
-        per_page: '100',
-      },
-      headers: {
-        Authorization: `Bearer ${bearer}`,
-      },
-    }).then(extractUsers)
-      .then(processUsers)
-      .catch(() => {
-        throw new Error('Unable to retrieve users from User Management Service.');
-      }))
-    .catch((err) => {
+export async function asyncGetUsers() {
+  try {
+    try {
+      let page = 0;
+      let users = [];
+      let extractedUsers = [];
+      let activeUsers = [];
+      let allUsers = [];
+
+      const tokenRequest = await accessTokenRequest();
+      const bearer = await requestAccessToken(tokenRequest);
+
+      // Below approach is required as the auth0 API results are paginated, with a maximum
+      // overall limit, as well as a maximum per_page limit. This approach (non-async) is
+      // taken to prevent excessive API calls which impact performance.
+      /* eslint-disable no-await-in-loop */
+      do {
+        users = await fetchUsers(bearer, page);
+        extractedUsers = await extractUsers(users);
+        activeUsers = extractedUsers.filter(user => user.name);
+        allUsers = allUsers.concat(activeUsers);
+        page += 1;
+      } while (extractedUsers.length === PAGE_LIMIT && page < (AUTH0_MAXIMUM / PAGE_LIMIT));
+      /* eslint-enable no-await-in-loop */
+
+      const processedUsers = await processUsers(allUsers);
+      return processedUsers;
+    } catch (err) {
       logger.error(err.message);
-      throw err;
-    });
+      throw new Error('Unable to retrieve users from User Management Service.');
+    }
+  } catch (err) {
+    logger.error(err.message);
+    throw err;
+  }
 }
+
+const fetchUsers = (bearer, page) => axios.get(`${authZeroManagementApi}/users`, {
+  params: {
+    fields: 'name,user_id',
+    per_page: PAGE_LIMIT,
+    page,
+  },
+  headers: {
+    Authorization: `Bearer ${bearer}`,
+  },
+});
 
 // Pending users are users with an account but have not logged in; these users do not have a populated name field.
 // This function filters pending users and returns only active users.
-const extractUsers = response => get(response, 'data', []).filter(user => user.name);
+const extractUsers = response => get(response, 'data', []);
 
 const processUsers = users => users.map(user => mapKeys(user, (value, key) => authKeyMapping[key]));
 


### PR DESCRIPTION
The auth0 API has a limit on the number of users that can be extracted in one call, as we are near to that limit now need to make multiple calls to extract all users in order for them to be accessible in the app.