### PR TITLE
feat: update auth service to discover oidc configuration rather than hardcoded auth0 configuration.

### DIFF
--- a/code/workspaces/auth-service/src/auth/accessToken.js
+++ b/code/workspaces/auth-service/src/auth/accessToken.js
@@ -1,17 +1,21 @@
 import axios from 'axios';
 import logger from 'winston';
 import { get } from 'lodash';
-import config from '../config/config';
+import getOidcConfig from '../config/oidcConfig';
 
-export const authOAuthEndpoint = `https://${config.get('authZeroDomain')}/oauth/token`;
-
-function requestAccessToken(accessTokenRequest) {
+async function requestAccessToken(accessTokenRequest) {
   logger.info('Requesting access token.');
-  return axios.post(authOAuthEndpoint, { ...accessTokenRequest, grant_type: 'client_credentials' })
-    .then(response => get(response, 'data.access_token'))
-    .catch(() => {
-      throw new Error('Unable to retrieve access token.');
-    });
+
+  const oidcConfig = await getOidcConfig();
+
+  try {
+    const response = await axios.post(
+      oidcConfig.token_endpoint, { ...accessTokenRequest, grant_type: 'client_credentials' },
+    );
+    return get(response, 'data.access_token');
+  } catch (error) {
+    throw new Error(`Unable to retrieve access token - Original message: "${error.message}"`);
+  }
 }
 
 export default requestAccessToken;

--- a/code/workspaces/auth-service/src/auth/accessToken.spec.js
+++ b/code/workspaces/auth-service/src/auth/accessToken.spec.js
@@ -22,6 +22,6 @@ describe('requestAccessToken', () => {
       .reply(401);
 
     return requestAccessToken()
-      .catch(err => expect(err.message).toBe('Unable to retrieve access token.'));
+      .catch(err => expect(err.message).toBe('Unable to retrieve access token - Original message: "Request failed with status code 401"'));
   });
 });

--- a/code/workspaces/auth-service/src/auth/accessToken.spec.js
+++ b/code/workspaces/auth-service/src/auth/accessToken.spec.js
@@ -1,6 +1,14 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import requestAccessToken, { authOAuthEndpoint } from './accessToken';
+import requestAccessToken from './accessToken';
+import getOidcConfig from '../config/oidcConfig';
+
+jest.mock('../config/oidcConfig');
+
+const oidcConfig = { token_endpoint: 'https://oidc-provider/oauth/token' };
+// using mockImplementation rather than mockResolvedValue as the latter doesn't return
+// the value correctly when called from the function under test.
+getOidcConfig.mockImplementation(async () => oidcConfig);
 
 const mock = new MockAdapter(axios);
 
@@ -10,7 +18,7 @@ describe('requestAccessToken', () => {
   });
 
   it('response with an access token', () => {
-    mock.onPost(authOAuthEndpoint)
+    mock.onPost(oidcConfig.token_endpoint)
       .reply(200, { access_token: 'expectedAccessToken' });
 
     return requestAccessToken()
@@ -18,7 +26,7 @@ describe('requestAccessToken', () => {
   });
 
   it('throws error when unable to get access token', () => {
-    mock.onPost(authOAuthEndpoint)
+    mock.onPost(oidcConfig.token_endpoint)
       .reply(401);
 
     return requestAccessToken()

--- a/code/workspaces/auth-service/src/config/__snapshots__/oidcConfig.spec.js.snap
+++ b/code/workspaces/auth-service/src/config/__snapshots__/oidcConfig.spec.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getOidcConfig returns cached value when configured to do so 1`] = `
+Object {
+  "issuer": "https://mjbr.eu.auth0.com/",
+  "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
+  "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token",
+}
+`;
+
+exports[`getOidcConfig returns config from environment to match snapshot when configuration endpoint requests fail 1`] = `
+Object {
+  "issuer": "https://mjbr.eu.auth0.com/",
+  "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
+  "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token",
+}
+`;

--- a/code/workspaces/auth-service/src/config/__snapshots__/oidcConfig.spec.js.snap
+++ b/code/workspaces/auth-service/src/config/__snapshots__/oidcConfig.spec.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getOidcConfig returns cached value when configured to do so 1`] = `
-Object {
-  "issuer": "https://mjbr.eu.auth0.com/",
-  "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
-  "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token",
-}
-`;
-
 exports[`getOidcConfig returns config from environment to match snapshot when configuration endpoint requests fail 1`] = `
 Object {
   "issuer": "https://mjbr.eu.auth0.com/",

--- a/code/workspaces/auth-service/src/config/config.js
+++ b/code/workspaces/auth-service/src/config/config.js
@@ -26,19 +26,19 @@ const config = convict({
     env: 'PUBLIC_KEY',
   },
   authorisationClientId: {
-    doc: 'Auth0 client id for the Datalabs Authorisation API',
+    doc: 'OpenID Connect provider client id for the Datalabs Authorisation API',
     format: 'String',
     default: 'authzClientId',
     env: 'AUTHORISATION_API_CLIENT_ID',
   },
   authorisationClientSecret: {
-    doc: 'Auth0 client secret for the Datalabs Authorisation API',
+    doc: 'OpenID Connect provider client secret for the Datalabs Authorisation API',
     format: 'String',
     default: 'authzClientSecret',
     env: 'AUTHORISATION_API_CLIENT_SECRET',
   },
   authorisationIdentifier: {
-    doc: 'Auth0 identifier for the Datalabs Authorisation API',
+    doc: 'OpenID Connect provider identifier for the Datalabs Authorisation API',
     format: 'String',
     default: 'authzIdentifier',
     env: 'AUTHORISATION_API_IDENTIFIER',
@@ -62,28 +62,42 @@ const config = convict({
     env: 'AUTHORISATION_PERMISSIONS',
   },
   userManagementClientId: {
-    doc: 'Auth0 client id for the user management API',
+    doc: 'OpenID Connect provider client id for the user management API',
     format: 'String',
     default: 'userMgmtClientId',
     env: 'USER_MANAGEMENT_API_CLIENT_ID',
   },
   userManagementClientSecret: {
-    doc: 'Auth0 client secret for the user management API',
+    doc: 'OpenID Connect provider client secret for the user management API',
     format: 'String',
     default: 'userMgmtClientSecret',
     env: 'USER_MANAGEMENT_API_CLIENT_SECRET',
   },
-  authZeroDomain: {
-    doc: 'URL of the auth0 domain',
+  oidcProviderDomain: {
+    doc: 'URL of the OpenID Connect provider domain',
     format: 'String',
     default: 'mjbr.eu.auth0.com',
-    env: 'AUTH_ZERO_DOMAIN',
+    env: 'OIDC_PROVIDER_DOMAIN',
   },
-  authZeroAudience: {
+  oidcProviderAudience: {
     doc: 'Audience for authorisation',
     format: 'String',
     default: 'https://datalab.datalabs.nerc.ac.uk/api',
-    env: 'AUTH_ZERO_AUDIENCE',
+    env: 'OIDC_PROVIDER_AUDIENCE',
+  },
+  oidcOAuthTokenEndpoint: {
+    doc: `Fallback for when OIDC provider does not provide configuration information via /.well-known/openid-configuration.
+          The endpoint on the oidcProviderDomain at which OAuth tokens are issued.`,
+    format: 'String',
+    default: '/oauth/token',
+    env: 'OIDC_OAUTH_TOKEN_ENDPOINT',
+  },
+  oidcJwksEndpoint: {
+    doc: `Fallback for when OIDC provider does not provide configuration information via /.well-known/openid-configuration.
+          The endpoint on the oidcProviderDomain at which JSON Web Key Set (JWKS) information is obtained.`,
+    format: 'String',
+    default: '/.well-known/jwks.json',
+    env: 'OIDC_JWKS_ENDPOINT',
   },
   databaseHost: {
     doc: 'The database hostname',

--- a/code/workspaces/auth-service/src/config/oidcConfig.js
+++ b/code/workspaces/auth-service/src/config/oidcConfig.js
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import logger from 'winston';
+import Promise from 'bluebird';
+import config from './config';
+
+let cachedOidcConfig;
+const oidcDomain = config.get('oidcProviderDomain');
+
+export default async function getOidcConfig({ cacheValue = true, getCachedValue = true } = {}) {
+  if (getCachedValue && cachedOidcConfig) {
+    return cachedOidcConfig;
+  }
+
+  const oidcConfig = await createOidcConfig();
+
+  if (cacheValue) {
+    cachedOidcConfig = oidcConfig;
+  }
+
+  return oidcConfig;
+}
+
+async function createOidcConfig() {
+  try {
+    return await createOidcConfigFromOpenIdConfigurationEndpoint();
+  } catch (error) {
+    logger.warn(error.message);
+    return createOidcConfigFromEnvironment();
+  }
+}
+
+async function createOidcConfigFromOpenIdConfigurationEndpoint() {
+  logger.info('Creating OIDC configuration from configuration endpoint.');
+  const configurationEndpoints = ['http://', 'https://'].map(
+    schema => `${schema}${oidcDomain}/.well-known/openid-configuration`,
+  );
+
+  try {
+    return await Promise.any(configurationEndpoints.map(callConfigurationEndpoint));
+  } catch (error) {
+    throw new Error('Failed to get OIDC configuration information from provider.');
+  }
+}
+
+async function callConfigurationEndpoint(endpoint) {
+  let response;
+  try {
+    response = await axios.get(endpoint);
+  } catch (error) {
+    throw new Error(`Failed to get OIDC configuration information from ${endpoint}.`);
+  }
+  return response.data;
+}
+
+function createOidcConfigFromEnvironment() {
+  logger.info('Creating OIDC configuration from environment.');
+  const oidcDomainWithSchema = `https://${oidcDomain}`;
+  return {
+    issuer: `${oidcDomainWithSchema}/`,
+    token_endpoint: `${oidcDomainWithSchema}${config.get('oidcOAuthTokenEndpoint')}`,
+    jwks_uri: `${oidcDomainWithSchema}${config.get('oidcJwksEndpoint')}`,
+  };
+}

--- a/code/workspaces/auth-service/src/config/oidcConfig.spec.js
+++ b/code/workspaces/auth-service/src/config/oidcConfig.spec.js
@@ -1,0 +1,72 @@
+import axios from 'axios';
+import getOidcConfig from './oidcConfig';
+
+jest.mock('axios');
+
+describe('getOidcConfig', () => {
+  const testConfiguration = {
+    issuer: 'expectedIssuer',
+    token_endpoint: 'expectedTokenEndpoint',
+    jwks_uri: 'expectedJwksUri',
+  };
+
+  const noCachedValueOptions = {
+    cacheValue: false,
+    getCachedValue: false,
+  };
+
+  beforeEach(() => {
+    axios.get.mockReset();
+  });
+
+  describe('returns config from configuration endpoint', () => {
+    it('when all calls successful', async () => {
+      axios.get.mockResolvedValue({ data: testConfiguration });
+      const configuration = await getOidcConfig(noCachedValueOptions);
+      expect(configuration).toEqual(testConfiguration);
+    });
+
+    it('when one of the calls fails', async () => {
+      axios.get.mockResolvedValueOnce({ data: testConfiguration });
+      axios.get.mockRejectedValueOnce(new Error('Expected promise rejection'));
+      const configuration = await getOidcConfig(noCachedValueOptions);
+      expect(configuration).toEqual(testConfiguration);
+    });
+  });
+
+  it('returns config from environment to match snapshot when configuration endpoint requests fail', async () => {
+    axios.get.mockRejectedValue(new Error('Expected promise rejection'));
+    const configuration = await getOidcConfig(noCachedValueOptions);
+    expect(configuration).toMatchSnapshot();
+  });
+
+  it('returns cached value when configured to do so', async () => {
+    // ensure there is a cached value available of a successful call
+    axios.get.mockResolvedValue({ data: testConfiguration });
+    await getOidcConfig({ cacheValue: true });
+    expect(axios.get).toBeCalled();
+
+    // clear usage information so it can be checked later
+    axios.get.mockClear();
+
+    // check cached value returned
+    const configuration = await getOidcConfig({ getCachedValue: true });
+    expect(axios.get).not.toBeCalled();
+    expect(configuration).toEqual(testConfiguration);
+  });
+
+  it('does not return cached value when configured not to do so', async () => {
+    // ensure there is a cached value available of a successful call
+    axios.get.mockResolvedValue({ data: testConfiguration });
+    await getOidcConfig({ cacheValue: true });
+
+    const alternativeConfiguration = {
+      different: 'value',
+    };
+    axios.get.mockResolvedValue({ data: alternativeConfiguration });
+
+    // check cached value returned
+    const configuration = await getOidcConfig({ getCachedValue: false });
+    expect(configuration).toEqual(alternativeConfiguration);
+  });
+});

--- a/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
+++ b/code/workspaces/auth-service/src/userManagement/authZeroUserManagement.js
@@ -5,7 +5,7 @@ import config from '../config/config';
 import requestAccessToken from '../auth/accessToken';
 import { getOrSetCacheAsyncWrapper } from '../cache/cache';
 
-export const authZeroManagementApi = `https://${config.get('authZeroDomain')}/api/v2`;
+export const authZeroManagementApi = `https://${config.get('oidcProviderDomain')}/api/v2`;
 const PAGE_LIMIT = 100;
 const AUTH0_MAXIMUM = 1000;
 


### PR DESCRIPTION
Update auth service such that it contacts the `/.well-known/openid-configuration` endpoint of the OIDC provider. This should allow the provider to provide all the information we need. If communitcation with this endpoint fails, the code falls back to using configured using environment variables.

This required changes to the k8s-manifests repository. These changes can be seen in the [linked PR](https://github.com/NERC-CEH/datalab-k8s-manifests/pull/100).