### PR TITLE
NERCDL-635 support nfs in deployment templates

### DIFF
--- a/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
@@ -26,20 +26,20 @@ spec:
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "mkdir -p /mnt/glusterfs/notebooks/{{ name }}"]
+          args: ["-c", "mkdir -p /mnt/persistentfs/notebooks/{{ name }}"]
           volumeMounts:
-            - mountPath: /mnt/glusterfs
-              name: glusterfsvol
-        # This container correct the folder permissions for the generated notebook directory to be owned by the
-        # datalabs:users (user:group; 1000:100).
-        - name: set-directory-owner
+            - mountPath: /mnt/persistentfs
+              name: persistentfsvol
+        # This container sets the folder permissions for the generated notebook directory to be usable by
+        # datalabs:users.
+        - name: set-directory-permissions
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "chown 1000:100 /mnt/glusterfs/notebooks && chown 1000:100 /mnt/glusterfs/notebooks/{{ name }}"]
+          args: ["-c", "chmod 777 /mnt/persistentfs/notebooks && chmod777 /mnt/persistentfs/notebooks/{{ name }}"]
           volumeMounts:
-            - mountPath: /mnt/glusterfs
-              name: glusterfsvol
+            - mountPath: /mnt/persistentfs
+              name: persistentfsvol
       containers:
         - image: {{ &jupyter.imageName }}:{{ jupyter.version }}
           imagePullPolicy : "IfNotPresent"
@@ -83,7 +83,7 @@ spec:
             periodSeconds: 10
           volumeMounts:
             {{#volumeMount}}
-            - name: glusterfsvol
+            - name: persistentfsvol
               mountPath: /data
             {{/volumeMount}}
             - name: spark-kubernetes-properties
@@ -96,7 +96,7 @@ spec:
               subPath: dask.yaml
       volumes:
         {{#volumeMount}}
-        - name: glusterfsvol
+        - name: persistentfsvol
           persistentVolumeClaim:
             claimName: {{ volumeMount }}-claim
         {{/volumeMount}}

--- a/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
@@ -36,7 +36,7 @@ spec:
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "chmod 777 /mnt/persistentfs/notebooks && chmod777 /mnt/persistentfs/notebooks/{{ name }}"]
+          args: ["-c", "chmod 777 /mnt/persistentfs/notebooks && chmod 777 /mnt/persistentfs/notebooks/{{ name }}"]
           volumeMounts:
             - mountPath: /mnt/persistentfs
               name: persistentfsvol

--- a/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
@@ -26,16 +26,17 @@ spec:
           args: ["-c", "mkdir -p /data/notebooks/{{ name }}"]
           volumeMounts:
             - mountPath: /data
-              name: glusterfsvol
-        # This container will force the directory own to be datalabs:users (user:group; 1000:100).
-        - name: set-directory-owner
+              name: persistentfsvol
+        # This container sets the folder permissions for the generated notebook directory to be usable by
+        # datalabs:users.
+        - name: set-directory-permissions
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "chown 1000:100 /data/notebooks && chown 1000:100 /data/notebooks/{{ name }}"]
+          args: ["-c", "chmod 777 /data/notebooks && chmod 777 /data/notebooks/{{ name }}"]
           volumeMounts:
             - mountPath: /data
-              name: glusterfsvol
+              name: persistentfsvol
         # This container will create the /home/datalabs to /data/notebooks/rstudio symlink
         - name: create-datalab-symlink
           image: busybox
@@ -91,12 +92,12 @@ spec:
             periodSeconds: 10
 {{#volumeMount}}
           volumeMounts:
-            - name: glusterfsvol
+            - name: persistentfsvol
               mountPath: /data
             - name: homedir
               mountPath: /home
       volumes:
-        - name: glusterfsvol
+        - name: persistentfsvol
           persistentVolumeClaim:
             claimName: {{ volumeMount }}-claim
         - name: homedir

--- a/code/workspaces/infrastructure-api/resources/zeppelin.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/zeppelin.deployment.template.yml
@@ -26,20 +26,20 @@ spec:
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "mkdir -p /mnt/glusterfs/notebooks/zeppelin"]
+          args: ["-c", "mkdir -p /mnt/persistentfs/notebooks/zeppelin"]
           volumeMounts:
-            - mountPath: /mnt/glusterfs
-              name: glusterfsvol
-        # This container correct the folder permissions for the generated notebook directory to be owned by the
-        # datalabs:users (user:group; 1000:100).
-        - name: set-directory-owner
+            - mountPath: /mnt/persistentfs
+              name: persistentfsvol
+        # This container sets the folder permissions for the generated notebook directory to be usable by
+        # datalabs:users.
+        - name: set-directory-permissions
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "chown 1000:100 /mnt/glusterfs/notebooks && chown 1000:100 /mnt/glusterfs/notebooks/zeppelin"]
+          args: ["-c", "chmod 777 /mnt/persistentfs/notebooks && chmod 777 /mnt/persistentfs/notebooks/zeppelin"]
           volumeMounts:
-            - mountPath: /mnt/glusterfs
-              name: glusterfsvol
+            - mountPath: /mnt/persistentfs
+              name: persistentfsvol
       containers:
         - name: {{ name }}-connect
           image: {{ &zeppelin.connectImageName }}:{{ zeppelin.connectVersion }}
@@ -94,7 +94,7 @@ spec:
             - name: zeppelin-shiro
               mountPath: /secret
 {{#volumeMount}}
-            - name: glusterfsvol
+            - name: persistentfsvol
               mountPath: /data
 {{/volumeMount}}
       volumes:
@@ -102,7 +102,7 @@ spec:
           secret:
             secretName: {{ name }}
 {{#volumeMount}}
-        - name: glusterfsvol
+        - name: persistentfsvol
           persistentVolumeClaim:
             claimName: {{ volumeMount }}-claim
 {{/volumeMount}}


### PR DESCRIPTION
- handle permissions of notebook folder using chmod rather than chown
- rename 'glusterfs' to 'persistentfs'