### PR TITLE
fix: redirect to login page rather than give 404 when use not logged in

### DIFF
--- a/code/workspaces/web-app/src/PublicApp.js
+++ b/code/workspaces/web-app/src/PublicApp.js
@@ -3,15 +3,15 @@ import { Route, Switch } from 'react-router-dom';
 import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
 import { publicAppTheme } from './theme';
 import WelcomePage from './pages/WelcomePage';
-import NotFoundPage from './pages/NotFoundPage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
+import RedirectToLoginPage from './pages/RedirectToLoginPage';
 
 const PublicApp = () => (
   <MuiThemeProvider theme={publicAppTheme}>
     <Switch>
       <Route exact path="/" component={WelcomePage} />
       <Route exact path="/verify" component={VerifyEmailPage} />
-      <Route component={NotFoundPage} />
+      <Route component={RedirectToLoginPage} />
     </Switch>
   </MuiThemeProvider>
 );

--- a/code/workspaces/web-app/src/components/app/RequireAuth.js
+++ b/code/workspaces/web-app/src/components/app/RequireAuth.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { Route } from 'react-router-dom';
@@ -34,7 +34,7 @@ const RequireAuth = ({ path, exact, strict, PrivateComponent, PublicComponent })
   const dispatch = useDispatch();
   const classes = useStyles();
 
-  useLayoutEffect(() => { effectFn(dispatch); }, [dispatch]);
+  useEffect(() => { effectFn(dispatch); }, [dispatch]);
 
   return <Route
     path={path}
@@ -45,7 +45,7 @@ const RequireAuth = ({ path, exact, strict, PrivateComponent, PublicComponent })
 };
 
 const switchContent = (tokens, permissions, PrivateComponent, PublicComponent, classes) => {
-  if (permissions.fetching) {
+  if (permissions.fetching || userHasSessionButAwaitingTokens(tokens)) {
     return () => (
       <CircularProgress
         className={classes.circularProgress}
@@ -54,14 +54,16 @@ const switchContent = (tokens, permissions, PrivateComponent, PublicComponent, c
     );
   }
 
-  if (isUserLoggedIn(tokens)) {
+  if (userLoggedIn(tokens)) {
     return props => (<PrivateComponent {...props} promisedUserPermissions={permissions} />);
   }
 
   return props => (<PublicComponent {...props} />);
 };
 
-const isUserLoggedIn = tokens => !isEmpty(tokens);
+const userHasSessionButAwaitingTokens = tokens => getAuth().getCurrentSession() && !userLoggedIn(tokens);
+
+const userLoggedIn = tokens => !isEmpty(tokens);
 
 RequireAuth.propTypes = {
   PrivateComponent: PropTypes.func.isRequired,

--- a/code/workspaces/web-app/src/pages/RedirectToLoginPage.js
+++ b/code/workspaces/web-app/src/pages/RedirectToLoginPage.js
@@ -1,0 +1,12 @@
+import { useLayoutEffect } from 'react';
+import getAuth from '../auth/auth';
+
+const RedirectToLoginPage = () => {
+  useLayoutEffect(() => {
+    getAuth().login();
+  }, []);
+
+  return null;
+};
+
+export default RedirectToLoginPage;


### PR DESCRIPTION
When a user is not logged-in and tries to access a page other than those that can be explicitly accessed when not logged in, they are redirected to the log-in page.