### PR TITLE
fix: remove unused imports

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/PaginationControls.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControls.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import PaginationControlButton, { PREVIOUS_PAGE, NEXT_PAGE } from './PaginationControlButton';

--- a/code/workspaces/web-app/src/components/stacks/StackCards.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles, withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import { sortBy } from 'lodash';
 import StackCard from './StackCard';
 import NewStackButton from './NewStackButton';


### PR DESCRIPTION
I missed these unused imports when creating the page pagination and they caused the CI pipeline to fail on master.