### PR TITLE
NERCDL-836 investigate error in api.Dockerfile

### DIFF
--- a/build/build-travis-wrapper.sh
+++ b/build/build-travis-wrapper.sh
@@ -3,6 +3,7 @@ set -e
 
 if [ "$#" -eq 1 ] && [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
   echo "Attemping to login to Docker Hub..."
+  docker --version
   docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   cd $TRAVIS_BUILD_DIR && ./build/build-container.sh $1 --push
 else

--- a/code/api.Dockerfile
+++ b/code/api.Dockerfile
@@ -35,6 +35,8 @@ RUN yarn install --prefer-offline --silent --production && yarn cache clean
 
 COPY ./workspaces/${WORKSPACE}/dist .
 COPY ./workspaces/${WORKSPACE}/resources ./resources
+# fix for multiple COPY errors, see https://github.com/moby/moby/issues/37965
+RUN true
 COPY ./version.json .
 
 EXPOSE 8000


### PR DESCRIPTION
Investigating issue with https://github.com/NERC-CEH/datalab/blob/master/code/api.Dockerfile#L38, failing with

Step 23/25 : COPY ./version.json .
failed to export image: failed to create image: failed to get layer sha256:29c3738ee8a18b593c165a3380bf07657b966178912cae73770c1f615f1dd0d0: layer does not exist
Error: Process completed with exit code 1.