### PR TITLE
fix: docker versioning

### DIFF
--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e
 
-GIT_DESCRIBE=`git describe --tags --always --candidates=10000`
+echo "Fetching recent git history"
+git fetch --shallow-exclude 0.30.0
+git repack -d
+git fetch --deepen=1
+GIT_DESCRIBE=`git describe --tags --always`
 
 if [[ ($# -eq 1 || $# -eq 2 && $2 == "--push" ) ]] && [[ "$1" =~ ^(docs|api|app|infrastructure|authorisation|common|chassis)$ ]]; then
   case "$1" in


### PR DESCRIPTION
Travis basically does
```
git clone --depth 50 https://github.com/NERC-CEH/datalab.git
```
see https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth.

Doing shallow clones can be a good idea, since eventually you can run into problems cloning repos with very big histories.  We don't need a full history, just enough to make sure we've got the most recent tags.  So this change gets tags back as far as 0.30.0.
The `git repack -d` is necessary to prevent an error similar to this one: https://stackoverflow.com/questions/63878612/git-fatal-error-in-object-unshallow-sha-1