### PR TITLE
fix: stop auth callback always ending up on projects page

### DIFF
--- a/code/workspaces/web-app/src/components/app/AuthCallback.js
+++ b/code/workspaces/web-app/src/components/app/AuthCallback.js
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import { replace } from 'connected-react-router';
 import getAuth from '../../auth/auth';
 import authActions from '../../actions/authActions';
-import { useSearchUrl } from '../../hooks/routerHooks';
 
 export const handleAuth = async (searchUrl, routeTo, dispatch, props) => {
   if (/verify/.test(searchUrl)) {
@@ -24,13 +23,12 @@ export const handleAuth = async (searchUrl, routeTo, dispatch, props) => {
 };
 
 const AuthCallback = (props) => {
-  const searchUrl = useSearchUrl();
   const dispatch = useDispatch();
   const routeTo = replace;
 
   useEffect(() => {
-    handleAuth(searchUrl, routeTo, dispatch, props);
-  }, [searchUrl, routeTo, dispatch, props]);
+    handleAuth(props.location.search, routeTo, dispatch, props);
+  }, [routeTo, dispatch, props]);
 
   return null;
 };


### PR DESCRIPTION
When handling the auth callback redirect (i.e. after logging-in), the app was always ending up on the projects page. This appears to do with the use of the `useSearchUrl` hook and the output of this being used as a dependency in the `AuthCallback` component's `useEffect`. What I think was happening is:
1. The user would log-in and Auth0 would direct back to `/callback` with extra information as query parameters in the URL. 
1. the `/callback` endpoint renders the `AuthCallback` component.
1. `useSearchUrl` got query parameter values from the url.
1. `handleAuth` handled the callback, including redirecting to the necessary page.
1. As the app url has changed, `useSearchUrl` was triggered due to the update in react-router state.
1. Because `searchUrl` now has a new value, the effect is called.
1. The new url doesn't contain any of the necessary query parameters to make `handleAuth` work, so as a fallback that was redirecting to `/projects`.

The value that was being obtained through `useSearchUrl` is provided in `props.location.search` and this value remains consistent across renders, therefore this is now being used instead and seems to work as expected.