### PR TITLE
fix: fetch tags before git describe

### DIFF
--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+git fetch --tags
 GIT_DESCRIBE=`git describe --tags --always`
 
 if [[ ($# -eq 1 || $# -eq 2 && $2 == "--push" ) ]] && [[ "$1" =~ ^(docs|api|app|infrastructure|authorisation|common|chassis)$ ]]; then


### PR DESCRIPTION
The git describe in docker image tags isn't using the latest tag, attempt to fix.