### PR TITLE
NERCDL-791 Document + make necessary changes for alternate OIDC provider

### DIFF
--- a/code/development-env/README.md
+++ b/code/development-env/README.md
@@ -191,6 +191,25 @@ docker-compose -f ./docker/docker-compose-vault.yml -f ./docker/docker-compose-m
 
 You should eventually see a message saying `You can now view datalab-app in the browser.`
 
+### Running with Keycloak
+
+If you wish to use a local authentication provider rather than auth0 to test this is possible by the following modifications to the `./docker/docker-compose-app.yml` file;
+
+- Unhash the lines in the auth service marked as "`OIDC_*`".
+- Hash out the line in the app service relating to `web_auth_config.json` and unhash the next line containing `web_auth_config_keycloak.json`.
+
+Keycloak must be resolvable both by the auth service as well as your local desktop, as keycloak is addressable by default using the docker network by its service name, the easiest way to make it work locally is to add a local DNS entry or a localhost entry for keycloak e.g;
+
+```bash
+127.0.0.1 keycloak
+```
+
+Finally, use the following command to start the app in place of the final one used above. When setting up for the first time it may take a minute before login is available as the OIDC client is set up for the first time.
+
+```bash
+docker-compose -f ./docker/docker-compose-vault.yml -f ./docker/docker-compose-mongo.yml -f ./docker/docker-compose-app.yml -f ./docker/docker-compose-proxy.yml -f ./docker/docker-compose-keycloak.yml up -d
+```
+
 ## Testing APIs
 
 The [Insomnia Rest client](https://insomnia.rest/) is recommended for testing APIs

--- a/code/development-env/config/keycloak/import.sh
+++ b/code/development-env/config/keycloak/import.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Job Import started: $(date)"
+
+/opt/jboss/keycloak/bin/kcadm.sh config credentials --user admin --password admin --server http://$KEYCLOAK_INSTANCE:8080/auth --realm master
+/opt/jboss/keycloak/bin/kcadm.sh create realms -s realm=DataLabs -s enabled=true
+/opt/jboss/keycloak/bin/kcadm.sh create users -r DataLabs -s username=admin -s enabled=true
+/opt/jboss/keycloak/bin/kcadm.sh set-password -r DataLabs --username admin --new-password admin
+/opt/jboss/keycloak/bin/kcadm.sh create clients -r DataLabs -s clientId=datalabs -s 'webOrigins=["*"]' -s 'redirectUris=["*"]' -s '"implicitFlowEnabled"=1' -s '"publicClient"=1'
+
+echo "Job Import finished: $(date)"
+

--- a/code/development-env/config/local/web_auth_config_keycloak.json
+++ b/code/development-env/config/local/web_auth_config_keycloak.json
@@ -1,0 +1,19 @@
+{
+  "client_id": "datalabs",
+  "redirect_uri": "https://testlab.datalabs.localhost/callback",
+  "response_type": "code",
+  "scope": "openid profile email",
+  "authority": "http://keycloak:8080/auth/realms/DataLabs",
+  "automaticSilentRenew": true,
+  "accessTokenExpiringNotificationTime": "600",
+  "filterProtocolClaims": true,
+  "loadUserInfo": true,
+  "metadata": {
+    "issuer": "http://keycloak:8080/auth/realms/DataLabs",
+    "authorization_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/auth",
+    "userinfo_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/userinfo",
+    "end_session_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/logout?redirect_uri=http://testlab.datalabs.localhost",
+    "jwks_uri": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/certs",
+    "token_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/token"
+  }
+}

--- a/code/development-env/docker/docker-compose-app.yml
+++ b/code/development-env/docker/docker-compose-app.yml
@@ -75,5 +75,5 @@ services:
       # web_auth_config is unique to each domain
       # When using KeyCloak unhash the line below and hash the Auth0 line
       # - $PWD/config/local/web_auth_config_keycloak.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro
-      # When using Auth0 unhash the line below and hash the Auth0 line
+      # When using Auth0 unhash the line below and hash the Keycloak line
       - $PWD/config/local/web_auth_config.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro

--- a/code/development-env/docker/docker-compose-app.yml
+++ b/code/development-env/docker/docker-compose-app.yml
@@ -23,13 +23,16 @@ services:
       AUTHORISATION_API_IDENTIFIER: ${AUTHORISATION_API_IDENTIFIER}
       USER_MANAGEMENT_API_CLIENT_ID: ${USER_MANAGEMENT_API_CLIENT_ID}
       USER_MANAGEMENT_API_CLIENT_SECRET: ${USER_MANAGEMENT_API_CLIENT_SECRET}
+      # Keycloak Authentication Parameters
+      # OIDC_OAUTH_TOKEN_ENDPOINT: "/protocol/openid-connect/token"
+      # OIDC_JWKS_ENDPOINT: "/protocol/openid-connect/certs"
+      # OIDC_PROVIDER_DOMAIN: "keycloak:8080/auth/realms/DataLabs"
+      # OIDC_PROVIDER_AUDIENCE: "account"
       BABEL_DISABLE_CACHE: 1
     ports:
       - 9000:9000
     volumes:
       - ${PWD}/..:/usr/src/app/:ro
-    links:
-      - mongodb
 
   datalab-infra:
     image: node:lts
@@ -44,10 +47,6 @@ services:
       - $PWD/..:/usr/src/app/:ro
       - $PWD/config/local/image_config.json:/usr/src/app/workspaces/common/src/config/image_config.json:ro
       - $PWD/config/local/storage_config.json:/usr/src/app/workspaces/common/src/config/storage_config.json:ro
-    links:
-      - datalab-auth
-      - mongodb
-      - vault
 
   datalab-api:
     image: node:lts
@@ -61,11 +60,6 @@ services:
     volumes:
       - $PWD/..:/usr/src/app:ro
       - $PWD/config/local/storage_config.json:/usr/src/app/workspaces/common/src/config/storage_config.json:ro
-    links:
-      - datalab-auth
-      - datalab-infra
-      - mongodb
-      - vault
 
   datalab-app:
     image: node:lts
@@ -77,6 +71,9 @@ services:
       - 3000:3000
     volumes:
       - $PWD/..:/usr/src/app:ro
-      # web_auth_config is unique to each domain and needs updating
-      - $PWD/config/local/web_auth_config.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro
       - $PWD/config/local/storage_config.json:/usr/src/app/workspaces/web-app/public/storage_config.json:ro
+      # web_auth_config is unique to each domain
+      # When using KeyCloak unhash the line below and hash the Auth0 line
+      # - $PWD/config/local/web_auth_config_keycloak.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro
+      # When using Auth0 unhash the line below and hash the Auth0 line
+      - $PWD/config/local/web_auth_config.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro

--- a/code/development-env/docker/docker-compose-keycloak.yml
+++ b/code/development-env/docker/docker-compose-keycloak.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+
+services:
+  keycloak:
+    image: jboss/keycloak
+    ports:
+      - 8080:8080
+    environment:
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=admin
+      - DB_VENDOR=h2
+
+  keycloak_import:
+    image: jboss/keycloak
+    environment:
+      - KEYCLOAK_INSTANCE=keycloak
+    depends_on:
+      - keycloak
+    entrypoint: /bin/bash -c "/bin/bash -c \"$${@}\""
+    command: /bin/bash -c "/usr/bin/sleep 60 && /usr/bin/cp /tmp/keycloak/import.sh /tmp/import.sh && /usr/bin/chmod +x /tmp/import.sh && /tmp/import.sh"
+    volumes:
+      - $PWD/config/keycloak:/tmp/keycloak/:ro

--- a/code/workspaces/web-app/src/auth/auth.js
+++ b/code/workspaces/web-app/src/auth/auth.js
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import Promise from 'bluebird';
-import { pick } from 'lodash';
 import Oidc from 'oidc-client';
 import cookies from './cookies';
 import { setSession, clearSession, getSession } from '../core/sessionUtil';
@@ -103,13 +102,13 @@ function expiresAtCalculator(expiresIn) {
   return moment.utc().add(expiresIn, 's').format('x');
 }
 
-function processIdentity(idTokenPayload) {
-  const knownFields = ['sub', 'name', 'nickname', 'picture', 'email'];
-  const identityObject = pick(idTokenPayload, knownFields);
-  if (Object.prototype.hasOwnProperty.call(identityObject, 'email')) {
-    identityObject.name = identityObject.email;
-    delete identityObject.email;
-  }
+function processIdentity({ sub, name, nickname, picture, email }) {
+  const identityObject = {
+    sub,
+    name: email || name,
+    nickname,
+    picture,
+  };
   return JSON.stringify(identityObject);
 }
 

--- a/code/workspaces/web-app/src/auth/auth.js
+++ b/code/workspaces/web-app/src/auth/auth.js
@@ -104,9 +104,13 @@ function expiresAtCalculator(expiresIn) {
 }
 
 function processIdentity(idTokenPayload) {
-  const knownFields = ['sub', 'name', 'nickname', 'picture'];
-
-  return JSON.stringify(pick(idTokenPayload, knownFields));
+  const knownFields = ['sub', 'name', 'nickname', 'picture', 'email'];
+  const identityObject = pick(idTokenPayload, knownFields);
+  if (Object.prototype.hasOwnProperty.call(identityObject, 'email')) {
+    identityObject.name = identityObject.email;
+    delete identityObject.email;
+  }
+  return JSON.stringify(identityObject);
 }
 
 let authSession;

--- a/code/workspaces/web-app/src/auth/authConfig.js
+++ b/code/workspaces/web-app/src/auth/authConfig.js
@@ -9,10 +9,6 @@ const getAuthConfig = () => axios
         ...data,
         silent_redirect_uri: `${window.location.origin}/silent_callback`,
         redirect_uri: `${window.location.origin}/callback`,
-        metadata: {
-          ...data.metadata,
-          end_session_endpoint: `${data.authority}/v2/logout?returnTo=${encodeURIComponent(window.location.origin)}&client_id=${data.client_id}`,
-        },
       };
     }
 


### PR DESCRIPTION
I found mainly things worked after a good deal of wrangling but there are a few minor changes in here it would be good if you can review;

- When choosing what identity traits to read in from auth0, `name` refers to the e-mail in but typically with OIDC this should be provided by a separate e-mail key. So have added code to replace the name with the e-mail directly if it is provided as that makes sure everything else works as expected. I don't think we have any current plans to keep user details so we only store the e-mail anyway.
- Added some documentation on how to get keycloak running in a local development setup.
- Refactored the main docker-compose file, [links](https://docs.docker.com/compose/compose-file/#links]) are now deprecated and as we're running the compose files as the same time they should share the same network. I don't know if this is different on mac however so it would be great if you can test and ensure everything is still working for you.
- Removed some old code which changed the web_auth_config dynamically when running locally but I believe this isn't required anymore and was breaking things as different re-direct parameters are used between Keycloak & auth0.