### PR TITLE
Add code-workspace file to fix ESLint in VS Code

### DIFF
--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -1,0 +1,19 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"extensions": {
+		"recommendations": [
+			"dbaeumer.vscode-eslint"
+		]
+	},
+	"settings": {
+		"eslint.workingDirectories": [
+			"./code"
+		],
+		"editor.formatOnSave": true,
+		"eslint.format.enable": true
+	}
+}


### PR DESCRIPTION
If you use VS code, you can use this file to open DataLabs as a workspace.
It will then recommend the ESLint extension, and configure VS Code to fix linting as you edit and save files.
The eslint.workingDirectories line is necessary because package.json is a level down from the root folder (without this, ESLint only works as a global install).