### PR TITLE
feat: make creator of the project an admin by default

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/projectService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.spec.js
@@ -19,7 +19,12 @@ const testProjects = [
   { key: 'key-2', name: 'name 2', description: 'description 2' },
 ];
 
+const user = {
+  sub: 'username',
+};
+
 const infraServiceUrl = config.get('infrastructureApi');
+const authServiceUrl = `${config.get('authorisationService')}`;
 
 describe('projectService', () => {
   beforeEach(() => {
@@ -58,12 +63,16 @@ describe('projectService', () => {
 
   it('createProject makes an api call and returns the response data', async () => {
     const dummyResponse = { id: 'id', ...testProject };
+    const dummyAuthResponse = { userId: user.sub, projectKey: testProject.key, role: 'admin' };
+
     httpMock.onPost(`${infraServiceUrl}/projects`, testProject)
       .reply(200, dummyResponse);
+    httpMock.onPut(`${authServiceUrl}/projects/${testProject.key}/users/${user.sub}/roles`, { role: 'admin' })
+      .reply(200, dummyAuthResponse);
 
     const creationRequest = { ...testProject, projectKey: testProject.key };
     delete creationRequest.key;
-    const result = await projectService.createProject(creationRequest, token);
+    const result = await projectService.createProject(creationRequest, user, token);
     expect(result).toEqual(dummyResponse);
   });
 
@@ -94,7 +103,7 @@ describe('projectActionRequestToProject', () => {
     const projectKey = 'projectKey';
     const baseData = { name: 'name', description: 'description', collaborationLink: 'collaborationLink' };
     const actionRequest = { projectKey, ...baseData };
-    const projcetDefinition = { key: projectKey, ...baseData };
-    expect(projectActionRequestToProject(actionRequest)).toEqual(projcetDefinition);
+    const projectDefinition = { key: projectKey, ...baseData };
+    expect(projectActionRequestToProject(actionRequest)).toEqual(projectDefinition);
   });
 });

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -64,7 +64,7 @@ const resolvers = {
     removeProjectPermission: (obj, { permission: { projectKey, userId } }, { user, token }) => (
       projectPermissionWrapper({ projectKey }, PERMISSIONS_DELETE, user, () => projectService.removeProjectPermission(projectKey, userId, token))
     ),
-    createProject: (obj, { project }, { user, token }) => instanceAdminWrapper(user, () => projectService.createProject(project, token)),
+    createProject: (obj, { project }, { user, token }) => instanceAdminWrapper(user, () => projectService.createProject(project, user, token)),
     updateProject: (obj, { project }, { user, token }) => projectPermissionWrapper({ projectKey: project.key }, SETTINGS_EDIT, user, () => projectService.updateProject(project, token)),
     deleteProject: (obj, { project: { projectKey } }, { user, token }) => instanceAdminWrapper(user, () => projectService.deleteProject(projectKey, token)),
   },


### PR DESCRIPTION
The idea is that soon we'll be looking to make changes so that users won't necessarily have to be a 'system admin' to create their own projects. Hence the creator should be made an admin by default on the new project so they can use it.

Would be interested to hear thoughts on the approach here as well, I was wondering whether to set the owner directly in the infrastructure API when creating the project rather than make it another query from the client-API, but it's just easier to implement this way as no API calls need to be changed.