### PR TITLE
test: add logging to getScale

### DIFF
--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
@@ -62,6 +62,9 @@ function deleteDeployment(name, namespace) {
 
 async function getScale(name, namespace) {
   const response = await axios.get(getDeploymentScaleUrl(namespace, name));
+  // TODO will remove these loggers once finished debugging
+  logger.info(`getScale response.status ${JSON.stringify(response.status)}`);
+  logger.info(`getScale response.data ${JSON.stringify(response.data)}`);
   return response.data.spec.replicas;
 }
 


### PR DESCRIPTION
Received the following error:
```
info: Restarting deployment: jupyterlab-nburl in namespace: psepbb {"service":"infrastructure-service"}
error: undefined {"config":{"url":"http://localhost:8001/apis/apps/v1/namespaces/psepbb/deployments/jupyterlab-nburl/scale","method":"get","headers":{"Accept":"application/json, text/plain, */*","User-Agent":"axios/0.19.0"},"transformRequest":[null],"transformResponse":[null],"timeout":0,"xsrfCookieName":"XSRF-TOKEN","xsrfHeaderName":"X-XSRF-TOKEN","maxContentLength":-1}}
```
It appears there is an undefined, probably in
```
  return response.data.spec.replicas;
```

This logging will help me to identify the problem.