### PR TITLE
NERCDL-635 choose storage type in data store

### DIFF
--- a/code/development-env/config/manifests/minikube-storage.yml
+++ b/code/development-env/config/manifests/minikube-storage.yml
@@ -5,3 +5,10 @@ metadata:
   namespace: kube-system
   name: glusterfs-storage
 provisioner: k8s.io/minikube-hostpath
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: nfs-storage
+provisioner: k8s.io/minikube-hostpath

--- a/code/development-env/insomnia/datalabs-apis.yaml
+++ b/code/development-env/insomnia/datalabs-apis.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2020-10-01T12:45:20.463Z
+__export_date: 2020-10-12T09:33:07.870Z
 __export_source: insomnia.desktop.app:v7.0.0
 resources:
   - _id: req_21517ac2a05e45d5af9813d3d84c98d7
@@ -224,7 +224,7 @@ resources:
       mimeType: application/json
       text: |-
         {
-        	"name": "jupyter",
+        	"name": "test2",
         	"type": "jupyter"
         }
     created: 1601542763150
@@ -236,7 +236,7 @@ resources:
     isPrivate: false
     metaSortKey: -1568712933543.5
     method: PUT
-    modified: 1601543126302
+    modified: 1601976141968
     name: Restart Stack
     parameters: []
     parentId: fld_541180f583704c469aaea72ca36c35be
@@ -245,7 +245,74 @@ resources:
     settingRebuildPath: true
     settingSendCookies: true
     settingStoreCookies: true
-    url: "{{ infra_api_url  }}/stack/project/restart"
+    url: "{{ infra_api_url  }}/stack/ploc/restart"
+    _type: request
+  - _id: req_aab771b6031e43d1ba89266cc5f782f8
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body:
+      mimeType: application/json
+      text: |-
+        {
+        	"projectKey": "ploc",
+        	"name": "locglusterfs",
+        	"displayName": "local glusterfs",
+        	"description": "test",
+        	"type": "glusterfs",
+        	"volumeSize": "5"
+        }
+    created: 1602494387999
+    description: ""
+    headers:
+      - id: pair_39e43053e7e84145ba27337b6f8de517
+        name: Content-Type
+        value: application/json
+    isPrivate: false
+    metaSortKey: -1568712933649.75
+    method: POST
+    modified: 1602494520510
+    name: Create Volume
+    parameters: []
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/volume"
+    _type: request
+  - _id: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    created: 1569410909114
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1569061905846.75
+    modified: 1569410912789
+    name: Volumes
+    parentId: fld_998699fb7271407c91200bc860ef8beb
+    _type: request_group
+  - _id: req_d460502f6a654c60abbfa6b619898eaf
+    authentication:
+      token: "{{ internal_token  }}"
+      type: bearer
+    body: {}
+    created: 1602494262838
+    description: ""
+    headers: []
+    isPrivate: false
+    metaSortKey: -1568712933599.75
+    method: GET
+    modified: 1602495084891
+    name: Get Volumes by Project
+    parameters: []
+    parentId: fld_f8507cecaacc4b00bd789a1cd72c59cd
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingSendCookies: true
+    settingStoreCookies: true
+    url: "{{ infra_api_url  }}/volumes/active/ploc"
     _type: request
   - _id: req_096786f5e88746f8b2d4eabe27e09694
     authentication:

--- a/code/workspaces/client-api/src/models/dataStorage.model.js
+++ b/code/workspaces/client-api/src/models/dataStorage.model.js
@@ -8,12 +8,18 @@ export const DELETED = 'deleted';
 
 const states = [REQUESTED, CREATING, DELETED];
 
+export const LEGACY_GLUSTERFS = '1';
+export const GLUSTERFS = 'glusterfs';
+export const NFS = 'nfs';
+
+const storageTypes = [LEGACY_GLUSTERFS, GLUSTERFS, NFS];
+
 const DataStorageSchema = new Schema({
   name: String,
   projectKey: String,
   displayName: String,
   description: String,
-  type: Number,
+  type: { type: String, enum: storageTypes, default: GLUSTERFS },
   volumeSize: String,
   url: String,
   internalEndpoint: String,

--- a/code/workspaces/client-api/src/models/dataStorage.model.js
+++ b/code/workspaces/client-api/src/models/dataStorage.model.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { stackTypes } from 'common';
 
 const { Schema } = mongoose;
 
@@ -8,18 +9,14 @@ export const DELETED = 'deleted';
 
 const states = [REQUESTED, CREATING, DELETED];
 
-export const LEGACY_GLUSTERFS = '1';
-export const GLUSTERFS = 'glusterfs';
-export const NFS = 'nfs';
-
-const storageTypes = [LEGACY_GLUSTERFS, GLUSTERFS, NFS];
+const storageTypes = [stackTypes.LEGACY_GLUSTERFS_VOLUME, stackTypes.GLUSTERFS_VOLUME, stackTypes.NFS_VOLUME];
 
 const DataStorageSchema = new Schema({
   name: String,
   projectKey: String,
   displayName: String,
   description: String,
-  type: { type: String, enum: storageTypes, default: GLUSTERFS },
+  type: { type: String, enum: storageTypes },
   volumeSize: String,
   url: String,
   internalEndpoint: String,

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -91,13 +91,6 @@ const resolvers = {
   ProjectUser: {
     name: (obj, args, ctx) => userService.getUserName(obj.userId, ctx.token),
   },
-
-  // This mapping is required to map the string to an id in the database.
-  // Ideally it would be removed but this would break existing database entries
-  StorageType: {
-    glusterfs: 1,
-    nfs: 2,
-  },
 };
 
 export default resolvers;

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -95,7 +95,8 @@ const resolvers = {
   // This mapping is required to map the string to an id in the database.
   // Ideally it would be removed but this would break existing database entries
   StorageType: {
-    nfs: 1,
+    glusterfs: 1,
+    nfs: 2,
   },
 };
 

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -106,13 +106,14 @@ input DataStorageUpdateRequest {
     users: [String]
 }
 
-# DataLabs data store type.
+# DataLabs data store type for retrieval.
+# type is not an enum when retrieving, because of legacy value for 1 = GlusterFS.  Enumeration is enforced in mongoose.
 type DataStore {
     id: ID
     name: String
     displayName: String
     description: String
-    type: StorageType
+    type: String
     volumeSize: Int
     url: String
     internalEndpoint: String
@@ -225,7 +226,7 @@ enum VisibilityType {
   public
 }
 
-# Data store classes within DataLabs
+# Data store classes within DataLabs for creation
 enum StorageType {
     # Network File System (NFS) share.
     nfs

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -229,6 +229,9 @@ enum VisibilityType {
 enum StorageType {
     # Network File System (NFS) share.
     nfs
+
+    # Gluster File System
+    glusterfs
 }
 
 # Type to represent Auth0 User

--- a/code/workspaces/common/src/stackTypes.js
+++ b/code/workspaces/common/src/stackTypes.js
@@ -6,6 +6,7 @@ const ZEPPELIN = 'zeppelin';
 const RSTUDIO = 'rstudio';
 const RSHINY = 'rshiny';
 const NBVIEWER = 'nbviewer';
+const LEGACY_GLUSTERFS_VOLUME = '1';
 const GLUSTERFS_VOLUME = 'glusterfs';
 const NFS_VOLUME = 'nfs';
 const PROJECT = 'project';
@@ -46,6 +47,11 @@ const STACK_TYPES = [
     category: PUBLISH,
   },
   {
+    name: LEGACY_GLUSTERFS_VOLUME,
+    shortDescription: 'A GlusterFS volume',
+    category: DATA_STORE,
+  },
+  {
     name: GLUSTERFS_VOLUME,
     shortDescription: 'A GlusterFS volume',
     category: DATA_STORE,
@@ -77,6 +83,7 @@ export {
   JUPYTER,
   JUPYTERLAB,
   NBVIEWER,
+  LEGACY_GLUSTERFS_VOLUME,
   GLUSTERFS_VOLUME,
   NFS_VOLUME,
   PROJECT,

--- a/code/workspaces/common/src/stackTypes.js
+++ b/code/workspaces/common/src/stackTypes.js
@@ -6,6 +6,7 @@ const ZEPPELIN = 'zeppelin';
 const RSTUDIO = 'rstudio';
 const RSHINY = 'rshiny';
 const NBVIEWER = 'nbviewer';
+const GLUSTERFS_VOLUME = 'glusterfs';
 const NFS_VOLUME = 'nfs';
 const PROJECT = 'project';
 
@@ -45,6 +46,11 @@ const STACK_TYPES = [
     category: PUBLISH,
   },
   {
+    name: GLUSTERFS_VOLUME,
+    shortDescription: 'A GlusterFS volume',
+    category: DATA_STORE,
+  },
+  {
     name: NFS_VOLUME,
     shortDescription: 'A NFS volume',
     category: DATA_STORE,
@@ -71,6 +77,7 @@ export {
   JUPYTER,
   JUPYTERLAB,
   NBVIEWER,
+  GLUSTERFS_VOLUME,
   NFS_VOLUME,
   PROJECT,
   PUBLISH,

--- a/code/workspaces/common/src/stackTypes.js
+++ b/code/workspaces/common/src/stackTypes.js
@@ -47,11 +47,6 @@ const STACK_TYPES = [
     category: PUBLISH,
   },
   {
-    name: LEGACY_GLUSTERFS_VOLUME,
-    shortDescription: 'A GlusterFS volume',
-    category: DATA_STORE,
-  },
-  {
     name: GLUSTERFS_VOLUME,
     shortDescription: 'A GlusterFS volume',
     category: DATA_STORE,

--- a/code/workspaces/infrastructure-api/src/config/config.js
+++ b/code/workspaces/infrastructure-api/src/config/config.js
@@ -37,11 +37,17 @@ const config = convict({
     default: 'http://localhost:8001',
     env: 'KUBERNETES_API',
   },
-  storageClass: {
-    doc: 'The storage class to use for new volumes',
+  glusterFSStorageClass: {
+    doc: 'The storage class to use for GlusterFS volumes',
     format: 'String',
     default: 'glusterfs-storage',
-    env: 'STORAGE_CLASS',
+    env: 'GLUSTERFS_STORAGE_CLASS',
+  },
+  nfsStorageClass: {
+    doc: 'The storage class to use for NFS volumes',
+    format: 'String',
+    default: 'nfs-storage',
+    env: 'NFS_STORAGE_CLASS',
   },
   authSigninUrl: {
     doc: 'The sign in URL',

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -1,9 +1,10 @@
+import { stackTypes } from 'common';
 import { service } from 'service-chassis';
 import { check, matchedData } from 'express-validator';
 import volumeManager from '../stacks/volumeManager';
 import dataStorageRepository from '../dataaccess/dataStorageRepository';
 import logger from '../config/logger';
-import { DELETED, NFS, GLUSTERFS } from '../models/dataStorage.model';
+import { DELETED } from '../models/dataStorage.model';
 
 async function createVolume(request, response, next) {
   // Build request params
@@ -133,7 +134,7 @@ const createVolumeValidator = service.middleware.validator([
   existsCheck('description'),
   existsCheck('type')
     .exists()
-    .isIn([GLUSTERFS, NFS]),
+    .isIn([stackTypes.GLUSTERFS_VOLUME, stackTypes.NFS_VOLUME]),
   existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
     .withMessage('Volume Size must be an integer between 5 and 200'),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -132,8 +132,8 @@ const createVolumeValidator = service.middleware.validator([
   existsCheck('displayName'),
   existsCheck('description'),
   existsCheck('type')
-    .isInt({ min: 1, max: 1 })
-    .withMessage('type must be specified as a valid storage type'),
+    .isInt({ min: 1, max: 2 })
+    .withMessage('Type must be 1 (glusterfs) or 2 (nfs)'),
   existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
     .withMessage('Volume Size must be an integer between 5 and 200'),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -3,7 +3,7 @@ import { check, matchedData } from 'express-validator';
 import volumeManager from '../stacks/volumeManager';
 import dataStorageRepository from '../dataaccess/dataStorageRepository';
 import logger from '../config/logger';
-import { DELETED } from '../models/dataStorage.model';
+import { DELETED, NFS, GLUSTERFS } from '../models/dataStorage.model';
 
 async function createVolume(request, response, next) {
   // Build request params
@@ -132,8 +132,8 @@ const createVolumeValidator = service.middleware.validator([
   existsCheck('displayName'),
   existsCheck('description'),
   existsCheck('type')
-    .isInt({ min: 1, max: 2 })
-    .withMessage('Type must be 1 (glusterfs) or 2 (nfs)'),
+    .exists()
+    .isIn([GLUSTERFS, NFS]),
   existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
     .withMessage('Volume Size must be an integer between 5 and 200'),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -136,7 +136,7 @@ const createVolumeValidator = service.middleware.validator([
   existsCheck('type')
     .exists()
     .isIn(allowedVolumeTypes)
-    .withMessage(`Type muste be one of ${allowedVolumeTypes}`),
+    .withMessage(`Type must be one of ${allowedVolumeTypes}`),
   existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
     .withMessage('Volume Size must be an integer between 5 and 200'),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -127,6 +127,7 @@ const updateVolumeUserValidator = service.middleware.validator([
   existsCheck('userIds.*'),
 ], logger);
 
+const allowedVolumeTypes = [stackTypes.GLUSTERFS_VOLUME, stackTypes.NFS_VOLUME];
 const createVolumeValidator = service.middleware.validator([
   projectKeyCheck,
   nameCheck,
@@ -134,7 +135,8 @@ const createVolumeValidator = service.middleware.validator([
   existsCheck('description'),
   existsCheck('type')
     .exists()
-    .isIn([stackTypes.GLUSTERFS_VOLUME, stackTypes.NFS_VOLUME]),
+    .isIn(allowedVolumeTypes)
+    .withMessage(`Type muste be one of ${allowedVolumeTypes}`),
   existsCheck('volumeSize')
     .isInt({ min: 5, max: 200 })
     .withMessage('Volume Size must be an integer between 5 and 200'),

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -90,11 +90,11 @@ describe('Volume Controller', () => {
       expectValidationError('volumeSize', 'Volume Size must be an integer between 5 and 200');
     });
 
-    it('should validate the type is between 1 and 2', async () => {
+    it('should validate the type is one of glusterfs,nfs', async () => {
       const requestBody = createRequestBody();
-      requestBody.type = 0;
+      requestBody.type = 1;
       await executeCreateValidator(requestBody);
-      expectValidationError('type', 'Type muste be one of glusterfs,nfs');
+      expectValidationError('type', 'Type must be one of glusterfs,nfs');
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -94,7 +94,7 @@ describe('Volume Controller', () => {
       const requestBody = createRequestBody();
       requestBody.type = 0;
       await executeCreateValidator(requestBody);
-      expectValidationError('type', 'Type must be 1 (glusterfs) or 2 (nfs)');
+      expectValidationError('type', 'Type muste be one of glusterfs,nfs');
     });
   });
 
@@ -283,7 +283,7 @@ function createRequestBody() {
     projectKey: 'project99',
     displayName: 'displayName',
     description: 'description',
-    type: 1,
+    type: 'glusterfs',
     volumeSize: '10',
   };
 }

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -89,6 +89,13 @@ describe('Volume Controller', () => {
       await executeCreateValidator(requestBody);
       expectValidationError('volumeSize', 'Volume Size must be an integer between 5 and 200');
     });
+
+    it('should validate the type is between 1 and 2', async () => {
+      const requestBody = createRequestBody();
+      requestBody.type = 0;
+      await executeCreateValidator(requestBody);
+      expectValidationError('type', 'Type must be 1 (glusterfs) or 2 (nfs)');
+    });
   });
 
   describe('delete volume', () => {

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
@@ -1,11 +1,11 @@
 import config from '../config/config';
 import { VolumeTemplates, generateManifest } from './manifestGenerator';
+import { NFS, GLUSTERFS } from '../models/dataStorage.model';
 
 function getStorageClass(type) {
-  // these values correspond to code/workspaces/client-api/src/schema/resolvers.js StorageType
-  if (type === '1') {
+  if (type === GLUSTERFS) {
     return config.get('glusterFSStorageClass');
-  } if (type === '2') {
+  } if (type === NFS) {
     return config.get('nfsStorageClass');
   }
   throw new Error(`Unrecognized storage class type ${type}`);

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
@@ -1,11 +1,22 @@
 import config from '../config/config';
 import { VolumeTemplates, generateManifest } from './manifestGenerator';
 
-function createVolume(name, volumeSize) {
+function getStorageClass(type) {
+  // these values correspond to code/workspaces/client-api/src/schema/resolvers.js StorageType
+  if (type === '1') {
+    return config.get('glusterFSStorageClass');
+  } if (type === '2') {
+    return config.get('nfsStorageClass');
+  }
+  throw new Error(`Unrecognized storage class type ${type}`);
+}
+
+async function createVolume(name, volumeSize, type) {
+  const storageClass = await getStorageClass(type);
   const context = {
     name,
     volumeSize,
-    storageClass: config.get('storageClass'),
+    storageClass,
   };
   return generateManifest(context, VolumeTemplates.DEFAULT_VOLUME);
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.js
@@ -1,11 +1,11 @@
+import { stackTypes } from 'common';
 import config from '../config/config';
 import { VolumeTemplates, generateManifest } from './manifestGenerator';
-import { NFS, GLUSTERFS } from '../models/dataStorage.model';
 
 function getStorageClass(type) {
-  if (type === GLUSTERFS) {
+  if (type === stackTypes.GLUSTERFS_VOLUME) {
     return config.get('glusterFSStorageClass');
-  } if (type === NFS) {
+  } if (type === stackTypes.NFS_VOLUME) {
     return config.get('nfsStorageClass');
   }
   throw new Error(`Unrecognized storage class type ${type}`);

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.spec.js
@@ -4,7 +4,7 @@ describe('volumeGenerator', () => {
   describe('createVolume', () => {
     it('creates GlusterFS manifest', async () => {
       // Act
-      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, '1');
+      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, 'glusterfs');
 
       // Assert
       expect(glusterFSManifest).toMatch('name: volume-name');
@@ -14,7 +14,7 @@ describe('volumeGenerator', () => {
 
     it('creates NFS manifest', async () => {
       // Act
-      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, '2');
+      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, 'nfs');
 
       // Assert
       expect(glusterFSManifest).toMatch('name: volume-name');
@@ -24,7 +24,7 @@ describe('volumeGenerator', () => {
 
     it('throws error for unexpected storage type', async () => {
       // Assert
-      await expect(volumeGenerator.createVolume('volume-name', 5, '0')).rejects.toThrow('Unrecognized storage class type 0');
+      await expect(volumeGenerator.createVolume('volume-name', 5, '1')).rejects.toThrow('Unrecognized storage class type 1');
     });
   });
 });

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeGenerator.spec.js
@@ -1,0 +1,30 @@
+import volumeGenerator from './volumeGenerator';
+
+describe('volumeGenerator', () => {
+  describe('createVolume', () => {
+    it('creates GlusterFS manifest', async () => {
+      // Act
+      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, '1');
+
+      // Assert
+      expect(glusterFSManifest).toMatch('name: volume-name');
+      expect(glusterFSManifest).toMatch('storage: 5G');
+      expect(glusterFSManifest).toMatch('storageClassName: glusterfs-storage');
+    });
+
+    it('creates NFS manifest', async () => {
+      // Act
+      const glusterFSManifest = await volumeGenerator.createVolume('volume-name', 5, '2');
+
+      // Assert
+      expect(glusterFSManifest).toMatch('name: volume-name');
+      expect(glusterFSManifest).toMatch('storage: 5G');
+      expect(glusterFSManifest).toMatch('storageClassName: nfs-storage');
+    });
+
+    it('throws error for unexpected storage type', async () => {
+      // Assert
+      await expect(volumeGenerator.createVolume('volume-name', 5, '0')).rejects.toThrow('Unrecognized storage class type 0');
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/models/dataStorage.model.js
+++ b/code/workspaces/infrastructure-api/src/models/dataStorage.model.js
@@ -8,12 +8,18 @@ export const DELETED = 'deleted';
 
 const states = [REQUESTED, CREATING, DELETED];
 
+export const LEGACY_GLUSTERFS = '1';
+export const GLUSTERFS = 'glusterfs';
+export const NFS = 'nfs';
+
+const storageTypes = [LEGACY_GLUSTERFS, GLUSTERFS, NFS];
+
 const DataStorageSchema = new Schema({
   name: String,
   projectKey: String,
   displayName: String,
   description: String,
-  type: Number,
+  type: { type: String, enum: storageTypes, default: GLUSTERFS },
   volumeSize: String,
   url: String,
   internalEndpoint: String,

--- a/code/workspaces/infrastructure-api/src/models/dataStorage.model.js
+++ b/code/workspaces/infrastructure-api/src/models/dataStorage.model.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { stackTypes } from 'common';
 
 const { Schema } = mongoose;
 
@@ -8,18 +9,14 @@ export const DELETED = 'deleted';
 
 const states = [REQUESTED, CREATING, DELETED];
 
-export const LEGACY_GLUSTERFS = '1';
-export const GLUSTERFS = 'glusterfs';
-export const NFS = 'nfs';
-
-const storageTypes = [LEGACY_GLUSTERFS, GLUSTERFS, NFS];
+const storageTypes = [stackTypes.LEGACY_GLUSTERFS_VOLUME, stackTypes.GLUSTERFS_VOLUME, stackTypes.NFS_VOLUME];
 
 const DataStorageSchema = new Schema({
   name: String,
   projectKey: String,
   displayName: String,
   description: String,
-  type: { type: String, enum: storageTypes, default: GLUSTERFS },
+  type: { type: String, enum: storageTypes },
   volumeSize: String,
   url: String,
   internalEndpoint: String,

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -95,10 +95,10 @@ export const createIngressRuleWithConnect = (params, generator) => (service) => 
 };
 
 export const createPersistentVolume = (params, generator) => () => {
-  const { name, volumeSize, projectKey } = params;
+  const { name, volumeSize, projectKey, type } = params;
   const volumeName = nameGenerator.pvcName(name);
 
-  return generator(volumeName, volumeSize)
+  return generator(volumeName, volumeSize, type)
     .then((manifest) => {
       logger.info(`Creating persistent volume ${chalk.blue(volumeName)} with manifest:`);
       logger.debug(manifest.toString());

--- a/code/workspaces/web-app/src/api/dataStorageService.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.js
@@ -1,3 +1,4 @@
+import { stackTypes } from 'common';
 import { gqlMutation, gqlQuery } from './graphqlClient';
 import errorHandler from './graphqlErrorHandler';
 
@@ -10,6 +11,19 @@ function loadDataStorage(projectKey) {
     }`;
 
   return gqlQuery(query, { projectKey })
+    .then((val) => {
+      // map legacy stack.type of '1' to 'glusterfs'
+      const newStacks = val.data.dataStorage.map(stack => ({
+        ...stack,
+        type: (stack.type === stackTypes.LEGACY_GLUSTERFS_VOLUME) ? stackTypes.GLUSTERFS_VOLUME : stack.type,
+      }));
+      const newVal = {
+        data: {
+          dataStorage: newStacks,
+        },
+      };
+      return newVal;
+    })
     .then(errorHandler('data.dataStorage', 'users'));
 }
 

--- a/code/workspaces/web-app/src/api/dataStorageService.spec.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.spec.js
@@ -7,13 +7,45 @@ describe('dataStorageService', () => {
   beforeEach(() => mockClient.clearResult());
 
   describe('loadDataStorage', () => {
-    it('should build the correct query and unpack the results', () => {
-      mockClient.prepareSuccess({ dataStorage: 'expectedValue' });
+    it('should build the correct query and unpack the results', async () => {
+      // Arrange
+      const legacyDataStorage = [
+        {
+          name: 'legacy glusterfs storage',
+          type: '1',
+        },
+        {
+          name: 'glusterfs storage',
+          type: 'glusterfs',
+        },
+        {
+          name: 'nfs storage',
+          type: 'nfs',
+        },
+      ];
+      const mappedDataStorage = [
+        {
+          name: 'legacy glusterfs storage',
+          type: 'glusterfs', // i.e. '1' has been mapped to 'glusterfs'
+        },
+        {
+          name: 'glusterfs storage',
+          type: 'glusterfs',
+        },
+        {
+          name: 'nfs storage',
+          type: 'nfs',
+        },
+      ];
+      const clientResponse = { dataStorage: legacyDataStorage };
+      mockClient.prepareSuccess(clientResponse);
 
-      dataStorageService.loadDataStorage('project99').then((response) => {
-        expect(response).toEqual('expectedValue');
-        expect(mockClient.lastQuery()).toMatchSnapshot();
-      });
+      // Act
+      const dataStorage = await dataStorageService.loadDataStorage('project99');
+
+      // Assert
+      expect(dataStorage).toEqual(mappedDataStorage);
+      expect(mockClient.lastQuery()).toMatchSnapshot();
     });
 
     it('should throw an error if the query fails', async () => {

--- a/code/workspaces/web-app/src/components/common/typography/StorageType.js
+++ b/code/workspaces/web-app/src/components/common/typography/StorageType.js
@@ -1,0 +1,6 @@
+import ProjectKey from './ProjectKey';
+
+// use the same style as ProjectKey
+const StorageType = ProjectKey;
+
+export default StorageType;

--- a/code/workspaces/web-app/src/components/dataStorage/CreateDataStoreForm.js
+++ b/code/workspaces/web-app/src/components/dataStorage/CreateDataStoreForm.js
@@ -6,7 +6,7 @@ import { renderTextField, renderSelectField, renderTextArea, CreateFormControls 
 import { syncValidate, asyncValidate } from './newDataStoreFormValidator';
 
 const { DATA_STORE, getStackSelections } = stackTypes;
-const initialValues = { type: 'nfs' };
+const initialValues = { type: 'glusterfs' };
 
 const CreateDataStoreForm = (props) => {
   const { handleSubmit, cancel, submitting } = props;

--- a/code/workspaces/web-app/src/components/dataStorage/__snapshots__/CreateDataStoreForm.spec.js.snap
+++ b/code/workspaces/web-app/src/components/dataStorage/__snapshots__/CreateDataStoreForm.spec.js.snap
@@ -18,6 +18,10 @@ exports[`CreateDataStoreForm creates correct snapshot for create Data Store Form
       options={
         Array [
           Object {
+            "text": "Glusterfs",
+            "value": "glusterfs",
+          },
+          Object {
             "text": "Nfs",
             "value": "nfs",
           },

--- a/code/workspaces/web-app/src/components/modal/__snapshots__/CreateDataStoreDialog.spec.js.snap
+++ b/code/workspaces/web-app/src/components/modal/__snapshots__/CreateDataStoreDialog.spec.js.snap
@@ -34,7 +34,7 @@ exports[`CreateDataStoreDialog dialog creates correct snapshot 1`] = `
           getFormState={[Function]}
           initialValues={
             Object {
-              "type": "nfs",
+              "type": "glusterfs",
             }
           }
           keepDirtyOnReinitialize={false}

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -9,6 +9,7 @@ import StackCardActions from './StackCardActions';
 import stackDescriptions from './stackDescriptions';
 import StackStatus from './StackStatus';
 import { useUsers } from '../../hooks/usersHooks';
+import StorageType from '../common/typography/StorageType';
 
 function styles(theme) {
   return {
@@ -97,6 +98,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
         <div className={classes.displayNameContainer}>
           <Typography variant="h5" className={classes.displayName} noWrap>{getDisplayName(stack)}</Typography>
           {typeName === 'Project' ? <ProjectKey>({stack.key})</ProjectKey> : null}
+          {typeName === 'Data Store' ? <StorageType>({stack.type})</StorageType> : null}
         </div>
         <Tooltip title={getDescription(stack, typeName)} placement='bottom-start'>
           <Typography variant="body1" noWrap>{getDescription(stack, typeName)}</Typography>

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -98,7 +98,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
         <div className={classes.displayNameContainer}>
           <Typography variant="h5" className={classes.displayName} noWrap>{getDisplayName(stack)}</Typography>
           {typeName === 'Project' ? <ProjectKey>({stack.key})</ProjectKey> : null}
-          {typeName === 'Data Store' ? <StorageType>({stack.type})</StorageType> : null}
+          {(typeName === 'Data Store' && stack.type) ? <StorageType>({stackDescriptions[stack.type].description})</StorageType> : null}
         </div>
         <Tooltip title={getDescription(stack, typeName)} placement='bottom-start'>
           <Typography variant="body1" noWrap>{getDescription(stack, typeName)}</Typography>

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -98,7 +98,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, typeName
         <div className={classes.displayNameContainer}>
           <Typography variant="h5" className={classes.displayName} noWrap>{getDisplayName(stack)}</Typography>
           {typeName === 'Project' ? <ProjectKey>({stack.key})</ProjectKey> : null}
-          {(typeName === 'Data Store' && stack.type) ? <StorageType>({stackDescriptions[stack.type].description})</StorageType> : null}
+          {(typeName === 'Data Store' && stack.type) ? <StorageType>({stack.type})</StorageType> : null}
         </div>
         <Tooltip title={getDescription(stack, typeName)} placement='bottom-start'>
           <Typography variant="body1" noWrap>{getDescription(stack, typeName)}</Typography>

--- a/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
@@ -57,6 +57,17 @@ describe('StackCard', () => {
     expect(output).toMatchSnapshot();
   });
 
+  it('creates correct snapshot for glusterfs stack type', () => {
+    // Arrange
+    const props = generateProps('glusterfs');
+
+    // Act
+    const output = shallowRender(props);
+
+    // Assert
+    expect(output).toMatchSnapshot();
+  });
+
   it('should show status ad buttons when status is ready', () => {
     // Arrange
     const props = generateProps('jupyter', 'ready');

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -150,6 +150,76 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
 </div>
 `;
 
+exports[`StackCard creates correct snapshot for glusterfs stack type 1`] = `
+<div
+  className="StackCard-cardDiv-1"
+>
+  <div
+    className="StackCard-imageDiv-2"
+  >
+    <WithStyles(ForwardRef(Icon))
+      className="StackCard-cardIcon-9"
+    >
+      save
+    </WithStyles(ForwardRef(Icon))>
+  </div>
+  <div
+    className="StackCard-textDiv-3"
+  >
+    <div
+      className="StackCard-displayNameContainer-5"
+    >
+      <WithStyles(ForwardRef(Typography))
+        className="StackCard-displayName-4"
+        noWrap={true}
+        variant="h5"
+      >
+        name1
+      </WithStyles(ForwardRef(Typography))>
+    </div>
+    <WithStyles(ForwardRef(Tooltip))
+      placement="bottom-start"
+      title="Gluster File System (GlusterFS) volume to store data for Notebooks and Sites."
+    >
+      <WithStyles(ForwardRef(Typography))
+        noWrap={true}
+        variant="body1"
+      >
+        Gluster File System (GlusterFS) volume to store data for Notebooks and Sites.
+      </WithStyles(ForwardRef(Typography))>
+    </WithStyles(ForwardRef(Tooltip))>
+  </div>
+  <div
+    className="StackCard-actionsDiv-6"
+  >
+    <WithStyles(StackCardActions)
+      deletePermission="delete"
+      deleteStack={[Function]}
+      editPermission="edit"
+      openPermission="open"
+      openStack={[Function]}
+      shareStack={[Function]}
+      stack={
+        Object {
+          "displayName": "name1",
+          "id": "100",
+          "shared": "private",
+          "status": undefined,
+          "type": "glusterfs",
+        }
+      }
+      userPermissions={
+        Array [
+          "open",
+          "delete",
+          "edit",
+        ]
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`StackCard should show status ad buttons when status is ready 1`] = `
 <div
   className="StackCard-cardDiv-1"

--- a/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
+++ b/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
@@ -6,7 +6,7 @@ import rshinyLogo from '../../assets/images/rshiny-logo.png';
 import rstudioLogo from '../../assets/images/rstudio-logo.png';
 import zeppelinLogo from '../../assets/images/zeppelin-logo.svg';
 
-const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, LEGACY_GLUSTERFS_VOLUME, GLUSTERFS_VOLUME, NFS_VOLUME, PROJECT } = stackTypes;
+const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, GLUSTERFS_VOLUME, NFS_VOLUME, PROJECT } = stackTypes;
 
 const jupyterDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
 const jupyterlabDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
@@ -27,7 +27,6 @@ export default {
   [RSTUDIO]: { description: rstudioDescription, logo: rstudioLogo },
   [RSHINY]: { description: rshinyDescription, logo: rshinyLogo },
   [NBVIEWER]: { description: nbviewerDescription, logo: nbviewerLogo },
-  [LEGACY_GLUSTERFS_VOLUME]: { description: glusterfsVolumeDescription, icon: 'save' },
   [GLUSTERFS_VOLUME]: { description: glusterfsVolumeDescription, icon: 'save' },
   [NFS_VOLUME]: { description: nfsVolumeDescription, icon: 'save' },
   [PROJECT]: { description: projectDescription, initial: true },

--- a/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
+++ b/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
@@ -6,7 +6,7 @@ import rshinyLogo from '../../assets/images/rshiny-logo.png';
 import rstudioLogo from '../../assets/images/rstudio-logo.png';
 import zeppelinLogo from '../../assets/images/zeppelin-logo.svg';
 
-const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, NFS_VOLUME, PROJECT } = stackTypes;
+const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, GLUSTERFS_VOLUME, NFS_VOLUME, PROJECT } = stackTypes;
 
 const jupyterDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
 const jupyterlabDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
@@ -16,6 +16,7 @@ const rstudioDescription = 'RStudio is an integrated development environment (ID
 const rshinyDescription = 'Shiny is an R package that makes it easy to build interactive web apps straight from R. You can host standalone apps on a webpage or '
   + 'embed them in R Markdown documents or build dashboards.';
 const nbviewerDescription = 'NBViewer is a simple way to share notebooks. Any Jupyter notebook can be served as a web page.';
+const glusterfsVolumeDescription = 'Gluster File System (GlusterFS) volume to store data for Notebooks and Sites.';
 const nfsVolumeDescription = 'Network File System (NFS) volume to store data for Notebooks and Sites.';
 const projectDescription = 'A project lets users share information';
 
@@ -26,6 +27,7 @@ export default {
   [RSTUDIO]: { description: rstudioDescription, logo: rstudioLogo },
   [RSHINY]: { description: rshinyDescription, logo: rshinyLogo },
   [NBVIEWER]: { description: nbviewerDescription, logo: nbviewerLogo },
+  [GLUSTERFS_VOLUME]: { description: glusterfsVolumeDescription, icon: 'save' },
   [NFS_VOLUME]: { description: nfsVolumeDescription, icon: 'save' },
   [PROJECT]: { description: projectDescription, initial: true },
 };

--- a/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
+++ b/code/workspaces/web-app/src/components/stacks/stackDescriptions.js
@@ -6,7 +6,7 @@ import rshinyLogo from '../../assets/images/rshiny-logo.png';
 import rstudioLogo from '../../assets/images/rstudio-logo.png';
 import zeppelinLogo from '../../assets/images/zeppelin-logo.svg';
 
-const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, GLUSTERFS_VOLUME, NFS_VOLUME, PROJECT } = stackTypes;
+const { JUPYTER, JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY, NBVIEWER, LEGACY_GLUSTERFS_VOLUME, GLUSTERFS_VOLUME, NFS_VOLUME, PROJECT } = stackTypes;
 
 const jupyterDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
 const jupyterlabDescription = 'Web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text.';
@@ -27,6 +27,7 @@ export default {
   [RSTUDIO]: { description: rstudioDescription, logo: rstudioLogo },
   [RSHINY]: { description: rshinyDescription, logo: rshinyLogo },
   [NBVIEWER]: { description: nbviewerDescription, logo: nbviewerLogo },
+  [LEGACY_GLUSTERFS_VOLUME]: { description: glusterfsVolumeDescription, icon: 'save' },
   [GLUSTERFS_VOLUME]: { description: glusterfsVolumeDescription, icon: 'save' },
   [NFS_VOLUME]: { description: nfsVolumeDescription, icon: 'save' },
   [PROJECT]: { description: projectDescription, initial: true },


### PR DESCRIPTION
Allows the user to choose between NFS and GlusterFS when creating a data store.
Also changes the Mongo storage to save the storage type as 'glusterfs' (and 'nfs') rather than '1'.
Legacy values of '1' are mapped to 'glusterfs' in the web-app dataStorageService.