### PR TITLE
fix: re-add erroneously removed redirect following login

### DIFF
--- a/code/workspaces/web-app/src/components/app/AuthCallback.js
+++ b/code/workspaces/web-app/src/components/app/AuthCallback.js
@@ -10,6 +10,7 @@ export const handleAuth = async (searchUrl, routeTo, dispatch) => {
     try {
       const authResponse = await getAuth().handleAuthentication();
       dispatch(authActions.userLogsIn(authResponse));
+      dispatch(routeTo('/'));
     } catch (error) {
       // Redirect to home page if auth fails
       dispatch(routeTo('/'));


### PR DESCRIPTION
I'd previously removed the re-direct as it used a parameter which was no longer being supplied, but we still do need to re-direct on login otherwise the user needs to refresh after they're returned from auth0.