### PR TITLE
fix to allow jupyter notebooks to work on NFS/AzureFile or other non-…

### DIFF
--- a/code/workspaces/infrastructure-api/resources/container-info.yml
+++ b/code/workspaces/infrastructure-api/resources/container-info.yml
@@ -1,5 +1,5 @@
 JUPYTER_IMAGE: 'nerc/jupyterlab'
-JUPYTER_VERSION: '0.1.5'
+JUPYTER_VERSION: '0.1.7'
 
 ZEPPELIN_IMAGE: 'nerc/zeppelin'
 ZEPPELIN_VERSION: '0.7.2.7'

--- a/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
@@ -66,6 +66,8 @@ spec:
               value: "/data/.jupyter"
             - name: CONDA_ENV_DIR
               value: "/data/conda/"
+            - name: JUPYTER_ALLOW_INSECURE_WRITES
+              value: 'true'
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
…posix respecting storage classes

Whilst trying to spin up Jupyter notebooks with DataLab backed by AzureFile storage I was experiencing the error:
```
File "/opt/conda/lib/python3.7/site-packages/jupyter_client/connect.py", line 105, in secure_write
    assert '0600' == oct(stat.S_IMODE(os.stat(fname).st_mode)).replace('0o', '0')
AssertionError
```
It seems that the issue is that Jupyter is trying to write a private config file for the kernel when it starts running which is can't do on AzureFile because all files are mounted with a given permission (e.g. 777). This will also be true on NFS where you can only mount the entire drive with given permissions.

I manually edited the deployment in my k8s cluster to check this works and it's only the templates in the infrastructure api that need updating.