### PR TITLE
fix: when patching replicas, wait for status.replicas=spec.replicas

### DIFF
--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.js
@@ -73,7 +73,7 @@ async function getSpecReplicas(name, namespace) {
 }
 
 async function setSpecReplicas(name, namespace, specReplicas) {
-  await axios.patch(
+  const response = await axios.patch(
     getDeploymentScaleUrl(namespace, name),
     { spec: { replicas: specReplicas } },
     PATCH_CONTENT_HEADER,
@@ -88,11 +88,13 @@ async function setSpecReplicas(name, namespace, specReplicas) {
     // eslint-disable-next-line no-await-in-loop
     if (specReplicas === await getStatusReplicas(name, namespace)) {
       // specified number of replicas matches status number of replicas
-      return;
+      return response;
     }
     // eslint-disable-next-line no-await-in-loop
     await new Promise(resolve => setTimeout(resolve, checkWaitMs));
   }
+
+  return response;
 }
 
 async function restartDeployment(name, namespace) {
@@ -103,7 +105,8 @@ async function restartDeployment(name, namespace) {
     await setSpecReplicas(name, namespace, 0);
   }
   const newSpecReplicas = initialSpecReplicas || 1;
-  await setSpecReplicas(name, namespace, newSpecReplicas);
+  const response = await setSpecReplicas(name, namespace, newSpecReplicas);
+  return response;
 }
 
 export default { getDeployment, createDeployment, deleteDeployment, updateDeployment, createOrUpdateDeployment, restartDeployment };

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentApi.spec.js
@@ -173,13 +173,14 @@ describe('Kubernetes Deployment API', () => {
         });
 
       // Act
-      await deploymentApi.restartDeployment(DEPLOYMENT_NAME, NAMESPACE);
+      const response = await deploymentApi.restartDeployment(DEPLOYMENT_NAME, NAMESPACE);
 
       // Assert
       expect(getSpy).toHaveBeenCalledTimes(5);
       expect(patchSpy).toHaveBeenCalledTimes(2);
       expect(patchSpy).toHaveBeenNthCalledWith(1, { spec: { replicas: 0 } });
       expect(patchSpy).toHaveBeenNthCalledWith(2, { spec: { replicas: 1 } });
+      expect(response.status).toEqual(204);
     });
 
     it('should return an error if restart fails', async () => {


### PR DESCRIPTION
If patches happen in quick succession, they generate a http 409 conflict error.
Modified code waits (upto 10s) for a change of replica scale to be completed.
(In testing, I've normally only waited 100ms).