### PR TITLE
fix: pagination button wording and warnings in test output

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/Pagination.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/Pagination.spec.js
@@ -33,7 +33,7 @@ describe('Pagination', () => {
   });
 
   it('renders array of additional items in control bar after pagination controls in own div', () => {
-    const barItems = [<span>Bar Item 1</span>, <span>Bar Item 1</span>];
+    const barItems = [<span key={0}>Bar Item 1</span>, <span key={1}>Bar Item 1</span>];
     const props = generateProps(4, 2, barItems);
     const output = shallowRender(props);
     expect(output).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/stacks/PaginationControlButton.js
+++ b/code/workspaces/web-app/src/components/stacks/PaginationControlButton.js
@@ -10,11 +10,11 @@ export const NEXT_PAGE = 'next';
 
 function getTooltipTitle(variant, disabled) {
   if (variant === PREVIOUS_PAGE) {
-    return !disabled ? 'Previous page' : 'No previous page to goto';
+    return !disabled ? 'Previous page' : 'No previous page';
   }
 
   if (variant === NEXT_PAGE) {
-    return !disabled ? 'Next page' : 'No next page to goto';
+    return !disabled ? 'Next page' : 'No next page';
   }
 
   return '';

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/Pagination.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/Pagination.spec.js.snap
@@ -25,10 +25,14 @@ exports[`Pagination renders array of additional items in control bar after pagin
       setPageNum={[Function]}
     />
     <div>
-      <span>
+      <span
+        key="0"
+      >
         Bar Item 1
       </span>
-      <span>
+      <span
+        key="1"
+      >
         Bar Item 1
       </span>
     </div>

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlButton.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/PaginationControlButton.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PaginationControlButton renders correctly when variant is "next" and it is disabled 1`] = `
 <WithStyles(ForwardRef(Tooltip))
-  title="No next page to goto"
+  title="No next page"
 >
   <span>
      
@@ -36,7 +36,7 @@ exports[`PaginationControlButton renders correctly when variant is "next" and it
 
 exports[`PaginationControlButton renders correctly when variant is "previous" and it is disabled 1`] = `
 <WithStyles(ForwardRef(Tooltip))
-  title="No previous page to goto"
+  title="No previous page"
 >
   <span>
      


### PR DESCRIPTION
Updated the wording in the pagination component for when there is no next page or no previous page. 

Updated test so does not output warning about arrays of components requiring a `key` prop.