### PR TITLE
feat: add stack card pagination

### DIFF
--- a/code/workspaces/web-app/.eslintrc
+++ b/code/workspaces/web-app/.eslintrc
@@ -47,6 +47,12 @@
         "consistent": true
       }
     ],
+    "no-plusplus": [
+      "error",
+      {
+        "allowForLoopAfterthoughts": true
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/code/workspaces/web-app/package.json
+++ b/code/workspaces/web-app/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "auth0-js": "^9.13.2",
     "@material-ui/core": "^4.9.0",
+    "@material-ui/icons": "^4.9.1",
+    "auth0-js": "^9.13.2",
     "axios": "0.19.0",
     "bluebird": "3.5.0",
     "common": "^0.1.0",
@@ -32,6 +33,7 @@
     "validate.js": "0.11.1"
   },
   "devDependencies": {
+    "@testing-library/react-hooks": "^3.4.1",
     "axios-mock-adapter": "1.17.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
@@ -43,7 +45,7 @@
     "jest": "~24.8.0",
     "jest-enzyme": "7.0.2",
     "react-scripts": "3.1.0",
-    "react-test-renderer": "16.8.6",
+    "react-test-renderer": "16.9.0",
     "redux-devtools": "^3.5.0",
     "redux-mock-store": "1.2.3",
     "shx": "^0.3.2"

--- a/code/workspaces/web-app/src/components/stacks/NewStackButton.js
+++ b/code/workspaces/web-app/src/components/stacks/NewStackButton.js
@@ -1,24 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import PagePrimaryAction from '../common/buttons/PagePrimaryActionButton';
 
-const styles = theme => ({
-  button: {
-    marginTop: 10,
-  },
-});
-
-const NewStackButton = ({ classes, onClick, typeName }) => (
-  <PagePrimaryAction className={classes.button} aria-label="add" onClick={onClick}>
+const NewStackButton = ({ onClick, typeName }) => (
+  <PagePrimaryAction aria-label="add" onClick={onClick}>
     {`Create ${typeName}`}
   </PagePrimaryAction>
 );
 
 NewStackButton.propTypes = {
-  classes: PropTypes.object.isRequired,
   onClick: PropTypes.func.isRequired,
   typeName: PropTypes.string.isRequired,
 };
 
-export default withStyles(styles)(NewStackButton);
+export default NewStackButton;

--- a/code/workspaces/web-app/src/components/stacks/NewStackButton.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/NewStackButton.spec.js
@@ -3,8 +3,7 @@ import { createShallow } from '@material-ui/core/test-utils';
 import NewStackButton from './NewStackButton';
 
 function shallowRender(props) {
-  const shallow = createShallow({ dive: true });
-
+  const shallow = createShallow();
   return shallow(<NewStackButton {...props} />);
 }
 

--- a/code/workspaces/web-app/src/components/stacks/Pagination.js
+++ b/code/workspaces/web-app/src/components/stacks/Pagination.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import PaginationControls from './PaginationControls';
+import useCallOnValueChange from '../../hooks/useCallOnValueChange';
+
+const useStyles = makeStyles(theme => ({
+  paginationControlBar: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    padding: [[theme.spacing(2), 0]],
+  },
+}));
+
+export function calculateNumberOfPages(numberOfItems, itemsPerPage) {
+  if (numberOfItems === 0) return 1;
+
+  const numberOfFullPages = Math.floor(numberOfItems / itemsPerPage);
+  const numberOfItemsOnPartialPage = numberOfItems % itemsPerPage;
+  return numberOfItemsOnPartialPage > 0 ? numberOfFullPages + 1 : numberOfFullPages;
+}
+
+function handleNumPagesDroppingBelowPageNum(numPages, pageNum, setPageNum) {
+  if (pageNum >= numPages) setPageNum(numPages - 1);
+}
+
+const Pagination = ({ items, itemsPerPage = 10, paginationBarItems }) => {
+  const classes = useStyles();
+  const [pageNum, setPageNum] = useState(0);
+  const numPages = calculateNumberOfPages(items.length, itemsPerPage);
+
+  useCallOnValueChange(
+    numPages,
+    () => handleNumPagesDroppingBelowPageNum(numPages, pageNum, setPageNum),
+  );
+
+  const itemsToDisplay = items.slice(itemsPerPage * pageNum, itemsPerPage * (pageNum + 1));
+
+  return (
+    <div>
+      <div>{itemsToDisplay}</div>
+      <div className={classes.paginationControlBar}>
+        <PaginationControls pageNum={pageNum} setPageNum={setPageNum} numPages={numPages} />
+        <div>{paginationBarItems}</div>
+      </div>
+    </div>
+  );
+};
+
+Pagination.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.element).isRequired,
+  itemsPerPage: PropTypes.number,
+  paginationBarItems: PropTypes.node,
+};
+
+export default Pagination;

--- a/code/workspaces/web-app/src/components/stacks/Pagination.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/Pagination.spec.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Pagination, { calculateNumberOfPages } from './Pagination';
+
+describe('Pagination', () => {
+  function shallowRender(props) {
+    return shallow(<Pagination {...props} />);
+  }
+
+  function generateProps(numItems, itemsPerPage, paginationBarItems) {
+    const items = [];
+    for (let i = 0; i < numItems; i++) {
+      items.push(<div key={i}>Item {i}</div>);
+    }
+    return {
+      items,
+      itemsPerPage,
+      paginationBarItems,
+    };
+  }
+
+  it('renders the correct number of items from the start of the array on the first page', () => {
+    const props = generateProps(10, 5, undefined);
+    const output = shallowRender(props);
+    expect(output).toMatchSnapshot();
+  });
+
+  it('renders single additional item in control bar after pagination controls in own div', () => {
+    const barItem = <span>Bar Item</span>;
+    const props = generateProps(4, 2, barItem);
+    const output = shallowRender(props);
+    expect(output).toMatchSnapshot();
+  });
+
+  it('renders array of additional items in control bar after pagination controls in own div', () => {
+    const barItems = [<span>Bar Item 1</span>, <span>Bar Item 1</span>];
+    const props = generateProps(4, 2, barItems);
+    const output = shallowRender(props);
+    expect(output).toMatchSnapshot();
+  });
+});
+
+describe('calculateNumberOfPages', () => {
+  it('gives 1 page when there are no items', () => {
+    expect(calculateNumberOfPages(0, 10)).toBe(1);
+  });
+
+  it('gives 1 page when there are less items than itemsPerPage', () => {
+    expect(calculateNumberOfPages(5, 10)).toBe(1);
+  });
+
+  it('gives 1 page when there are the same number of items as itemsPerPage', () => {
+    expect(calculateNumberOfPages(10, 10)).toBe(1);
+  });
+
+  it('gives 2 pages when items > itemsPerPage and items < 2 * itemsPerPage', () => {
+    expect(calculateNumberOfPages(12, 10)).toBe(2);
+  });
+});

--- a/code/workspaces/web-app/src/components/stacks/PaginationControlButton.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControlButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import IconButton from '@material-ui/core/IconButton';
+import PropTypes from 'prop-types';
+import NavigateBeforeRoundedIcon from '@material-ui/icons/NavigateBeforeRounded';
+import NavigateNextRoundedIcon from '@material-ui/icons/NavigateNextRounded';
+
+export const PREVIOUS_PAGE = 'previous';
+export const NEXT_PAGE = 'next';
+
+function getTooltipTitle(variant, disabled) {
+  if (variant === PREVIOUS_PAGE) {
+    return !disabled ? 'Previous page' : 'No previous page to goto';
+  }
+
+  if (variant === NEXT_PAGE) {
+    return !disabled ? 'Next page' : 'No next page to goto';
+  }
+
+  return '';
+}
+
+const PaginationControlButton = ({ variant, onClick, disabled = false }) => (
+    <Tooltip title={getTooltipTitle(variant, disabled)}>
+    <span> {/* need span to make tooltip work when button is disabled */}
+      <IconButton
+        size="small"
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {variant === PREVIOUS_PAGE && <NavigateBeforeRoundedIcon />}
+        {variant === NEXT_PAGE && <NavigateNextRoundedIcon />}
+      </IconButton>
+    </span>
+    </Tooltip>
+);
+
+PaginationControlButton.propTypes = {
+  variant: PropTypes.oneOf([PREVIOUS_PAGE, NEXT_PAGE]).isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+export default PaginationControlButton;

--- a/code/workspaces/web-app/src/components/stacks/PaginationControlButton.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControlButton.spec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PaginationControlButton, { PREVIOUS_PAGE, NEXT_PAGE } from './PaginationControlButton';
+
+describe('PaginationControlButton', () => {
+  function shallowRender(props) {
+    return shallow(<PaginationControlButton {...props} />);
+  }
+
+  function generateProps({
+    variant = PREVIOUS_PAGE,
+    onClick = jest.fn().mockName('onClick'),
+    disabled = false,
+  }) {
+    return { variant, onClick, disabled };
+  }
+
+  it(`renders correctly when variant is "${PREVIOUS_PAGE}" and it is not disabled`, () => {
+    const props = generateProps({ variant: PREVIOUS_PAGE });
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+
+  it(`renders correctly when variant is "${PREVIOUS_PAGE}" and it is disabled`, () => {
+    const props = generateProps({ variant: PREVIOUS_PAGE, disabled: true });
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+
+  it(`renders correctly when variant is "${NEXT_PAGE}" and it is not disabled`, () => {
+    const props = generateProps({ variant: NEXT_PAGE });
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+
+  it(`renders correctly when variant is "${NEXT_PAGE}" and it is disabled`, () => {
+    const props = generateProps({ variant: NEXT_PAGE, disabled: true });
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/components/stacks/PaginationControlTextField.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControlTextField.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+import theme from '../../theme';
+
+const useStyles = makeStyles(() => ({
+  pageNumberInput: {
+    maxWidth: '3em',
+    margin: 0,
+  },
+}));
+
+const PaginationControlTextField = (
+  { pageInputValue, setPageInputValue, changePageToUserInput },
+) => {
+  const classes = useStyles();
+
+  return (
+    <TextField
+      className={classes.pageNumberInput}
+      inputProps={{
+        style: {
+          textAlign: 'center',
+          padding: theme.spacing(1),
+        },
+      }}
+      variant="outlined" margin="dense" size="small"
+      value={pageInputValue}
+      onChange={event => setPageInputValue(event.target.value)}
+      onBlur={() => changePageToUserInput()}
+      onKeyPress={event => event.key === 'Enter' && changePageToUserInput()}
+    />
+  );
+};
+
+PaginationControlTextField.propTypes = {
+  pageInputValue: PropTypes.oneOfType(
+    [PropTypes.number, PropTypes.string],
+  ).isRequired,
+  setPageInputValue: PropTypes.func.isRequired,
+  changePageToUserInput: PropTypes.func.isRequired,
+};
+
+export default PaginationControlTextField;

--- a/code/workspaces/web-app/src/components/stacks/PaginationControlTextField.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControlTextField.spec.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PaginationControlTextField from './PaginationControlTextField';
+
+describe('PaginationControlTextField', () => {
+  function shallowRender(props) {
+    return shallow(<PaginationControlTextField {...props} />);
+  }
+
+  function generateProps({
+    pageInputValue = 1,
+    setPageInputValue = () => {},
+    changePageToUserInput = () => {},
+  }) {
+    return { pageInputValue, setPageInputValue, changePageToUserInput };
+  }
+
+  it('renders with the provided pageInputValue as the value', () => {
+    const props = generateProps({ pageInputValue: 5 });
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+
+  it('calls setPageInputValue with the new value when the input changes', () => {
+    const setPageInputValueMock = jest.fn();
+    const props = generateProps({ setPageInputValue: setPageInputValueMock });
+    const render = shallowRender(props);
+
+    const valueChangedTo = 5;
+    render.simulate('change', { target: { value: valueChangedTo } });
+
+    expect(setPageInputValueMock.mock.calls.length).toBe(1);
+    expect(setPageInputValueMock.mock.calls[0][0]).toBe(5);
+  });
+
+  it('calls changePageToUserInput when blurred', () => {
+    const changePageToUserInputMock = jest.fn();
+    const props = generateProps({ changePageToUserInput: changePageToUserInputMock });
+    const render = shallowRender(props);
+
+    render.simulate('blur');
+
+    expect(changePageToUserInputMock.mock.calls.length).toBe(1);
+  });
+
+  it('calls changePageToUserInput when Enter key is pressed', () => {
+    const changePageToUserInputMock = jest.fn();
+    const props = generateProps({ changePageToUserInput: changePageToUserInputMock });
+    const render = shallowRender(props);
+
+    render.simulate('keyPress', { key: 'Enter' });
+
+    expect(changePageToUserInputMock.mock.calls.length).toBe(1);
+  });
+});

--- a/code/workspaces/web-app/src/components/stacks/PaginationControls.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControls.js
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import PaginationControlButton, { PREVIOUS_PAGE, NEXT_PAGE } from './PaginationControlButton';
+import PaginationControlTextField from './PaginationControlTextField';
+import useCallOnValueChange from '../../hooks/useCallOnValueChange';
+
+const useStyles = makeStyles(injectedTheme => ({
+  paginationControlsContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
+  controlText: {
+    margin: [[0, injectedTheme.spacing(2)]],
+    userSelect: 'none',
+  },
+}));
+
+function pageNumToPageInputValue(pageNum) {
+  return pageNum + 1;
+}
+
+function pageInputValueToPageNum(pageInputValue) {
+  return pageInputValue - 1;
+}
+
+function pageInputValueInBounds(pageInputValue, numPages) {
+  return pageInputValue >= 1 && pageInputValue <= numPages;
+}
+
+function ensurePageInputAlignedWithPageNum(pageInputValue, setPageInputValue, pageNum) {
+  const requiredValue = pageNumToPageInputValue(pageNum);
+  if (pageInputValue !== requiredValue) setPageInputValue(requiredValue);
+}
+
+function handleChangePageToUserInput(
+  pageInputValue, setPageInputValue, pageNum, setPageNum, numPages,
+) {
+  const nanInput = isNaN(pageInputValueToPageNum(pageInputValue));
+
+  if (nanInput || !pageInputValueInBounds(pageInputValue, numPages)) {
+    // reset to be the appropriate display for the current page number
+    setPageInputValue(pageNumToPageInputValue(pageNum));
+  } else {
+    setPageNum(pageInputValueToPageNum(pageInputValue));
+  }
+}
+
+function gotoPreviousPage(pageNum, setPageNum, setPageInputValue) {
+  const newPageNum = pageNum - 1;
+  setPageNum(newPageNum);
+  setPageInputValue(pageNumToPageInputValue(newPageNum));
+}
+
+function gotoNextPage(pageNum, setPageNum, setPageInputValue) {
+  const newPageNum = pageNum + 1;
+  setPageNum(newPageNum);
+  setPageInputValue(pageNumToPageInputValue(newPageNum));
+}
+
+const PaginationControls = ({ pageNum, setPageNum, numPages }) => {
+  const classes = useStyles();
+
+  const [pageInputValue, setPageInputValue] = useState(pageNumToPageInputValue(pageNum));
+
+  useCallOnValueChange(
+    pageNum,
+    () => ensurePageInputAlignedWithPageNum(pageInputValue, setPageInputValue, pageNum),
+  );
+
+  const changePageToUserInput = () => handleChangePageToUserInput(
+    pageInputValue, setPageInputValue, pageNum, setPageNum, numPages,
+  );
+
+  const hasPreviousPage = pageNum > 0;
+  const hasNextPage = pageNum < numPages - 1;
+
+  return (
+    <div className={classes.paginationControlsContainer}>
+      <PaginationControlButton
+        id="previous-page"
+        variant={PREVIOUS_PAGE}
+        disabled={!hasPreviousPage}
+        onClick={() => gotoPreviousPage(pageNum, setPageNum, setPageInputValue)}
+      />
+      <div className={classes.controlText}>Page</div>
+      <PaginationControlTextField
+        pageInputValue={pageInputValue}
+        setPageInputValue={setPageInputValue}
+        changePageToUserInput={changePageToUserInput}
+      />
+      <div className={classes.controlText}>of {numPages}</div>
+      <PaginationControlButton
+        id="next-page"
+        variant={NEXT_PAGE}
+        disabled={!hasNextPage}
+        onClick={() => gotoNextPage(pageNum, setPageNum, setPageInputValue)}
+      />
+    </div>
+  );
+};
+
+PaginationControls.propTypes = {
+  pageNum: PropTypes.number.isRequired,
+  setPageNum: PropTypes.func.isRequired,
+  numPages: PropTypes.number.isRequired,
+};
+
+export default PaginationControls;

--- a/code/workspaces/web-app/src/components/stacks/PaginationControls.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControls.spec.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PaginationControls from './PaginationControls';
+import PaginationControlTextField from './PaginationControlTextField';
+
+describe('PaginationControls', () => {
+  function shallowRender(props) {
+    return shallow(<PaginationControls {...props} />);
+  }
+
+  function generateProps(pageNum, setPageNum, numPages) {
+    return { pageNum, setPageNum, numPages };
+  }
+
+  it('renders with children in correct order', () => {
+    const props = generateProps(0, () => {}, 5);
+    const render = shallowRender(props);
+    expect(render).toMatchSnapshot();
+  });
+
+  describe('has a previous page button that', () => {
+    function findPreviousPageButton(render) {
+      return render.find('#previous-page');
+    }
+
+    it('renders as disabled when on page 0', () => {
+      const props = generateProps(0, () => {}, 5);
+      const render = shallowRender(props);
+      const previousPageButton = findPreviousPageButton(render);
+      expect(previousPageButton).toMatchSnapshot();
+    });
+
+    it('renders as not disabled when not on page 0', () => {
+      const props = generateProps(1, () => {}, 5);
+      const render = shallowRender(props);
+      const previousPageButton = findPreviousPageButton(render);
+      expect(previousPageButton).toMatchSnapshot();
+    });
+  });
+
+  describe('has a next page button that', () => {
+    function findNextPageButton(render) {
+      return render.find('#next-page');
+    }
+
+    it('renders as disabled when on the last page', () => {
+      const props = generateProps(0, () => {}, 1);
+      const render = shallowRender(props);
+      const nextPageButton = findNextPageButton(render);
+      expect(nextPageButton).toMatchSnapshot();
+    });
+
+    it('renders as not disabled when not on last page', () => {
+      const props = generateProps(0, () => {}, 5);
+      const render = shallowRender(props);
+      const nextPageButton = findNextPageButton(render);
+      expect(nextPageButton).toMatchSnapshot();
+    });
+  });
+
+  describe('has a PaginationControlTextField that', () => {
+    function findPaginationControlTextField(render) {
+      return render.find(PaginationControlTextField);
+    }
+
+    it('renders with pageInputValue prop of pageNum + 1', () => {
+      const props = generateProps(0, () => {}, 5);
+      const render = shallowRender(props);
+      const textField = findPaginationControlTextField(render);
+      expect(textField).toMatchSnapshot();
+    });
+  });
+});

--- a/code/workspaces/web-app/src/components/stacks/StackCards.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.js
@@ -1,21 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { sortBy } from 'lodash';
 import StackCard from './StackCard';
 import NewStackButton from './NewStackButton';
 import PermissionWrapper from '../common/ComponentPermissionWrapper';
 import PromisedContentWrapper from '../common/PromisedContentWrapper';
+import Pagination from './Pagination';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   stackDiv: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  bottomControlDiv: {
-    display: 'flex',
-    justifyContent: 'flex-end',
   },
   placeholderCard: {
     width: '100%',
@@ -26,47 +23,51 @@ const styles = theme => ({
     borderTop: `1px solid ${theme.palette.divider}`,
     borderBottom: `1px solid ${theme.palette.divider}`,
   },
-});
+}));
 
-const StackCards = ({ stacks, typeName, typeNamePlural, openStack, deleteStack, editStack, openCreationForm,
-  userPermissions, createPermission, openPermission, deletePermission, editPermission, getLogs, classes, shareStack }) => {
+const StackCards = (
+  { stacks, typeName, typeNamePlural, openStack, deleteStack, editStack, openCreationForm,
+    userPermissions, createPermission, openPermission, deletePermission, editPermission, getLogs, shareStack },
+) => {
+  const classes = useStyles();
+
   const sortedStacks = stacks.fetching ? [] : sortBy(stacks.value, stack => stack.displayName.toLowerCase());
+  const renderedStacks = sortedStacks && sortedStacks.length > 0
+    ? sortedStacks.map(stack => (
+      <StackCard
+        key={stack.id}
+        stack={stack}
+        typeName={typeName}
+        openStack={openStack}
+        deleteStack={deleteStack}
+        editStack={editStack}
+        shareStack={shareStack}
+        userPermissions={userPermissions(stack)}
+        openPermission={openPermission}
+        deletePermission={deletePermission}
+        editPermission={editPermission}
+        getLogs={getLogs}
+      />))
+    : [<div className={classes.placeholderCard} key={'placeholder-card'}>
+        <Typography variant="body1">{`No ${typeNamePlural || 'items'} to display.`}</Typography>
+      </div>];
+
+  const actionButton = (
+    <PermissionWrapper style={{ width: '100%' }} userPermissions={userPermissions()} permission={createPermission}>
+      <NewStackButton onClick={openCreationForm} typeName={typeName} />
+    </PermissionWrapper>
+  );
+
   return (
     <div className={classes.stackDiv}>
       <PromisedContentWrapper fetchingClassName={classes.placeholderCard} promise={stacks}>
-        <div> {/* extra div enables working css styling of stack card */}
-          {sortedStacks && sortedStacks.length > 0
-            ? sortedStacks.map(stack => (
-            <StackCard
-              key={stack.id}
-              stack={stack}
-              typeName={typeName}
-              openStack={openStack}
-              deleteStack={deleteStack}
-              editStack={editStack}
-              shareStack={shareStack}
-              userPermissions={userPermissions(stack)}
-              openPermission={openPermission}
-              deletePermission={deletePermission}
-              editPermission={editPermission}
-              getLogs={getLogs}
-            />))
-            : <div className={classes.placeholderCard}>
-              <Typography variant="body1">{`No ${typeNamePlural || 'items'} to display.`}</Typography>
-            </div>
-          }
-        </div>
+        <Pagination items={renderedStacks} paginationBarItems={actionButton}/>
       </PromisedContentWrapper>
-      <PermissionWrapper style={{ width: '100%' }} userPermissions={userPermissions()} permission={createPermission}>
-        <div className={classes.bottomControlDiv}>
-          <NewStackButton onClick={openCreationForm} typeName={typeName} />
-        </div>
-      </PermissionWrapper>
     </div>
   );
 };
 
-export default withStyles(styles)(StackCards);
+export default StackCards;
 
 StackCards.propTypes = {
   stacks: PropTypes.shape({

--- a/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
@@ -32,7 +32,7 @@ describe('StackCards', () => {
     const props = generateProps();
 
     // Act
-    const output = shallowRender(props).dive();
+    const output = shallowRender(props);
 
     // Assert
     expect(output).toMatchSnapshot();
@@ -43,7 +43,7 @@ describe('StackCards', () => {
     const props = { ...generateProps(), stacks: { fetching: false, value: [] } };
 
     // Act
-    const output = shallowRender(props).dive();
+    const output = shallowRender(props);
 
     // Assert
     expect(output).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/NewStackButton.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/NewStackButton.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`New Stack Button creates correct snapshot 1`] = `
 <PagePrimaryActionButton
   aria-label="add"
-  className="NewStackButton-button-1"
   onClick={[Function]}
 >
   Create Stack

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/Pagination.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/Pagination.spec.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination renders array of additional items in control bar after pagination controls in own div 1`] = `
+<div>
+  <div>
+    <div
+      key="0"
+    >
+      Item 
+      0
+    </div>
+    <div
+      key="1"
+    >
+      Item 
+      1
+    </div>
+  </div>
+  <div
+    className="makeStyles-paginationControlBar-1"
+  >
+    <PaginationControls
+      numPages={2}
+      pageNum={0}
+      setPageNum={[Function]}
+    />
+    <div>
+      <span>
+        Bar Item 1
+      </span>
+      <span>
+        Bar Item 1
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Pagination renders single additional item in control bar after pagination controls in own div 1`] = `
+<div>
+  <div>
+    <div
+      key="0"
+    >
+      Item 
+      0
+    </div>
+    <div
+      key="1"
+    >
+      Item 
+      1
+    </div>
+  </div>
+  <div
+    className="makeStyles-paginationControlBar-1"
+  >
+    <PaginationControls
+      numPages={2}
+      pageNum={0}
+      setPageNum={[Function]}
+    />
+    <div>
+      <span>
+        Bar Item
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Pagination renders the correct number of items from the start of the array on the first page 1`] = `
+<div>
+  <div>
+    <div
+      key="0"
+    >
+      Item 
+      0
+    </div>
+    <div
+      key="1"
+    >
+      Item 
+      1
+    </div>
+    <div
+      key="2"
+    >
+      Item 
+      2
+    </div>
+    <div
+      key="3"
+    >
+      Item 
+      3
+    </div>
+    <div
+      key="4"
+    >
+      Item 
+      4
+    </div>
+  </div>
+  <div
+    className="makeStyles-paginationControlBar-1"
+  >
+    <PaginationControls
+      numPages={2}
+      pageNum={0}
+      setPageNum={[Function]}
+    />
+    <div />
+  </div>
+</div>
+`;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlButton.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlButton.spec.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationControlButton renders correctly when variant is "next" and it is disabled 1`] = `
+<WithStyles(ForwardRef(Tooltip))
+  title="No next page to goto"
+>
+  <span>
+     
+    <WithStyles(ForwardRef(IconButton))
+      disabled={true}
+      onClick={[MockFunction onClick]}
+      size="small"
+    >
+      <NavigateNextRoundedIcon />
+    </WithStyles(ForwardRef(IconButton))>
+  </span>
+</WithStyles(ForwardRef(Tooltip))>
+`;
+
+exports[`PaginationControlButton renders correctly when variant is "next" and it is not disabled 1`] = `
+<WithStyles(ForwardRef(Tooltip))
+  title="Next page"
+>
+  <span>
+     
+    <WithStyles(ForwardRef(IconButton))
+      disabled={false}
+      onClick={[MockFunction onClick]}
+      size="small"
+    >
+      <NavigateNextRoundedIcon />
+    </WithStyles(ForwardRef(IconButton))>
+  </span>
+</WithStyles(ForwardRef(Tooltip))>
+`;
+
+exports[`PaginationControlButton renders correctly when variant is "previous" and it is disabled 1`] = `
+<WithStyles(ForwardRef(Tooltip))
+  title="No previous page to goto"
+>
+  <span>
+     
+    <WithStyles(ForwardRef(IconButton))
+      disabled={true}
+      onClick={[MockFunction onClick]}
+      size="small"
+    >
+      <NavigateBeforeRoundedIcon />
+    </WithStyles(ForwardRef(IconButton))>
+  </span>
+</WithStyles(ForwardRef(Tooltip))>
+`;
+
+exports[`PaginationControlButton renders correctly when variant is "previous" and it is not disabled 1`] = `
+<WithStyles(ForwardRef(Tooltip))
+  title="Previous page"
+>
+  <span>
+     
+    <WithStyles(ForwardRef(IconButton))
+      disabled={false}
+      onClick={[MockFunction onClick]}
+      size="small"
+    >
+      <NavigateBeforeRoundedIcon />
+    </WithStyles(ForwardRef(IconButton))>
+  </span>
+</WithStyles(ForwardRef(Tooltip))>
+`;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlTextField.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlTextField.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationControlTextField renders with the provided pageInputValue as the value 1`] = `
+<WithStyles(ForwardRef(TextField))
+  className="makeStyles-pageNumberInput-1"
+  inputProps={
+    Object {
+      "style": Object {
+        "padding": 5,
+        "textAlign": "center",
+      },
+    }
+  }
+  margin="dense"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onKeyPress={[Function]}
+  size="small"
+  value={5}
+  variant="outlined"
+/>
+`;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControls.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControls.spec.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationControls has a PaginationControlTextField that renders with pageInputValue prop of pageNum + 1 1`] = `
+<PaginationControlTextField
+  changePageToUserInput={[Function]}
+  pageInputValue={1}
+  setPageInputValue={[Function]}
+/>
+`;
+
+exports[`PaginationControls has a next page button that renders as disabled when on the last page 1`] = `
+<PaginationControlButton
+  disabled={true}
+  id="next-page"
+  onClick={[Function]}
+  variant="next"
+/>
+`;
+
+exports[`PaginationControls has a next page button that renders as not disabled when not on last page 1`] = `
+<PaginationControlButton
+  disabled={false}
+  id="next-page"
+  onClick={[Function]}
+  variant="next"
+/>
+`;
+
+exports[`PaginationControls has a previous page button that renders as disabled when on page 0 1`] = `
+<PaginationControlButton
+  disabled={true}
+  id="previous-page"
+  onClick={[Function]}
+  variant="previous"
+/>
+`;
+
+exports[`PaginationControls has a previous page button that renders as not disabled when not on page 0 1`] = `
+<PaginationControlButton
+  disabled={false}
+  id="previous-page"
+  onClick={[Function]}
+  variant="previous"
+/>
+`;
+
+exports[`PaginationControls renders with children in correct order 1`] = `
+<div
+  className="makeStyles-paginationControlsContainer-1"
+>
+  <PaginationControlButton
+    disabled={true}
+    id="previous-page"
+    onClick={[Function]}
+    variant="previous"
+  />
+  <div
+    className="makeStyles-controlText-2"
+  >
+    Page
+  </div>
+  <PaginationControlTextField
+    changePageToUserInput={[Function]}
+    pageInputValue={1}
+    setPageInputValue={[Function]}
+  />
+  <div
+    className="makeStyles-controlText-2"
+  >
+    of 
+    5
+  </div>
+  <PaginationControlButton
+    disabled={false}
+    id="next-page"
+    onClick={[Function]}
+    variant="next"
+  />
+</div>
+`;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
 <div
-  className="StackCards-stackDiv-1"
+  className="makeStyles-stackDiv-1"
 >
   <PromisedContentWrapper
-    fetchingClassName="StackCards-placeholderCard-3"
+    fetchingClassName="makeStyles-placeholderCard-2"
     promise={
       Object {
         "fetching": false,
@@ -29,116 +29,114 @@ exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
       }
     }
   >
-    <div>
-       
-      <WithStyles(StackCard)
-        deletePermission="delete"
-        deleteStack={[Function]}
-        editPermission="edit"
-        key="1"
-        openPermission="open"
-        openStack={[Function]}
-        stack={
-          Object {
-            "displayName": "name1",
-            "id": "1",
-            "type": "type1",
-          }
-        }
-        typeName="expectedTypeName"
-        userPermissions={
-          Array [
-            "open",
-            "delete",
-            "create",
-            "edit",
-          ]
-        }
-      />
-      <WithStyles(StackCard)
-        deletePermission="delete"
-        deleteStack={[Function]}
-        editPermission="edit"
-        key="2"
-        openPermission="open"
-        openStack={[Function]}
-        stack={
-          Object {
-            "displayName": "name2",
-            "id": "2",
-            "type": "type2",
-          }
-        }
-        typeName="expectedTypeName"
-        userPermissions={
-          Array [
-            "open",
-            "delete",
-            "create",
-            "edit",
-          ]
-        }
-      />
-      <WithStyles(StackCard)
-        deletePermission="delete"
-        deleteStack={[Function]}
-        editPermission="edit"
-        key="3"
-        openPermission="open"
-        openStack={[Function]}
-        stack={
-          Object {
-            "displayName": "name3",
-            "id": "3",
-            "type": "type3",
-          }
-        }
-        typeName="expectedTypeName"
-        userPermissions={
-          Array [
-            "open",
-            "delete",
-            "create",
-            "edit",
-          ]
-        }
-      />
-    </div>
-  </PromisedContentWrapper>
-  <ComponentWrapper
-    permission="create"
-    style={
-      Object {
-        "width": "100%",
+    <Pagination
+      items={
+        Array [
+          <ForwardRef(WithStyles)
+            deletePermission="delete"
+            deleteStack={[Function]}
+            editPermission="edit"
+            openPermission="open"
+            openStack={[Function]}
+            stack={
+              Object {
+                "displayName": "name1",
+                "id": "1",
+                "type": "type1",
+              }
+            }
+            typeName="expectedTypeName"
+            userPermissions={
+              Array [
+                "open",
+                "delete",
+                "create",
+                "edit",
+              ]
+            }
+          />,
+          <ForwardRef(WithStyles)
+            deletePermission="delete"
+            deleteStack={[Function]}
+            editPermission="edit"
+            openPermission="open"
+            openStack={[Function]}
+            stack={
+              Object {
+                "displayName": "name2",
+                "id": "2",
+                "type": "type2",
+              }
+            }
+            typeName="expectedTypeName"
+            userPermissions={
+              Array [
+                "open",
+                "delete",
+                "create",
+                "edit",
+              ]
+            }
+          />,
+          <ForwardRef(WithStyles)
+            deletePermission="delete"
+            deleteStack={[Function]}
+            editPermission="edit"
+            openPermission="open"
+            openStack={[Function]}
+            stack={
+              Object {
+                "displayName": "name3",
+                "id": "3",
+                "type": "type3",
+              }
+            }
+            typeName="expectedTypeName"
+            userPermissions={
+              Array [
+                "open",
+                "delete",
+                "create",
+                "edit",
+              ]
+            }
+          />,
+        ]
       }
-    }
-    userPermissions={
-      Array [
-        "open",
-        "delete",
-        "create",
-        "edit",
-      ]
-    }
-  >
-    <div
-      className="StackCards-bottomControlDiv-2"
-    >
-      <WithStyles(NewStackButton)
-        onClick={[Function]}
-        typeName="expectedTypeName"
-      />
-    </div>
-  </ComponentWrapper>
+      paginationBarItems={
+        <ComponentWrapper
+          permission="create"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+          userPermissions={
+            Array [
+              "open",
+              "delete",
+              "create",
+              "edit",
+            ]
+          }
+        >
+          <NewStackButton
+            onClick={[Function]}
+            typeName="expectedTypeName"
+          />
+        </ComponentWrapper>
+      }
+    />
+  </PromisedContentWrapper>
 </div>
 `;
 
 exports[`StackCards creates correct snapshot for an empty array 1`] = `
 <div
-  className="StackCards-stackDiv-1"
+  className="makeStyles-stackDiv-1"
 >
   <PromisedContentWrapper
-    fetchingClassName="StackCards-placeholderCard-3"
+    fetchingClassName="makeStyles-placeholderCard-2"
     promise={
       Object {
         "fetching": false,
@@ -146,43 +144,44 @@ exports[`StackCards creates correct snapshot for an empty array 1`] = `
       }
     }
   >
-    <div>
-       
-      <div
-        className="StackCards-placeholderCard-3"
-      >
-        <WithStyles(ForwardRef(Typography))
-          variant="body1"
-        >
-          No items to display.
-        </WithStyles(ForwardRef(Typography))>
-      </div>
-    </div>
-  </PromisedContentWrapper>
-  <ComponentWrapper
-    permission="create"
-    style={
-      Object {
-        "width": "100%",
+    <Pagination
+      items={
+        Array [
+          <div
+            className="makeStyles-placeholderCard-2"
+          >
+            <ForwardRef(WithStyles)
+              variant="body1"
+            >
+              No items to display.
+            </ForwardRef(WithStyles)>
+          </div>,
+        ]
       }
-    }
-    userPermissions={
-      Array [
-        "open",
-        "delete",
-        "create",
-        "edit",
-      ]
-    }
-  >
-    <div
-      className="StackCards-bottomControlDiv-2"
-    >
-      <WithStyles(NewStackButton)
-        onClick={[Function]}
-        typeName="expectedTypeName"
-      />
-    </div>
-  </ComponentWrapper>
+      paginationBarItems={
+        <ComponentWrapper
+          permission="create"
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+          userPermissions={
+            Array [
+              "open",
+              "delete",
+              "create",
+              "edit",
+            ]
+          }
+        >
+          <NewStackButton
+            onClick={[Function]}
+            typeName="expectedTypeName"
+          />
+        </ComponentWrapper>
+      }
+    />
+  </PromisedContentWrapper>
 </div>
 `;

--- a/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
@@ -48,7 +48,7 @@ Object {
 `;
 
 exports[`DataStorageContainer is a container which passes correct props to StackCard 1`] = `
-<WithStyles(StackCards)
+<StackCards
   createPermission="projects:project99:storage:create"
   deletePermission="projects:project99:storage:delete"
   deleteStack={[Function]}

--- a/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/projects/__snapshots__/ProjectsContainer.spec.js.snap
@@ -67,7 +67,7 @@ exports[`ProjectsContainer is a container which passes correct props to StackCar
       variant="filled"
     />
   </div>
-  <WithStyles(StackCards)
+  <StackCards
     createPermission="system:instance:admin"
     deletePermission=""
     deleteStack={[Function]}

--- a/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
@@ -42,7 +42,7 @@ Object {
 `;
 
 exports[`StacksContainer is a container which passes correct props to StackCard 1`] = `
-<WithStyles(StackCards)
+<StackCards
   createPermission="projects:projtest:stacks:create"
   deletePermission="projects:projtest:stacks:delete"
   deleteStack={[Function]}

--- a/code/workspaces/web-app/src/hooks/useCallOnValueChange.js
+++ b/code/workspaces/web-app/src/hooks/useCallOnValueChange.js
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+// Call callback when value changes
+function useCallOnValueChange(value, callback) {
+  const [previousValue, setPreviousValue] = useState(value);
+  if (value !== previousValue) {
+    setPreviousValue(value);
+    callback();
+  }
+}
+
+export default useCallOnValueChange;

--- a/code/workspaces/web-app/src/hooks/useCallOnValueChange.spec.js
+++ b/code/workspaces/web-app/src/hooks/useCallOnValueChange.spec.js
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useCallOnValueChange from './useCallOnValueChange';
+
+describe('useCallOnValueChange', () => {
+  it('calls callback when input value changes, does not when value is the same', () => {
+    const originalValue = 0;
+    const callbackMock = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ value, callback }) => useCallOnValueChange(value, callback),
+      { initialProps: { value: originalValue, callback: callbackMock } },
+    );
+
+    // check not called on initial call
+    expect(callbackMock.mock.calls.length).toBe(0);
+
+    // check does not call callback when called with original value again
+    rerender({ value: originalValue, callback: callbackMock });
+    expect(callbackMock.mock.calls.length).toBe(0);
+
+    // check calls callback when value changes
+    const newValue = 10;
+    rerender({ value: newValue, callback: callbackMock });
+    expect(callbackMock.mock.calls.length).toBe(1);
+
+    // check does not call callback when called with new value again
+    rerender({ value: newValue, callback: callbackMock });
+    expect(callbackMock.mock.calls.length).toBe(1);
+  });
+});

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -843,6 +843,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.4":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.3":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
@@ -1271,6 +1278,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
 
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/react-transition-group@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz#92529142addb5cc179dbf42d246c7e3fe4d6104b"
@@ -1531,6 +1545,14 @@
     "@svgr/plugin-jsx" "^4.3.2"
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
+
+"@testing-library/react-hooks@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
+  integrity sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.3.0"
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
@@ -1830,6 +1852,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.2.tgz#8c851c4598a23a3a34173069fb4c5c9e41c02e3f"
@@ -1872,6 +1901,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__react-hooks@^3.3.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz#be148b7fa7d19cd3349c4ef9d9534486bc582fcc"
+  integrity sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/tough-cookie@*":
   version "2.3.5"
@@ -11328,17 +11364,7 @@ react-scripts@3.1.0:
   optionalDependencies:
     fsevents "2.0.7"
 
-react-test-renderer@16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
-  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.13.6"
-
-react-test-renderer@^16.0.0-0:
+react-test-renderer@16.9.0, react-test-renderer@^16.0.0-0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
   integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
@@ -12003,14 +12029,6 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
-
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
I've created a Pagination component that can take a list of items and then paginate those items. I have added this component to the StackCards components as this is used to handle the projects. This has the effect of paginating Notebooks and Storage etc. but this was the easiest way to implement it and I thought it would be beneficial any way. At the moment this is fixed to paginate in blocks of ten items although this is controlled through a prop on the pagination component so it should be easy to update to allow users control over this in the future if it proves desirable.