### PR TITLE
refactor: replace hard coded urls with environment variable injection

### DIFF
--- a/code/workspaces/auth-service/src/auth/authZeroAuthMiddleware.js
+++ b/code/workspaces/auth-service/src/auth/authZeroAuthMiddleware.js
@@ -6,13 +6,13 @@ const secretStrategy = jwksRsa.expressJwtSecret({
   cache: true,
   rateLimit: true,
   jwksRequestsPerMinute: 10,
-  jwksUri: 'https://mjbr.eu.auth0.com/.well-known/jwks.json',
+  jwksUri: `https://${config.get('authZeroDomain')}/.well-known/jwks.json`,
 });
 
 const baseConfig = {
   secret: secretStrategy,
   audience: config.get('authZeroAudience'),
-  issuer: 'https://mjbr.eu.auth0.com/',
+  issuer: `https://${config.get('authZeroDomain')}/`,
   algorithms: ['RS256'],
 };
 

--- a/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
+++ b/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
@@ -5,12 +5,12 @@ import config from '../config/config';
 import requestAccessToken from '../auth/accessToken';
 import { getOrSetCacheAsyncWrapper } from '../cache/cache';
 
-export const authZeroManagementApi = 'https://mjbr.eu.auth0.com/api/v2';
+export const authZeroManagementApi = `https://${config.get('authZeroDomain')}/api/v2`;
 const PAGE_LIMIT = 100;
 const AUTH0_MAXIMUM = 1000;
 
 const accessTokenRequest = () => ({
-  audience: `https://${config.get('authZeroDomain')}/api/v2/`,
+  audience: `${authZeroManagementApi}/`,
   client_id: config.get('userManagementClientId'),
   client_secret: config.get('userManagementClientSecret'),
 });


### PR DESCRIPTION
I noticed when looking at some code that the Auth0 URL had been hard coded in a couple of places. I thought I would fix it while I was there as it was a small job and might bite us when we try and move away from Auth0.