### PR TITLE
feat: enable configuring whether a catalogue is available

### DIFF
--- a/code/development-env/config/local/catalogue_config.json
+++ b/code/development-env/config/local/catalogue_config.json
@@ -1,0 +1,3 @@
+{
+  "available": true
+}

--- a/code/development-env/docker/docker-compose-app.yml
+++ b/code/development-env/docker/docker-compose-app.yml
@@ -68,6 +68,8 @@ services:
     volumes:
       - $PWD/..:/usr/src/app:ro
       - $PWD/config/local/storage_config.json:/usr/src/app/workspaces/web-app/public/storage_config.json:ro
+      - $PWD/config/local/image_config.json:/usr/src/app/workspaces/web-app/public/image_config.json:ro
+      - $PWD/config/local/catalogue_config.json:/usr/src/app/workspaces/web-app/public/catalogue_config.json:ro
       # web_auth_config is unique to each domain
       # When using KeyCloak unhash the line below and hash the Auth0 line
       # - $PWD/config/local/web_auth_config_keycloak.json:/usr/src/app/workspaces/web-app/public/web_auth_config.json:ro

--- a/code/workspaces/common/src/config/catalogue_config.json
+++ b/code/workspaces/common/src/config/catalogue_config.json
@@ -1,0 +1,3 @@
+{
+  "available": true
+}

--- a/code/workspaces/web-app/public/catalogue_config.json
+++ b/code/workspaces/web-app/public/catalogue_config.json
@@ -1,0 +1,3 @@
+{
+  "available": true
+}

--- a/code/workspaces/web-app/src/actions/__snapshots__/catalogueConfigActions.spec.js.snap
+++ b/code/workspaces/web-app/src/actions/__snapshots__/catalogueConfigActions.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadCatalogConfig created action matches snapshot 1`] = `
+Object {
+  "payload": "expected catalogue config value",
+  "type": "LOAD_CATALOGUE_CONFIG_ACTION",
+}
+`;

--- a/code/workspaces/web-app/src/actions/catalogueConfigActions.js
+++ b/code/workspaces/web-app/src/actions/catalogueConfigActions.js
@@ -1,0 +1,12 @@
+import { catalogueConfig } from '../config/catalogue';
+
+export const LOAD_CATALOGUE_CONFIG_ACTION = 'LOAD_CATALOGUE_CONFIG_ACTION';
+
+const loadCatalogueConfig = () => ({
+  type: LOAD_CATALOGUE_CONFIG_ACTION,
+  payload: catalogueConfig(),
+});
+
+export default {
+  loadCatalogueConfig,
+};

--- a/code/workspaces/web-app/src/actions/catalogueConfigActions.spec.js
+++ b/code/workspaces/web-app/src/actions/catalogueConfigActions.spec.js
@@ -1,0 +1,11 @@
+import { catalogueConfig } from '../config/catalogue';
+import catalogueConfigActions from './catalogueConfigActions';
+
+jest.mock('../config/catalogue');
+
+describe('loadCatalogConfig', () => {
+  it('created action matches snapshot', () => {
+    catalogueConfig.mockReturnValueOnce('expected catalogue config value');
+    expect(catalogueConfigActions.loadCatalogueConfig()).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/components/common/GridSkeleton.js
+++ b/code/workspaces/web-app/src/components/common/GridSkeleton.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Skeleton from '@material-ui/lab/Skeleton';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => {
+  const horizontalSpacing = theme.spacing(3);
+  const verticalSpacing = theme.spacing(1);
+
+  return {
+    grid: {
+      display: 'grid',
+      gridTemplateColumns: ({ columns }) => `repeat(${columns}, 1fr)`,
+      rowGap: `${verticalSpacing}px`,
+      columnGap: `${horizontalSpacing}px`,
+      margin: [[verticalSpacing, 0]],
+    },
+  };
+});
+
+const GridSkeleton = ({ rows = 3, columns = 3, sizingText = 'Text to infer size from', sizingTextVariant = 'body1', className }) => {
+  const classes = useStyles({ columns });
+
+  const contents = [];
+  for (let i = 0; i < rows * columns; i++) {
+    contents.push(
+      <Skeleton key={i} variant="text">
+        <Typography variant={sizingTextVariant}>{sizingText}</Typography>
+      </Skeleton>,
+    );
+  }
+
+  const finalClassName = constructClassName(classes.grid, className);
+  return <div className={finalClassName}>{contents}</div>;
+};
+
+GridSkeleton.propTypes = {
+  rows: PropTypes.number,
+  columns: PropTypes.number,
+  sizingText: PropTypes.string,
+  sizingTextVariant: PropTypes.oneOf([ // The Material UI Typography variants
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'subtitle1', 'subtitle2',
+    'body1', 'body2',
+    'caption', 'button', 'overline', 'srOnly', 'inherit',
+  ]),
+  className: PropTypes.string,
+};
+
+const constructClassName = (...classNames) => (
+  classNames
+    .filter(name => name) // remove falsy values
+    .join(' ')
+);
+
+export default GridSkeleton;

--- a/code/workspaces/web-app/src/components/common/GridSkeleton.spec.js
+++ b/code/workspaces/web-app/src/components/common/GridSkeleton.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import GridSkeleton from './GridSkeleton';
+
+// By default class names from makeStyles have a counter that is incremented each time they
+// are used. This means that the test results are not repeatable as it is reliant on order
+// hence this mock is being used. The rest of the styles framework needs to remain unmocked.
+jest.mock(
+  '@material-ui/core/styles',
+  () => ({
+    ...jest.requireActual('@material-ui/core/styles'),
+    makeStyles: jest.fn().mockReturnValue(() => ({ grid: 'mockMakeStyles-grid' })),
+  }),
+);
+
+describe('GridSkeleton', () => {
+  it('renders the correct number of items to fill grid', () => {
+    const columns = 2;
+    const rows = 4;
+    const wrapper = shallow(<GridSkeleton columns={columns} rows={rows} />);
+    expect(wrapper.children().length).toBe(rows * columns);
+  });
+
+  it('renders correct children passing down provided props to children', () => {
+    const sizingText = 'Test sizing text';
+    const sizingTextVariant = 'h5';
+    const wrapper = shallow(<GridSkeleton sizingText={sizingText} sizingTextVariant={sizingTextVariant} />);
+    expect(wrapper.childAt(0)).toMatchSnapshot();
+  });
+
+  it('renders to match snapshot for 1 x 2 grid', () => {
+    expect(shallow(<GridSkeleton rows={1} columns={2} />)).toMatchSnapshot();
+  });
+
+  describe('correctly constructs final class name from default class names and provided class name when', () => {
+    it('when no class name is provided', () => {
+      const wrapper = shallow(<GridSkeleton />);
+      expect(wrapper.prop('className')).toMatchSnapshot();
+    });
+
+    it('when class name is provided', () => {
+      const wrapper = shallow(<GridSkeleton className="test-class-name"/>);
+      expect(wrapper.prop('className')).toMatchSnapshot();
+    });
+  });
+});

--- a/code/workspaces/web-app/src/components/common/PromisedContentSkeletonWrapper.js
+++ b/code/workspaces/web-app/src/components/common/PromisedContentSkeletonWrapper.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PromisedContentSkeletonWrapper = ({ promises, skeletonComponent, skeletonProps = {}, children }) => {
+  const fetching = Array.isArray(promises) ? promises.some(item => item.fetching) : promises.fetching;
+
+  if (fetching) return React.createElement(skeletonComponent, skeletonProps);
+  return children;
+};
+
+const promisePropTypes = PropTypes.shape({
+  fetching: PropTypes.bool.isRequired,
+});
+
+PromisedContentSkeletonWrapper.propTypes = {
+  promises: PropTypes.oneOfType([
+    promisePropTypes.isRequired,
+    PropTypes.arrayOf(promisePropTypes).isRequired,
+  ]),
+  skeletonComponent: PropTypes.oneOfType([
+    PropTypes.node.isRequired,
+    PropTypes.elementType.isRequired,
+  ]),
+  skeletonProps: PropTypes.object,
+};
+
+export default PromisedContentSkeletonWrapper;

--- a/code/workspaces/web-app/src/components/common/PromisedContentSkeletonWrapper.spec.js
+++ b/code/workspaces/web-app/src/components/common/PromisedContentSkeletonWrapper.spec.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PromisedContentSkeletonWrapper from './PromisedContentSkeletonWrapper';
+
+const TestSkeleton = props => <div {...props}>This is a test SKELETON component.</div>;
+const TestChild = props => <div{...props}>This is a test CHILD component.</div>;
+
+const createPromises = (...fetchingValues) => {
+  if (fetchingValues.length === 0) throw new Error('Must provide at lease one fetching value');
+  if (fetchingValues.length === 1) return { fetching: fetchingValues[0] };
+  return fetchingValues.map(fetching => ({ fetching }));
+};
+
+const expectRenderToMatchSnapshotWithFetchingValues = (...fetchingValues) => {
+  const promises = createPromises(...fetchingValues);
+  const wrapper = shallow(
+    <PromisedContentSkeletonWrapper promises={promises} skeletonComponent={TestSkeleton}>
+      <TestChild />
+    </PromisedContentSkeletonWrapper>,
+  );
+  expect(wrapper).toMatchSnapshot();
+};
+
+describe('PromisedContentSkeletonWrapper', () => {
+  describe('when passed a single promise', () => {
+    it('renders child component when promise is not fetching', () => {
+      expectRenderToMatchSnapshotWithFetchingValues(false);
+    });
+
+    it('renders skeleton component when promise is fetching', () => {
+      expectRenderToMatchSnapshotWithFetchingValues(true);
+    });
+  });
+
+  describe('when passed multiple promises', () => {
+    it('renders child component when none of the promises are fetching', () => {
+      expectRenderToMatchSnapshotWithFetchingValues(false, false, false);
+    });
+
+    it('renders skeleton component when all promises are fetching', () => {
+      expectRenderToMatchSnapshotWithFetchingValues(true, true, true);
+    });
+
+    it('renders skeleton component when one promise is fetching', () => {
+      expectRenderToMatchSnapshotWithFetchingValues(false, true, false);
+    });
+  });
+
+  it('passes skeletonProps to skeletonComponent when it is being rendered', () => {
+    const promise = createPromises(true);
+    const wrapper = shallow(
+        <PromisedContentSkeletonWrapper
+          promises={promise}
+          skeletonComponent={TestSkeleton}
+          skeletonProps={{ propOne: 'prop-one', propTwo: 'prop-two' }}
+        >
+          <TestChild />
+        </PromisedContentSkeletonWrapper>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/components/common/__snapshots__/GridSkeleton.spec.js.snap
+++ b/code/workspaces/web-app/src/components/common/__snapshots__/GridSkeleton.spec.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GridSkeleton correctly constructs final class name from default class names and provided class name when when class name is provided 1`] = `"mockMakeStyles-grid test-class-name"`;
+
+exports[`GridSkeleton correctly constructs final class name from default class names and provided class name when when no class name is provided 1`] = `"mockMakeStyles-grid"`;
+
+exports[`GridSkeleton renders correct children passing down provided props to children 1`] = `
+<WithStyles(ForwardRef(Skeleton))
+  key="0"
+  variant="text"
+>
+  <WithStyles(ForwardRef(Typography))
+    variant="h5"
+  >
+    Test sizing text
+  </WithStyles(ForwardRef(Typography))>
+</WithStyles(ForwardRef(Skeleton))>
+`;
+
+exports[`GridSkeleton renders to match snapshot for 1 x 2 grid 1`] = `
+<div
+  className="mockMakeStyles-grid"
+>
+  <WithStyles(ForwardRef(Skeleton))
+    key="0"
+    variant="text"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      Text to infer size from
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Skeleton))>
+  <WithStyles(ForwardRef(Skeleton))
+    key="1"
+    variant="text"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="body1"
+    >
+      Text to infer size from
+    </WithStyles(ForwardRef(Typography))>
+  </WithStyles(ForwardRef(Skeleton))>
+</div>
+`;

--- a/code/workspaces/web-app/src/components/common/__snapshots__/PromisedContentSkeletonWrapper.spec.js.snap
+++ b/code/workspaces/web-app/src/components/common/__snapshots__/PromisedContentSkeletonWrapper.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromisedContentSkeletonWrapper passes skeletonProps to skeletonComponent when it is being rendered 1`] = `
+<TestSkeleton
+  propOne="prop-one"
+  propTwo="prop-two"
+/>
+`;
+
+exports[`PromisedContentSkeletonWrapper when passed a single promise renders child component when promise is not fetching 1`] = `<TestChild />`;
+
+exports[`PromisedContentSkeletonWrapper when passed a single promise renders skeleton component when promise is fetching 1`] = `<TestSkeleton />`;
+
+exports[`PromisedContentSkeletonWrapper when passed multiple promises renders child component when none of the promises are fetching 1`] = `<TestChild />`;
+
+exports[`PromisedContentSkeletonWrapper when passed multiple promises renders skeleton component when all promises are fetching 1`] = `<TestSkeleton />`;
+
+exports[`PromisedContentSkeletonWrapper when passed multiple promises renders skeleton component when one promise is fetching 1`] = `<TestSkeleton />`;

--- a/code/workspaces/web-app/src/config/__snapshots__/catalogue.spec.js.snap
+++ b/code/workspaces/web-app/src/config/__snapshots__/catalogue.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`catalogueConfig returns correct configuration 1`] = `
+Object {
+  "available": true,
+}
+`;

--- a/code/workspaces/web-app/src/config/catalogue.js
+++ b/code/workspaces/web-app/src/config/catalogue.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export async function catalogueConfig() {
+  const { data } = await axios.get('/catalogue_config.json');
+  return data;
+}
+
+export async function catalogueAvailable() {
+  const config = await catalogueConfig();
+  return config.available;
+}

--- a/code/workspaces/web-app/src/config/catalogue.spec.js
+++ b/code/workspaces/web-app/src/config/catalogue.spec.js
@@ -1,0 +1,20 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import data from 'common/src/config/catalogue_config.json';
+import { catalogueConfig, catalogueAvailable } from './catalogue';
+
+const httpMock = new MockAdapter(axios);
+httpMock.onGet('/catalogue_config.json').reply(() => [200, data]);
+
+describe('catalogueConfig', () => {
+  it('returns correct configuration', async () => {
+    const config = await catalogueConfig();
+    expect(config).toMatchSnapshot();
+  });
+});
+
+describe('catalogueConfig', () => {
+  it('returns correct value for whether catalogue is available', async () => {
+    expect(await catalogueAvailable()).toBe(true);
+  });
+});

--- a/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.js
@@ -4,7 +4,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
-import Skeleton from '@material-ui/lab/Skeleton';
 import { useUsers } from '../../hooks/usersHooks';
 import { useRoles } from '../../hooks/rolesHooks';
 import { useStacksArray } from '../../hooks/stacksHooks';
@@ -15,12 +14,13 @@ import sortByName from '../../components/common/sortByName';
 import filterUserByRoles from './filterUserByRoles';
 import UserResources from './UserResources';
 import PromisedContentWrapper from '../../components/common/PromisedContentWrapper';
+import PromisedContentSkeletonWrapper from '../../components/common/PromisedContentSkeletonWrapper';
+import UserSelect from '../../components/common/input/UserSelect';
+import GridSkeleton from '../../components/common/GridSkeleton';
 import Pagination from '../../components/stacks/Pagination';
 import roleActions from '../../actions/roleActions';
 import projectActions from '../../actions/projectActions';
 import createUserRoles from './createUserRoles';
-import UserSelect from '../../components/common/input/UserSelect';
-import PromisedContentSkeletonWrapper from '../../components/common/PromisedContentSkeletonWrapper';
 import catalogueConfigActions from '../../actions/catalogueConfigActions';
 
 const useStyles = makeStyles(theme => ({
@@ -114,7 +114,7 @@ function AdminUsersContainer() {
         </div>
         <PromisedContentSkeletonWrapper
           promises={catalogueAvailable}
-          skeletonComponent={FilterSkeleton}
+          skeletonComponent={GridSkeleton}
           skeletonProps={{ rows: 3, columns: 4 }}
         >
           <div className={classes.filterColumn}>
@@ -145,25 +145,5 @@ function AdminUsersContainer() {
     </>
   );
 }
-
-const FilterSkeleton = ({ rows = 3, columns = 3 }) => {
-  const classes = useStyles();
-
-  const columnItems = [];
-  for (let i = 0; i < rows; i++) {
-    columnItems.push(
-      <Skeleton className={classes.skeletonFilterItem} key={i} variant="text">
-        <Typography>Text to infer size from.</Typography>
-      </Skeleton>,
-    );
-  }
-
-  const output = [];
-  for (let i = 0; i < columns; i++) {
-    output.push(<div key={i} className={classes.filterColumn}>{columnItems}</div>);
-  }
-
-  return <>{output}</>;
-};
 
 export default AdminUsersContainer;

--- a/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.spec.js
@@ -7,6 +7,7 @@ import { useRoles } from '../../hooks/rolesHooks';
 import { useStacksArray } from '../../hooks/stacksHooks';
 import { useDataStorageArray } from '../../hooks/dataStorageHooks';
 import { useProjectsArray } from '../../hooks/projectsHooks';
+import { useCatalogueAvailable } from '../../hooks/catalogueConfigHooks';
 
 jest.mock('react-redux');
 jest.mock('../../hooks/usersHooks');
@@ -14,6 +15,7 @@ jest.mock('../../hooks/rolesHooks');
 jest.mock('../../hooks/stacksHooks');
 jest.mock('../../hooks/dataStorageHooks');
 jest.mock('../../hooks/projectsHooks');
+jest.mock('../../hooks/catalogueConfigHooks');
 jest.mock('./UserResources', () => ({
   __esModule: true,
   default: jest.fn().mockReturnValue(<>user resources</>),
@@ -37,9 +39,16 @@ useRoles.mockReturnValue({ fetching: false, value: roles });
 useStacksArray.mockReturnValue({ fetching: false, value: [] });
 useDataStorageArray.mockReturnValue({ fetching: false, value: [] });
 useProjectsArray.mockReturnValue({ fetching: false, value: [] });
+useProjectsArray.mockReturnValue({ fetching: false, value: [] });
+useCatalogueAvailable.mockReturnValue({ fetching: false, value: true });
 
 describe('AdminUsersContainer', () => {
   it('renders correctly passing correct props to children', () => {
+    expect(shallow(<AdminUsersContainer/>)).toMatchSnapshot();
+  });
+
+  it('does not render catalogue permission filters when there is no catalogue available', () => {
+    useCatalogueAvailable.mockReturnValueOnce({ fetching: false, value: false });
     expect(shallow(<AdminUsersContainer/>)).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/containers/adminListUsers/UserResources.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/UserResources.js
@@ -7,7 +7,6 @@ import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { makeStyles } from '@material-ui/core/styles';
 import { permissionTypes } from 'common';
-import Skeleton from '@material-ui/lab/Skeleton';
 import { useCurrentUserId } from '../../hooks/authHooks';
 import { ResourceAccordion, ResourceAccordionSummary, ResourceAccordionDetails } from '../adminResources/ResourceAccordion';
 import userSummary from './userSummary';
@@ -17,6 +16,7 @@ import Pagination from '../../components/stacks/Pagination';
 import roleActions from '../../actions/roleActions';
 import { useCatalogueAvailable } from '../../hooks/catalogueConfigHooks';
 import PromisedContentSkeletonWrapper from '../../components/common/PromisedContentSkeletonWrapper';
+import GridSkeleton from '../../components/common/GridSkeleton';
 
 const { CATALOGUE_ROLES } = permissionTypes;
 
@@ -114,7 +114,7 @@ export default function UserResources({ user, filters, roles }) {
         <ResourceAccordionDetails>
           <div className={classes.resources}>
             <div className={classes.systemRoles}>
-              <PromisedContentSkeletonWrapper promises={catalogueAvailable} skeletonComponent={SystemRoleSkeleton}>
+              <PromisedContentSkeletonWrapper promises={catalogueAvailable} skeletonComponent={GridSkeleton} skeletonProps={{ rows: 1, columns: 2 }}>
                 <SystemCheckbox label="Instance admin" checked={roles.instanceAdmin} name="instanceAdmin" disabled={user.userId === currentUserId} />
                 {catalogueAvailable.value && <SystemSelect itemPrefix="Catalogue" current={roles.catalogueRole} items={CATALOGUE_ROLES} name="catalogue" />}
               </PromisedContentSkeletonWrapper>
@@ -126,17 +126,3 @@ export default function UserResources({ user, filters, roles }) {
     </div>
   );
 }
-
-const SystemRoleSkeleton = () => {
-  const classes = useStyles();
-  return (
-    <>
-      <Skeleton className={classes.systemRoleSkeletonItem} variant="text" style>
-        <Typography>Instance admin checkbox</Typography>
-      </Skeleton>
-      <Skeleton className={classes.systemRoleSkeletonItem} variant="text">
-        <Typography>Catalogue permission select</Typography>
-      </Skeleton>
-    </>
-  );
-};

--- a/code/workspaces/web-app/src/containers/adminListUsers/UserResources.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/UserResources.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { shallow } from 'enzyme';
 import UserResources from './UserResources';
+import { useCatalogueAvailable } from '../../hooks/catalogueConfigHooks';
 
 const user = { name: 'user name', userId: 'uid1' };
 const projectKey = 'proj-1234';
@@ -15,6 +16,7 @@ jest.mock('./UserProject', () => ({
   __esModule: true,
   default: jest.fn().mockReturnValue(<>user project</>),
 }));
+jest.mock('../../hooks/catalogueConfigHooks');
 
 describe('UserResources', () => {
   const shallowRender = () => {
@@ -43,7 +45,15 @@ describe('UserResources', () => {
     return shallow(<UserResources {...props} />);
   };
 
-  it('renders to match snapshot passing correct props to children', () => {
-    expect(shallowRender()).toMatchSnapshot();
+  describe('renders to match snapshot passing correct props to children', () => {
+    it('when catalogue is available', () => {
+      useCatalogueAvailable.mockReturnValueOnce({ fetching: false, value: true });
+      expect(shallowRender()).toMatchSnapshot();
+    });
+
+    it('when catalogue is not available', () => {
+      useCatalogueAvailable.mockReturnValueOnce({ fetching: false, value: false });
+      expect(shallowRender()).toMatchSnapshot();
+    });
   });
 });

--- a/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/AdminUsersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/AdminUsersContainer.spec.js.snap
@@ -1,5 +1,206 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AdminUsersContainer does not render catalogue permission filters when there is no catalogue available 1`] = `
+<Fragment>
+  <UserSelect
+    label="Users"
+    multiselect={true}
+    placeholder="Filter by user"
+    selectedUsers={Array []}
+    setSelectedUsers={[Function]}
+  />
+  <div
+    className="makeStyles-filterControls-1"
+  >
+    <div
+      className="makeStyles-filterColumn-2"
+    >
+      <span
+        className="makeStyles-filterText-3"
+      >
+        Filter
+      </span>
+    </div>
+    <PromisedContentSkeletonWrapper
+      promises={
+        Object {
+          "fetching": false,
+          "value": false,
+        }
+      }
+      skeletonComponent={[Function]}
+      skeletonProps={
+        Object {
+          "columns": 4,
+          "rows": 3,
+        }
+      }
+    >
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Instance admin"
+          name="instanceAdmin"
+        />
+      </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Project admin"
+          name="projectAdmin"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Project user"
+          name="projectUser"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Project viewer"
+          name="projectViewer"
+        />
+      </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Site owner"
+          name="siteOwner"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Notebook owner"
+          name="notebookOwner"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Storage access"
+          name="storageAccess"
+        />
+      </div>
+    </PromisedContentSkeletonWrapper>
+  </div>
+  <div>
+    <PromisedContentWrapper
+      fetchingClassName="makeStyles-placeholderCard-5"
+      promise={
+        Array [
+          Object {
+            "fetching": false,
+            "value": Array [
+              Object {
+                "catalogueRole": "admin",
+                "instanceAdmin": true,
+                "name": "Test User 1",
+                "userId": "user1",
+              },
+              Object {
+                "catalogueRole": "user",
+                "instanceAdmin": false,
+                "name": "Test User 2",
+                "userId": "user2",
+              },
+            ],
+          },
+          Object {
+            "fetching": false,
+            "value": Array [],
+          },
+        ]
+      }
+    >
+      <Pagination
+        items={
+          Array [
+            <mockConstructor
+              filters={
+                Object {
+                  "catalogueAdmin": false,
+                  "catalogueEditor": false,
+                  "cataloguePublisher": false,
+                  "instanceAdmin": false,
+                  "notebookOwner": false,
+                  "projectAdmin": false,
+                  "projectUser": false,
+                  "projectViewer": false,
+                  "siteOwner": false,
+                  "storageAccess": false,
+                }
+              }
+              roles={
+                Object {
+                  "catalogueAdmin": true,
+                  "catalogueEditor": false,
+                  "cataloguePublisher": false,
+                  "catalogueRole": "admin",
+                  "instanceAdmin": true,
+                  "notebookOwner": Array [],
+                  "projectAdmin": Array [],
+                  "projectUser": Array [],
+                  "projectViewer": Array [],
+                  "siteOwner": Array [],
+                  "storageAccess": Array [],
+                }
+              }
+              user={
+                Object {
+                  "name": "Test User 1",
+                  "userId": "user1",
+                }
+              }
+            />,
+            <mockConstructor
+              filters={
+                Object {
+                  "catalogueAdmin": false,
+                  "catalogueEditor": false,
+                  "cataloguePublisher": false,
+                  "instanceAdmin": false,
+                  "notebookOwner": false,
+                  "projectAdmin": false,
+                  "projectUser": false,
+                  "projectViewer": false,
+                  "siteOwner": false,
+                  "storageAccess": false,
+                }
+              }
+              roles={
+                Object {
+                  "catalogueAdmin": false,
+                  "catalogueEditor": false,
+                  "cataloguePublisher": false,
+                  "catalogueRole": "user",
+                  "instanceAdmin": false,
+                  "notebookOwner": Array [],
+                  "projectAdmin": Array [],
+                  "projectUser": Array [],
+                  "projectViewer": Array [],
+                  "siteOwner": Array [],
+                  "storageAccess": Array [],
+                }
+              }
+              user={
+                Object {
+                  "name": "Test User 2",
+                  "userId": "user2",
+                }
+              }
+            />,
+          ]
+        }
+        itemsName="Users"
+        itemsPerPage={5}
+      />
+    </PromisedContentWrapper>
+  </div>
+</Fragment>
+`;
+
 exports[`AdminUsersContainer renders correctly passing correct props to children 1`] = `
 <Fragment>
   <UserSelect
@@ -21,76 +222,92 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
         Filter
       </span>
     </div>
-    <div
-      className="makeStyles-filterColumn-2"
+    <PromisedContentSkeletonWrapper
+      promises={
+        Object {
+          "fetching": false,
+          "value": true,
+        }
+      }
+      skeletonComponent={[Function]}
+      skeletonProps={
+        Object {
+          "columns": 4,
+          "rows": 3,
+        }
+      }
     >
-      <FilterCheckBox
-        checked={false}
-        label="Instance admin"
-        name="instanceAdmin"
-      />
-    </div>
-    <div
-      className="makeStyles-filterColumn-2"
-    >
-      <FilterCheckBox
-        checked={false}
-        label="Catalogue admin"
-        name="catalogueAdmin"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Catalogue publisher"
-        name="cataloguePublisher"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Catalogue editor"
-        name="catalogueEditor"
-      />
-    </div>
-    <div
-      className="makeStyles-filterColumn-2"
-    >
-      <FilterCheckBox
-        checked={false}
-        label="Project admin"
-        name="projectAdmin"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Project user"
-        name="projectUser"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Project viewer"
-        name="projectViewer"
-      />
-    </div>
-    <div
-      className="makeStyles-filterColumn-2"
-    >
-      <FilterCheckBox
-        checked={false}
-        label="Site owner"
-        name="siteOwner"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Notebook owner"
-        name="notebookOwner"
-      />
-      <FilterCheckBox
-        checked={false}
-        label="Storage access"
-        name="storageAccess"
-      />
-    </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Instance admin"
+          name="instanceAdmin"
+        />
+      </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Catalogue admin"
+          name="catalogueAdmin"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Catalogue publisher"
+          name="cataloguePublisher"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Catalogue editor"
+          name="catalogueEditor"
+        />
+      </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Project admin"
+          name="projectAdmin"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Project user"
+          name="projectUser"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Project viewer"
+          name="projectViewer"
+        />
+      </div>
+      <div
+        className="makeStyles-filterColumn-2"
+      >
+        <FilterCheckBox
+          checked={false}
+          label="Site owner"
+          name="siteOwner"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Notebook owner"
+          name="notebookOwner"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Storage access"
+          name="storageAccess"
+        />
+      </div>
+    </PromisedContentSkeletonWrapper>
   </div>
   <div>
     <PromisedContentWrapper
-      fetchingClassName="makeStyles-placeholderCard-4"
+      fetchingClassName="makeStyles-placeholderCard-5"
       promise={
         Array [
           Object {

--- a/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserResources renders to match snapshot passing correct props to children 1`] = `
+exports[`UserResources renders to match snapshot passing correct props to children when catalogue is available 1`] = `
 <div
   className="makeStyles-container-1"
 >
@@ -31,24 +31,143 @@ exports[`UserResources renders to match snapshot passing correct props to childr
         <div
           className="makeStyles-systemRoles-5"
         >
-          <SystemCheckbox
-            checked={true}
-            disabled={false}
-            label="Instance admin"
-            name="instanceAdmin"
-          />
-          <SystemSelect
-            itemPrefix="Catalogue"
-            items={
-              Array [
-                "admin",
-                "publisher",
-                "editor",
-                "user",
-              ]
+          <PromisedContentSkeletonWrapper
+            promises={
+              Object {
+                "fetching": false,
+                "value": true,
+              }
             }
-            name="catalogue"
-          />
+            skeletonComponent={[Function]}
+          >
+            <SystemCheckbox
+              checked={true}
+              disabled={false}
+              label="Instance admin"
+              name="instanceAdmin"
+            />
+            <SystemSelect
+              itemPrefix="Catalogue"
+              items={
+                Array [
+                  "admin",
+                  "publisher",
+                  "editor",
+                  "user",
+                ]
+              }
+              name="catalogue"
+            />
+          </PromisedContentSkeletonWrapper>
+        </div>
+        <Pagination
+          items={
+            Array [
+              <mockConstructor
+                filters={
+                  Object {
+                    "instanceAdmin": false,
+                    "notebookOwner": false,
+                    "projectAdmin": false,
+                    "projectUser": false,
+                    "projectViewer": false,
+                    "siteOwner": false,
+                    "storageAccess": false,
+                  }
+                }
+                projectKey="proj-1234"
+                roles={
+                  Object {
+                    "instanceAdmin": true,
+                    "notebookOwner": Array [
+                      Object {
+                        "name": "notebook name",
+                        "projectKey": "proj-1234",
+                      },
+                    ],
+                    "projectAdmin": Array [
+                      "proj-1234",
+                    ],
+                    "projectUser": Array [
+                      "proj-1234",
+                    ],
+                    "projectViewer": Array [
+                      "proj-1234",
+                    ],
+                    "siteOwner": Array [
+                      Object {
+                        "name": "site name",
+                        "projectKey": "proj-1234",
+                      },
+                    ],
+                    "storageAccess": Array [
+                      Object {
+                        "name": "storage name",
+                        "projectKey": "proj-1234",
+                      },
+                    ],
+                  }
+                }
+                userId="uid1"
+              />,
+            ]
+          }
+          itemsName="Projects"
+          itemsPerPage={5}
+        />
+      </div>
+    </WithStyles(WithStyles(ForwardRef(ExpansionPanelDetails)))>
+  </WithStyles(WithStyles(ForwardRef(ExpansionPanel)))>
+</div>
+`;
+
+exports[`UserResources renders to match snapshot passing correct props to children when catalogue is not available 1`] = `
+<div
+  className="makeStyles-container-1"
+>
+  <WithStyles(WithStyles(ForwardRef(ExpansionPanel)))>
+    <WithStyles(WithStyles(ForwardRef(ExpansionPanelSummary)))
+      expandIcon={<Memo(ExpandMoreIcon) />}
+    >
+      <div
+        className="makeStyles-summary-4"
+      >
+        <WithStyles(ForwardRef(Typography))
+          className="makeStyles-heading-3"
+          variant="h5"
+        >
+          user name
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))
+          variant="body2"
+        >
+          1 project, 1 site, 1 notebook, 1 data store
+        </WithStyles(ForwardRef(Typography))>
+      </div>
+    </WithStyles(WithStyles(ForwardRef(ExpansionPanelSummary)))>
+    <WithStyles(WithStyles(ForwardRef(ExpansionPanelDetails)))>
+      <div
+        className="makeStyles-resources-2"
+      >
+        <div
+          className="makeStyles-systemRoles-5"
+        >
+          <PromisedContentSkeletonWrapper
+            promises={
+              Object {
+                "fetching": false,
+                "value": false,
+              }
+            }
+            skeletonComponent={[Function]}
+          >
+            <SystemCheckbox
+              checked={true}
+              disabled={false}
+              label="Instance admin"
+              name="instanceAdmin"
+            />
+          </PromisedContentSkeletonWrapper>
         </div>
         <Pagination
           items={

--- a/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
@@ -39,6 +39,12 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               }
             }
             skeletonComponent={[Function]}
+            skeletonProps={
+              Object {
+                "columns": 2,
+                "rows": 1,
+              }
+            }
           >
             <SystemCheckbox
               checked={true}
@@ -160,6 +166,12 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               }
             }
             skeletonComponent={[Function]}
+            skeletonProps={
+              Object {
+                "columns": 2,
+                "rows": 1,
+              }
+            }
           >
             <SystemCheckbox
               checked={true}

--- a/code/workspaces/web-app/src/hooks/catalogueConfigHooks.js
+++ b/code/workspaces/web-app/src/hooks/catalogueConfigHooks.js
@@ -1,0 +1,5 @@
+import useShallowSelector from './useShallowSelector';
+import catalogueConfigSelectors from '../selectors/catalogueConfigSelectors';
+
+export const useCatalogueConfig = () => useShallowSelector(catalogueConfigSelectors.catalogueConfig);
+export const useCatalogueAvailable = () => useShallowSelector(catalogueConfigSelectors.catalogueAvailable);

--- a/code/workspaces/web-app/src/hooks/catalogueConfigHooks.spec.js
+++ b/code/workspaces/web-app/src/hooks/catalogueConfigHooks.spec.js
@@ -1,0 +1,36 @@
+import catalogueConfigSelectors from '../selectors/catalogueConfigSelectors';
+import useShallowSelector from './useShallowSelector';
+import { useCatalogueConfig, useCatalogueAvailable } from './catalogueConfigHooks';
+
+jest.mock('./useShallowSelector');
+
+useShallowSelector.mockImplementation(selector => selector());
+
+const catalogueConfigSelectorMock = jest.fn().mockName('catalogueConfigSelector');
+catalogueConfigSelectors.catalogueConfig = catalogueConfigSelectorMock;
+const catalogueAvailableSelectorMock = jest.fn().mockName('catalogueAvailableSelector');
+catalogueConfigSelectors.catalogueAvailable = catalogueAvailableSelectorMock;
+
+describe('useCatalogueConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses catalogueConfig selector as a shallow selector', () => {
+    useCatalogueConfig();
+    expect(useShallowSelector).toHaveBeenCalledTimes(1);
+    expect(useShallowSelector).toHaveBeenCalledWith(catalogueConfigSelectorMock);
+  });
+});
+
+describe('useCatalogueAvailable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses catalogueAvailable selector as a shallow selector', () => {
+    useCatalogueAvailable();
+    expect(useShallowSelector).toHaveBeenCalledTimes(1);
+    expect(useShallowSelector).toHaveBeenCalledWith(catalogueAvailableSelectorMock);
+  });
+});

--- a/code/workspaces/web-app/src/reducers/catalogueConfigReducer.js
+++ b/code/workspaces/web-app/src/reducers/catalogueConfigReducer.js
@@ -1,0 +1,21 @@
+import typeToReducer from 'type-to-reducer';
+import { LOAD_CATALOGUE_CONFIG_ACTION } from '../actions/catalogueConfigActions';
+import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS } from '../actions/actionTypes';
+
+const initialState = {
+  value: {},
+  fetching: false,
+};
+
+export default typeToReducer({
+  [LOAD_CATALOGUE_CONFIG_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({
+      ...state,
+      fetching: true,
+    }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({
+      value: action.payload,
+      fetching: false,
+    }),
+  },
+}, initialState);

--- a/code/workspaces/web-app/src/reducers/catalogueConfigReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/catalogueConfigReducer.spec.js
@@ -1,0 +1,26 @@
+import catalogueConfigReducer from './catalogueConfigReducer';
+import { LOAD_CATALOGUE_CONFIG_ACTION } from '../actions/catalogueConfigActions';
+import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS } from '../actions/actionTypes';
+
+describe('catalogueConfigReducer', () => {
+  describe('LOAD_CATALOGUE_CONFIG_ACTION', () => {
+    it('should handle PENDING state', () => {
+      const startState = { fetching: false, value: { available: true } };
+      const action = {
+        type: `${LOAD_CATALOGUE_CONFIG_ACTION}_${PROMISE_TYPE_PENDING}`,
+      };
+      const nextState = catalogueConfigReducer(startState, action);
+      expect(nextState).toEqual({ fetching: true, value: { available: true } });
+    });
+
+    it('should handle SUCCESS state', () => {
+      const startState = { fetching: true, value: {} };
+      const action = {
+        type: `${LOAD_CATALOGUE_CONFIG_ACTION}_${PROMISE_TYPE_SUCCESS}`,
+        payload: { available: true },
+      };
+      const nextState = catalogueConfigReducer(startState, action);
+      expect(nextState).toEqual({ fetching: false, value: { available: true } });
+    });
+  });
+});

--- a/code/workspaces/web-app/src/reducers/index.js
+++ b/code/workspaces/web-app/src/reducers/index.js
@@ -10,6 +10,7 @@ import users from './usersReducer';
 import roles from './rolesReducer';
 import projectUsers from './projectSettingsReducers';
 import currentProject from './currentProjectReducer';
+import catalogueConfig from './catalogueConfigReducer';
 
 const rootReducer = history => combineReducers({
   authentication,
@@ -21,6 +22,7 @@ const rootReducer = history => combineReducers({
   roles,
   projectUsers,
   currentProject,
+  catalogueConfig,
   router: connectRouter(history),
   form: formReducer,
 });

--- a/code/workspaces/web-app/src/selectors/catalogueConfigSelectors.js
+++ b/code/workspaces/web-app/src/selectors/catalogueConfigSelectors.js
@@ -1,0 +1,11 @@
+const selectCatalogueConfig = ({ catalogueConfig }) => catalogueConfig;
+const selectCatalogueAvailable = (state) => {
+  const catalogueConfig = selectCatalogueConfig(state);
+  const available = (catalogueConfig.value && catalogueConfig.value.available) || false;
+  return { ...catalogueConfig, value: available };
+};
+
+export default {
+  catalogueConfig: selectCatalogueConfig,
+  catalogueAvailable: selectCatalogueAvailable,
+};

--- a/code/workspaces/web-app/src/selectors/catalogueConfigSelectors.spec.js
+++ b/code/workspaces/web-app/src/selectors/catalogueConfigSelectors.spec.js
@@ -1,0 +1,38 @@
+import catalogueConfigSelectors from './catalogueConfigSelectors';
+
+const { catalogueConfig, catalogueAvailable } = catalogueConfigSelectors;
+
+const createState = ({ fetching = false, available = true } = {}) => ({
+  catalogueConfig: {
+    fetching,
+    value: { available },
+  },
+});
+
+describe('catalogueConfig', () => {
+  it('returns the value of catalogue config in provided state', () => {
+    const state = createState();
+    expect(catalogueConfig(state)).toEqual(state.catalogueConfig);
+  });
+});
+
+describe('catalogueAvailable', () => {
+  it('returns value of fetching from catalogue value', () => {
+    [false, true].forEach((fetching) => {
+      const state = createState({ fetching });
+      expect(catalogueAvailable(state).fetching).toEqual(fetching);
+    });
+  });
+
+  it('returns value of available from catalogue config as value', () => {
+    [false, true].forEach((available) => {
+      const state = createState({ available });
+      expect(catalogueAvailable(state).value).toEqual(available);
+    });
+  });
+
+  it('returns available as false if catalogueConfig empty', () => {
+    const state = { catalogueConfig: {} };
+    expect(catalogueAvailable(state).value).toBe(false);
+  });
+});


### PR DESCRIPTION
* Added `catalogue_config.json` which enables configuration of whether there is a catalogue available or not
* Added necessary components to store/read this config in/from redux state
* Updated following components on admin users page to only render when catalogue is configured as being available:
  * catalogue permission filters 
  * catalogue permission changer 
* Added `PromissedContentSkeletonWrapper` that can render passed Skeleton components while waiting for asynchronous content to load (analogous to the existing `PromisedContentWrapper` that renders a spinner while waiting for content to load).
