### PR TITLE
fix: attempt to fix docker tagging

### DIFF
--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-git fetch --tags
-GIT_DESCRIBE=`git describe --tags --always`
+GIT_DESCRIBE=`git describe --tags --always --candidates=10000`
 
 if [[ ($# -eq 1 || $# -eq 2 && $2 == "--push" ) ]] && [[ "$1" =~ ^(docs|api|app|infrastructure|authorisation|common|chassis)$ ]]; then
   case "$1" in


### PR DESCRIPTION
The docker image tagging isn't matching what we get in git describe.  I've previously tried to fix this by doing
git fetch --tags
but that didn't help, so now I'm increasing how it looks through branches, see --candidates in https://git-scm.com/docs/git-describe.