### PR TITLE
NERCDL-650: remove unused get volumes endpoint

### DIFF
--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.js
@@ -50,11 +50,6 @@ async function queryVolume(request, response) {
   response.send(volume);
 }
 
-async function listVolumes(request, response) {
-  const volumes = await volumeManager.listVolumes();
-  response.send(volumes);
-}
-
 async function listProjectActiveVolumes(request, response) {
   const { projectKey } = matchedData(request);
   const volumes = await dataStorageRepository.getAllProjectActive(request.user, projectKey);
@@ -194,7 +189,6 @@ export default {
   createVolume,
   deleteVolume,
   queryVolume,
-  listVolumes,
   getById,
   listProjectActiveVolumes,
   addUsers,

--- a/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/volumeController.spec.js
@@ -125,17 +125,6 @@ describe('Volume Controller', () => {
     });
   });
 
-  describe('list volumes', () => {
-    it('should return the volumes', async () => {
-      listVolumeMock.mockReturnValue(Promise.resolve(['volume']));
-      const response = httpMocks.createResponse();
-
-      await volumeController.listVolumes(request, response);
-      expect(response.statusCode).toBe(200);
-      expect(response._getData()).toEqual(['volume']); // eslint-disable-line no-underscore-dangle
-    });
-  });
-
   describe('get volume by id', () => {
     it('should return the volume', async () => {
       getByIdMock.mockReturnValue(Promise.resolve('volume'));

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.js
@@ -58,22 +58,6 @@ function queryPersistentVolumeClaim(name, namespace) {
     .catch(() => {});
 }
 
-function listPersistentVolumeClaims(namespace) {
-  // List only visible volumes (ie not internal volumes)
-  logger.info('Getting visible volume claims');
-  return axios.get(getPVCUrl(namespace), { params: { labelSelector: 'user-created' } })
-    .then(processPVCs)
-    .catch(() => []);
-}
-
-function processPVCs(response) {
-  if (response.data && response.data.items) {
-    return response.data.items.map(processVolumeDetails);
-  }
-
-  return [];
-}
-
 function processVolumeDetails(volume) {
   let name;
 
@@ -95,5 +79,4 @@ export default {
   updatePersistentVolumeClaim,
   createOrUpdatePersistentVolumeClaim,
   queryPersistentVolumeClaim,
-  listPersistentVolumeClaims,
 };

--- a/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/volumeApi.spec.js
@@ -24,7 +24,6 @@ afterAll(() => {
 
 const manifest = createManifest();
 const pvc = createPVC();
-const pvcs = createPVCs();
 
 describe('Kubernetes Persistent Volume API', () => {
   describe('get pvc', () => {
@@ -163,31 +162,6 @@ describe('Kubernetes Persistent Volume API', () => {
         });
     });
   });
-
-  describe('list pvcs', () => {
-    it('should return an array of pvcs', () => {
-      mock.onGet(`${PVC_URL}`, { params: { labelSelector: 'user-created' } }).reply(200, pvcs);
-
-      return volumeApi.listPersistentVolumeClaims(NAMESPACE)
-        .then((response) => {
-          expect(response.length).toBe(2);
-          expect(response[0]).toEqual({
-            name: PVC_NAME,
-            storageType: PVC_TYPE,
-            capacityTotal: PVC_CAPACITY,
-          });
-        });
-    });
-
-    it('should return an empty array if the pvc does not exist', () => {
-      mock.onGet(`${PVC_URL}`, { params: { labelSelector: 'user-created' } }).reply(404);
-
-      return volumeApi.listPersistentVolumeClaims(NAMESPACE)
-        .then((response) => {
-          expect(response).toEqual([]);
-        });
-    });
-  });
 });
 
 function createPVC() {
@@ -207,15 +181,6 @@ function createPVC() {
         },
       },
     },
-  };
-}
-
-function createPVCs() {
-  return {
-    items: [
-      createPVC(),
-      createPVC(),
-    ],
   };
 }
 

--- a/code/workspaces/infrastructure-api/src/routers/volumesRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/volumesRouter.js
@@ -1,13 +1,12 @@
 import express from 'express';
 import { service } from 'service-chassis';
 import { permissionTypes } from 'common';
-import { permissionWrapper, projectPermissionWrapper } from '../auth/permissionMiddleware';
+import { projectPermissionWrapper } from '../auth/permissionMiddleware';
 import volume from '../controllers/volumeController';
 
 const { errorWrapper: ew } = service.middleware;
 
 const {
-  elementPermissions: { STORAGE_LIST },
   projectPermissions: { PROJECT_KEY_STORAGE_LIST, PROJECT_KEY_STORAGE_EDIT },
 } = permissionTypes;
 
@@ -16,11 +15,6 @@ const volumesRouter = express.Router();
 // TODO - routes running permission wrapper won't currently work.
 //  Don't know use case for them and UI interaction seems to be working as expected so leaving for now.
 
-volumesRouter.get(
-  '/',
-  permissionWrapper(STORAGE_LIST),
-  ew(volume.listVolumes),
-);
 volumesRouter.get(
   '/active/:projectKey',
   projectPermissionWrapper(PROJECT_KEY_STORAGE_LIST),

--- a/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/volumeManager.js
@@ -56,8 +56,4 @@ function queryVolume(params) {
   return volumeApi.queryPersistentVolumeClaim(`${name}-claim`);
 }
 
-function listVolumes() {
-  return volumeApi.listPersistentVolumeClaims();
-}
-
-export default { createVolume, deleteVolume, queryVolume, listVolumes };
+export default { createVolume, deleteVolume, queryVolume };


### PR DESCRIPTION
The get volumes endpoint was unused and didn't work (since listPersistentVolumeClaims needed a namespace parameter), so I have removed it.