### PR TITLE
NERCDL-867 create sign-up page

### DIFF
--- a/architecture/deployment/oidc-deployment-and-configuration.md
+++ b/architecture/deployment/oidc-deployment-and-configuration.md
@@ -2,7 +2,7 @@
 
 In order for DataLabs to function there must be an OpenID connect (OIDC) compliant authentication provider (e.g Auth0, Keycloak, AWS Cognito) which will either
 store user information directly or serve to re-direct users to a different
-authentication provider which in turn will allow a user to recieve an identity
+authentication provider which in turn will allow a user to receive an identity
 token.
 
 All providers are different and offer various advantages. There are multiple
@@ -138,9 +138,30 @@ used;
 | OIDC_PROVIDER_AUDIENCE | This will be a value which is custom to the DataLabs deployment and will be used as the audience parameter on internal tokens that the authentication service generates | https://datalabs.domain/api |
 
 
-Not all providers offer a `${OIDC_PROVIDER_DOMAIN}/.well-known/openid-configuration` endpoint. If the provider you are using does not, two additional paramters must be specified for the necessary configuration information.
+Not all providers offer a `${OIDC_PROVIDER_DOMAIN}/.well-known/openid-configuration` endpoint. If the provider you are using does not, two additional parameters must be specified for the necessary configuration information.
 
 | Name                      | Description                                                | Example (and default)  |
 |---------------------------|------------------------------------------------------------|------------------------|
 | OIDC_OAUTH_TOKEN_ENDPOINT | Endpoint from the BASE URL where oauth tokens can be found | /oauth/token           |
 | OIDC_JWKS_ENDPOINT        | Endpoint from the BASE URL where JWKs can be found         | /.well-known/jwks.json |
+
+### Self-service sign-up
+Depending on your identity provider, self-service sign-up may or may not be possible.
+The appropriate corresponding behaviour is configured in the [configmap](https://github.com/NERC-CEH/datalab-k8s-manifests/blob/master/templates/datalab/oidc-configmap.template.yml).
+
+**Self-service is available**
+```yaml
+  "signUp": {
+    "selfService": true
+  }
+```
+In this case, the 'Sign Up' button of DataLabs will redirect to the identity provider's sign-in page.
+
+**Self-service is not available**
+```yaml
+  "signUp": {
+    "selfService": false,
+    "requestEmail": "appsupport@ceh.ac.uk"
+  }
+```
+In this case, the 'Sign Up' button of DataLabs will redirect to a page asking the user to request an account by emailing the `requestEmail` address.

--- a/code/development-env/config/local/web_auth_config.json
+++ b/code/development-env/config/local/web_auth_config.json
@@ -1,22 +1,30 @@
 {
-  "client_id": "Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
-  "redirect_uri": "https://testlab.datalabs.localhost/callback",
-  "response_type": "code",
-  "scope": "openid profile",
-  "authority": "https://mjbr.eu.auth0.com",
-  "automaticSilentRenew": true,
-  "accessTokenExpiringNotificationTime": "600",
-  "filterProtocolClaims": true,
-  "loadUserInfo": true,
-  "extraQueryParams": {
-      "audience": "https://datalab.datalabs.nerc.ac.uk/api"
+  "oidc": {
+    "userManager": {
+      "client_id": "Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
+      "redirect_uri": "https://testlab.datalabs.localhost/callback",
+      "response_type": "code",
+      "scope": "openid profile",
+      "authority": "https://mjbr.eu.auth0.com",
+      "automaticSilentRenew": true,
+      "accessTokenExpiringNotificationTime": "600",
+      "filterProtocolClaims": true,
+      "loadUserInfo": true,
+      "extraQueryParams": {
+        "audience": "https://datalab.datalabs.nerc.ac.uk/api"
+      },
+      "metadata": {
+        "issuer": "https://mjbr.eu.auth0.com/",
+        "authorization_endpoint": "https://mjbr.eu.auth0.com/authorize",
+        "userinfo_endpoint": "https://mjbr.eu.auth0.com/userinfo",
+        "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://testlab.datalabs.localhost/&client_id=Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
+        "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
+        "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token"
+      }
+    }
   },
-  "metadata": {
-      "issuer": "https://mjbr.eu.auth0.com/",
-      "authorization_endpoint": "https://mjbr.eu.auth0.com/authorize",
-      "userinfo_endpoint": "https://mjbr.eu.auth0.com/userinfo",
-      "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://testlab.datalabs.localhost/&client_id=Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
-      "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
-      "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token"
+  "signUp": {
+    "selfService": true,
+    "requestEmail": "datalabs@ceh.ac.uk"
   }
 }

--- a/code/development-env/config/local/web_auth_config.json
+++ b/code/development-env/config/local/web_auth_config.json
@@ -25,6 +25,6 @@
   },
   "signUp": {
     "selfService": true,
-    "requestEmail": "datalabs@ceh.ac.uk"
+    "requestEmail": "appsupport@ceh.ac.uk"
   }
 }

--- a/code/development-env/config/local/web_auth_config_keycloak.json
+++ b/code/development-env/config/local/web_auth_config_keycloak.json
@@ -1,19 +1,27 @@
 {
-  "client_id": "datalabs",
-  "redirect_uri": "https://testlab.datalabs.localhost/callback",
-  "response_type": "code",
-  "scope": "openid profile email",
-  "authority": "http://keycloak:8080/auth/realms/DataLabs",
-  "automaticSilentRenew": true,
-  "accessTokenExpiringNotificationTime": "600",
-  "filterProtocolClaims": true,
-  "loadUserInfo": true,
-  "metadata": {
-    "issuer": "http://keycloak:8080/auth/realms/DataLabs",
-    "authorization_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/auth",
-    "userinfo_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/userinfo",
-    "end_session_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/logout?redirect_uri=http://testlab.datalabs.localhost",
-    "jwks_uri": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/certs",
-    "token_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/token"
+  "oidc": {
+    "userManager": {
+      "client_id": "datalabs",
+      "redirect_uri": "https://testlab.datalabs.localhost/callback",
+      "response_type": "code",
+      "scope": "openid profile email",
+      "authority": "http://keycloak:8080/auth/realms/DataLabs",
+      "automaticSilentRenew": true,
+      "accessTokenExpiringNotificationTime": "600",
+      "filterProtocolClaims": true,
+      "loadUserInfo": true,
+      "metadata": {
+        "issuer": "http://keycloak:8080/auth/realms/DataLabs",
+        "authorization_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/auth",
+        "userinfo_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/userinfo",
+        "end_session_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/logout?redirect_uri=http://testlab.datalabs.localhost",
+        "jwks_uri": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/certs",
+        "token_endpoint": "http://keycloak:8080/auth/realms/DataLabs/protocol/openid-connect/token"
+      }
+    }
+  },
+  "signUp": {
+    "selfService": true,
+    "requestEmail": "appsupport@ceh.ac.uk"
   }
 }

--- a/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
+++ b/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
@@ -93,25 +93,6 @@ Array [
 ]
 `;
 
-exports[`userRolesRepository read operations getRoles returns expected snapshot 1`] = `
-Object {
-  "catalogueRole": "user",
-  "instanceAdmin": false,
-  "projectRoles": Array [
-    Object {
-      "projectKey": "project 1",
-      "role": "admin",
-    },
-    Object {
-      "projectKey": "project 2",
-      "role": "user",
-    },
-  ],
-  "userId": "uid1",
-  "userName": "user1",
-}
-`;
-
 exports[`userRolesRepository read operations getUser returns expected snapshot 1`] = `
 Object {
   "name": "user1",

--- a/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
+++ b/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
@@ -93,6 +93,25 @@ Array [
 ]
 `;
 
+exports[`userRolesRepository read operations getRoles returns expected snapshot 1`] = `
+Object {
+  "catalogueRole": "user",
+  "instanceAdmin": false,
+  "projectRoles": Array [
+    Object {
+      "projectKey": "project 1",
+      "role": "admin",
+    },
+    Object {
+      "projectKey": "project 2",
+      "role": "user",
+    },
+  ],
+  "userId": "uid1",
+  "userName": "user1",
+}
+`;
+
 exports[`userRolesRepository read operations getUser returns expected snapshot 1`] = `
 Object {
   "name": "user1",

--- a/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
+++ b/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
@@ -1,15 +1,26 @@
+const cloneUser = user => ({
+  ...user,
+  projectRoles: [...user.projectRoles],
+});
 
-function createDatabaseMock(items) {
+const wrapUser = user => ({
+  ...user,
+  toObject: () => user,
+});
+
+function createDatabaseMock(users) {
+  const documents = users.map(cloneUser).map(wrapUser);
   let lastInvocation;
+  let findOneReturn;
 
   return () => ({
     find: (query) => {
       lastInvocation = { query };
-      return { exec: () => Promise.resolve(items) };
+      return { exec: () => Promise.resolve(documents) };
     },
     findOne: (query) => {
       lastInvocation = { query };
-      return { exec: () => Promise.resolve(items[0]) };
+      return { exec: () => Promise.resolve(findOneReturn) };
     },
     findOneAndUpdate: (query, entity, params) => {
       lastInvocation = { query, entity, params };
@@ -21,20 +32,18 @@ function createDatabaseMock(items) {
     },
     exists: (query) => {
       lastInvocation = { query };
-      return Promise.resolve(items.length > 0);
+      return Promise.resolve(documents.length > 0);
     },
     create: (entity) => {
-      const wrappedEntity = {
-        ...entity,
-        toObject: () => entity,
-      };
+      const document = wrapUser(cloneUser(entity));
       lastInvocation = { entity };
-      return Promise.resolve(wrappedEntity);
+      return Promise.resolve(document);
     },
     invocation: () => lastInvocation,
     query: () => lastInvocation.query,
     entity: () => lastInvocation.entity,
     params: () => lastInvocation.params,
+    setFindOneReturn: (user) => { findOneReturn = user ? wrapUser(cloneUser(user)) : undefined; },
     clear: () => { lastInvocation = undefined; },
   });
 }

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -26,7 +26,10 @@ function addDefaults(roles) {
 async function getRoles(userId, userName) {
   let roles = await UserRoles().findOne({ userId }).exec();
   if (!roles) {
-    roles = await addRecordForNewUser(userId, userName, []);
+    // Need to add this user.  Make the first ever user an instanceAdmin.
+    const allRoles = await UserRoles().find().exec();
+    const instanceAdmin = allRoles.length === 0;
+    roles = await addRecordForNewUser(userId, userName, [], instanceAdmin);
   }
 
   return addDefaults(roles);
@@ -92,12 +95,15 @@ async function getProjectUsers(projectKey) {
   return projectUsers.map(addDefaults);
 }
 
-function addRecordForNewUser(userId, userName, projectRoles) {
+function addRecordForNewUser(userId, userName, projectRoles, instanceAdmin) {
   const user = {
     userId,
     userName,
     projectRoles,
   };
+  if (instanceAdmin) {
+    user.instanceAdmin = true;
+  }
   return UserRoles().create(user);
 }
 

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -26,10 +26,7 @@ function addDefaults(roles) {
 async function getRoles(userId, userName) {
   let roles = await UserRoles().findOne({ userId }).exec();
   if (!roles) {
-    // Need to add this user.  Make the first ever user an instanceAdmin.
-    const allRoles = await UserRoles().find().exec();
-    const instanceAdmin = allRoles.length === 0;
-    roles = await addRecordForNewUser(userId, userName, [], instanceAdmin);
+    roles = await addRecordForNewUser(userId, userName, []);
   }
 
   return addDefaults(roles);
@@ -95,15 +92,12 @@ async function getProjectUsers(projectKey) {
   return projectUsers.map(addDefaults);
 }
 
-function addRecordForNewUser(userId, userName, projectRoles, instanceAdmin) {
+function addRecordForNewUser(userId, userName, projectRoles) {
   const user = {
     userId,
     userName,
     projectRoles,
   };
-  if (instanceAdmin) {
-    user.instanceAdmin = true;
-  }
   return UserRoles().create(user);
 }
 

--- a/code/workspaces/web-app/public/web_auth_config.json
+++ b/code/workspaces/web-app/public/web_auth_config.json
@@ -24,6 +24,6 @@
   },
   "signUp": {
     "selfService": true,
-    "requestEmail": "datalabs@ceh.ac.uk"
+    "requestEmail": "appsupport@ceh.ac.uk"
   }
 }

--- a/code/workspaces/web-app/public/web_auth_config.json
+++ b/code/workspaces/web-app/public/web_auth_config.json
@@ -1,21 +1,29 @@
 {
-  "client_id": "Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
-  "redirect_uri": "https://testlab.datalabs.localhost/callback",
-  "response_type": "code",
-  "scope": "openid profile",
-  "authority": "https://mjbr.eu.auth0.com",
-  "automaticSilentRenew": true,
-  "filterProtocolClaims": true,
-  "loadUserInfo": true,
-  "extraQueryParams": {
-      "audience": "https://datalab.datalabs.nerc.ac.uk/api"
+  "oidc": {
+    "userManager": {
+      "client_id": "Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
+      "redirect_uri": "https://testlab.datalabs.localhost/callback",
+      "response_type": "code",
+      "scope": "openid profile",
+      "authority": "https://mjbr.eu.auth0.com",
+      "automaticSilentRenew": true,
+      "filterProtocolClaims": true,
+      "loadUserInfo": true,
+      "extraQueryParams": {
+        "audience": "https://datalab.datalabs.nerc.ac.uk/api"
+      },
+      "metadata": {
+        "issuer": "https://mjbr.eu.auth0.com/",
+        "authorization_endpoint": "https://mjbr.eu.auth0.com/authorize",
+        "userinfo_endpoint": "https://mjbr.eu.auth0.com/userinfo",
+        "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://testlab.datalabs.localhost/&client_id=Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
+        "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
+        "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token"
+      }
+    }
   },
-  "metadata": {
-      "issuer": "https://mjbr.eu.auth0.com/",
-      "authorization_endpoint": "https://mjbr.eu.auth0.com/authorize",
-      "userinfo_endpoint": "https://mjbr.eu.auth0.com/userinfo",
-      "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://testlab.datalabs.localhost/&client_id=Xf62MEzjqxfaId1DVWnFul61D9oA3eMt",
-      "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
-      "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token"
+  "signUp": {
+    "selfService": true,
+    "requestEmail": "datalabs@ceh.ac.uk"
   }
 }

--- a/code/workspaces/web-app/src/PublicApp.js
+++ b/code/workspaces/web-app/src/PublicApp.js
@@ -5,6 +5,7 @@ import { publicAppTheme } from './theme';
 import WelcomePage from './pages/WelcomePage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
 import RedirectToLoginPage from './pages/RedirectToLoginPage';
+import SignUpPage from './pages/SignUpPage';
 
 const PublicApp = () => (
   <MuiThemeProvider theme={publicAppTheme}>
@@ -14,6 +15,9 @@ const PublicApp = () => (
       </Route>
       <Route exact path="/verify">
         <VerifyEmailPage />
+      </Route>
+      <Route exact path="/sign-up">
+        <SignUpPage />
       </Route>
       <Route>
         <RedirectToLoginPage />

--- a/code/workspaces/web-app/src/auth/auth.js
+++ b/code/workspaces/web-app/src/auth/auth.js
@@ -9,8 +9,8 @@ class Auth {
     this.authConfig = authConfig;
     this.oidcAsync = promisifyOidcInit;
     this.oidcInit = oidcInit;
+    this.signUpConfig = this.signUpConfig.bind(this);
     this.login = this.login.bind(this);
-    this.signUp = this.signUp.bind(this);
     this.logout = this.logout.bind(this);
     this.handleAuthentication = this.handleAuthentication.bind(this);
     this.renewSession = this.renewSession.bind(this);
@@ -19,14 +19,13 @@ class Auth {
     this.getCurrentSession = this.getCurrentSession.bind(this);
   }
 
+  signUpConfig() {
+    return this.authConfig.signUp;
+  }
+
   login() {
     // Re-direct to login screen
     this.oidcInit.signinRedirect({ state: { appRedirect: window.location.pathname } });
-  }
-
-  signUp() {
-    // Re-direct to login screen
-    this.oidcInit.signinRedirect();
   }
 
   logout() {
@@ -120,7 +119,7 @@ const initialiseAuth = (authConfig) => {
     Oidc.Log.level = Oidc.Log.INFO;
 
     const userManagerConfig = {
-      ...authConfig,
+      ...authConfig.oidc.userManager,
       userStore: new Oidc.WebStorageStateStore(),
     };
 

--- a/code/workspaces/web-app/src/auth/auth.js
+++ b/code/workspaces/web-app/src/auth/auth.js
@@ -9,8 +9,9 @@ class Auth {
     this.authConfig = authConfig;
     this.oidcAsync = promisifyOidcInit;
     this.oidcInit = oidcInit;
-    this.signUpConfig = this.signUpConfig.bind(this);
     this.login = this.login.bind(this);
+    this.selfServiceSignUp = this.selfServiceSignUp.bind(this);
+    this.signUpConfig = this.signUpConfig.bind(this);
     this.logout = this.logout.bind(this);
     this.handleAuthentication = this.handleAuthentication.bind(this);
     this.renewSession = this.renewSession.bind(this);
@@ -19,13 +20,18 @@ class Auth {
     this.getCurrentSession = this.getCurrentSession.bind(this);
   }
 
-  signUpConfig() {
-    return this.authConfig.signUp;
-  }
-
   login() {
     // Re-direct to login screen
     this.oidcInit.signinRedirect({ state: { appRedirect: window.location.pathname } });
+  }
+
+  selfServiceSignUp() {
+    // Re-direct to login screen
+    this.oidcInit.signinRedirect();
+  }
+
+  signUpConfig() {
+    return this.authConfig.signUp;
   }
 
   logout() {

--- a/code/workspaces/web-app/src/auth/auth.spec.js
+++ b/code/workspaces/web-app/src/auth/auth.spec.js
@@ -9,14 +9,21 @@ const signinRedirectCallbackMock = jest.fn();
 const signoutRedirectMock = jest.fn();
 
 const authConfig = {
-  authority: 'expected.auth0.com',
-  client_id: 'expected-client-id',
-  extraQueryParams: {
-    audience: 'https://datalab.datalabs.nerc.ac.uk/api',
+  oidc: {
+    userManager: {
+      authority: 'expected.auth0.com',
+      client_id: 'expected-client-id',
+      extraQueryParams: {
+        audience: 'https://datalab.datalabs.nerc.ac.uk/api',
+      },
+      response_type: 'token id_token',
+      scope: 'openid profile',
+      redirect_uri: `${window.location.origin}/callback`,
+    },
   },
-  response_type: 'token id_token',
-  scope: 'openid profile',
-  redirect_uri: `${window.location.origin}/callback`,
+  signUp: {
+    selfService: true,
+  },
 };
 
 const MockAuth = {
@@ -51,6 +58,14 @@ describe('auth', () => {
         expires_at: moment.utc().add(10, 'hours'),
       }),
     );
+  });
+
+  it('signUpConfig returns expected config', () => {
+    // Act
+    const signUpConfig = auth.signUpConfig();
+
+    // Assert
+    expect(signUpConfig).toEqual({ selfService: true });
   });
 
   it('login calls signinRedirect with correct props', () => {

--- a/code/workspaces/web-app/src/auth/auth0UniversalLoginScreens.js
+++ b/code/workspaces/web-app/src/auth/auth0UniversalLoginScreens.js
@@ -1,7 +1,0 @@
-// Possible values for the intial screen for the Auth0 Universal login page
-// https://auth0.com/docs/libraries/lock/v11/configuration#initialscreen-string-
-export default Object.freeze({
-  LOGIN: 'login',
-  SIGN_UP: 'signUp',
-  FORGOT_PASSWORD: 'forgotPassword',
-});

--- a/code/workspaces/web-app/src/auth/authConfig.js
+++ b/code/workspaces/web-app/src/auth/authConfig.js
@@ -5,11 +5,10 @@ const getAuthConfig = () => axios
   .then(({ data }) => {
     // Overwrite default configuration for running locally/development purposes
     if (window.location.hostname.match(/localhost/)) {
-      return {
-        ...data,
-        silent_redirect_uri: `${window.location.origin}/silent_callback`,
-        redirect_uri: `${window.location.origin}/callback`,
-      };
+      const localData = data;
+      localData.oidc.userManager.silent_redirect_uri = `${window.location.origin}/silent_callback`;
+      localData.oidc.userManager.redirect_uri = `${window.location.origin}/callback`;
+      return localData;
     }
 
     return data;

--- a/code/workspaces/web-app/src/components/welcome/HeroBar.js
+++ b/code/workspaces/web-app/src/components/welcome/HeroBar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import { useHistory } from 'react-router-dom';
 import datalabsLogo from '../../assets/images/datalabs-vert.png';
 import getAuth from '../../auth/auth';
 import PrimaryActionButton from '../common/buttons/PrimaryActionButton';
@@ -36,16 +37,29 @@ const styles = theme => ({
 
 const tagLine = 'DataLabs provides you with tools to power your research and share the results';
 
-const HeroBar = ({ classes }) => (
+const HeroBar = ({ classes }) => {
+  const history = useHistory();
+
+  const signUp = () => {
+    const auth = getAuth();
+    if (auth.signUpConfig().selfService) {
+      auth.login();
+    } else {
+      history.push('/sign-up');
+    }
+  };
+
+  return (
   <div className={classes.bar}>
     <img className={classes.logo} src={datalabsLogo} alt="DataLabs-Logo" />
     <Typography className={classes.tagLine} variant="h6">{tagLine}</Typography>
     <div className={classes.buttons}>
-      <PagePrimaryActionButton className={classes.button} color="primary" onClick={getAuth().signUp}>Sign Up</PagePrimaryActionButton>
+      <PagePrimaryActionButton className={classes.button} color="primary" onClick={signUp}>Sign Up</PagePrimaryActionButton>
       <PrimaryActionButton className={classes.button} color="primary" onClick={getAuth().login}>Log In</PrimaryActionButton>
     </div>
   </div>
-);
+  );
+};
 
 HeroBar.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/code/workspaces/web-app/src/components/welcome/HeroBar.js
+++ b/code/workspaces/web-app/src/components/welcome/HeroBar.js
@@ -43,7 +43,7 @@ const HeroBar = ({ classes }) => {
   const signUp = () => {
     const auth = getAuth();
     if (auth.signUpConfig().selfService) {
-      auth.login();
+      auth.selfServiceSignUp();
     } else {
       history.push('/sign-up');
     }

--- a/code/workspaces/web-app/src/components/welcome/HeroBar.spec.js
+++ b/code/workspaces/web-app/src/components/welcome/HeroBar.spec.js
@@ -5,9 +5,9 @@ import getAuth from '../../auth/auth';
 
 jest.mock('../../auth/auth');
 getAuth.mockImplementation(() => ({
-  selfService: jest.fn().mockReturnValue({ selfService: true }),
   login: jest.fn(),
-  signUp: jest.fn(),
+  selfServiceSignUp: jest.fn(),
+  signUpConfig: jest.fn().mockReturnValue({ selfService: true }),
 }));
 
 describe('HeroBar', () => {

--- a/code/workspaces/web-app/src/components/welcome/SignUp.js
+++ b/code/workspaces/web-app/src/components/welcome/SignUp.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import datalabsLogo from '../../assets/images/datalabs-vert.png';
+import PagePrimaryActionButton from '../common/buttons/PagePrimaryActionButton';
+import PrimaryActionButton from '../common/buttons/PrimaryActionButton';
+import getAuth from '../../auth/auth';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    backgroundColor: 'inherit',
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    maxWidth: '40em',
+  },
+  logo: {
+    width: 300,
+    maxWidth: '75%',
+  },
+  textContainer: {
+    color: theme.palette.highlightMono,
+    padding: [[theme.spacing(8), 0]],
+  },
+  text: {
+    color: 'inherit',
+  },
+  buttons: {
+    display: 'flex',
+    justifyContent: 'center',
+    marginBottom: 0,
+  },
+  button: {
+    '& + &': {
+      marginLeft: theme.spacing(2),
+    },
+  },
+  link: {
+    color: theme.palette.highlightMono,
+  },
+}));
+
+const SignUp = () => {
+  const classes = useStyles();
+  const { requestEmail } = getAuth().signUpConfig();
+
+  return (
+    <div className={classes.container}>
+      <img className={classes.logo} src={datalabsLogo} alt="DataLabs-Logo" />
+      <div className={classes.textContainer}>
+        <Typography className={classes.text} variant="h5">Sign Up</Typography>
+        <Typography className={classes.text} variant="body1">
+          In order to use DataLabs, please email
+          {' '}
+          <a className={classes.link} href={`mailto:${requestEmail}`}>{requestEmail}</a>
+          {' '}
+          and request an account.
+          Your account will be created using your email address.
+        </Typography>
+      </div>
+      <div className={classes.buttons}>
+        <PrimaryActionButton
+          className={classes.button}
+          color="primary"
+          onClick={() => { window.location.href = '/'; }}
+        >
+          Home
+        </PrimaryActionButton>
+        <PagePrimaryActionButton
+          className={classes.button}
+          color="primary"
+          href={`mailto:${requestEmail}`}
+        >
+          Email {requestEmail}
+        </PagePrimaryActionButton>
+      </div>
+    </div>
+  );
+};
+
+export default SignUp;

--- a/code/workspaces/web-app/src/components/welcome/SignUp.spec.js
+++ b/code/workspaces/web-app/src/components/welcome/SignUp.spec.js
@@ -1,23 +1,21 @@
 import React from 'react';
 import { createShallow } from '@material-ui/core/test-utils';
-import HeroBar from './HeroBar';
+import SignUp from './SignUp';
 import getAuth from '../../auth/auth';
 
 jest.mock('../../auth/auth');
 getAuth.mockImplementation(() => ({
-  selfService: jest.fn().mockReturnValue({ selfService: true }),
-  login: jest.fn(),
-  signUp: jest.fn(),
+  signUpConfig: jest.fn().mockReturnValue({ requestEmail: 'test@test.com' }),
 }));
 
-describe('HeroBar', () => {
+describe('SignUp', () => {
   let shallow;
 
   beforeEach(() => {
-    shallow = createShallow({ dive: true });
+    shallow = createShallow();
   });
 
   it('renders correct snapshot', () => {
-    expect(shallow(<HeroBar />)).toMatchSnapshot();
+    expect(shallow(<SignUp />)).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/components/welcome/__snapshots__/HeroBar.spec.js.snap
+++ b/code/workspaces/web-app/src/components/welcome/__snapshots__/HeroBar.spec.js.snap
@@ -21,7 +21,7 @@ exports[`HeroBar renders correct snapshot 1`] = `
     <PagePrimaryActionButton
       className="HeroBar-button-5"
       color="primary"
-      onClick={[MockFunction]}
+      onClick={[Function]}
     >
       Sign Up
     </PagePrimaryActionButton>

--- a/code/workspaces/web-app/src/components/welcome/__snapshots__/SignUp.spec.js.snap
+++ b/code/workspaces/web-app/src/components/welcome/__snapshots__/SignUp.spec.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SignUp renders correct snapshot 1`] = `
+<div
+  className="makeStyles-container-1"
+>
+  <img
+    alt="DataLabs-Logo"
+    className="makeStyles-logo-2"
+    src="datalabs-vert.png"
+  />
+  <div
+    className="makeStyles-textContainer-3"
+  >
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-text-4"
+      variant="h5"
+    >
+      Sign Up
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(Typography))
+      className="makeStyles-text-4"
+      variant="body1"
+    >
+      In order to use DataLabs, please email
+       
+      <a
+        className="makeStyles-link-7"
+        href="mailto:test@test.com"
+      >
+        test@test.com
+      </a>
+       
+      and request an account. Your account will be created using your email address.
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+  <div
+    className="makeStyles-buttons-5"
+  >
+    <PrimaryActionButton
+      className="makeStyles-button-6"
+      color="primary"
+      onClick={[Function]}
+    >
+      Home
+    </PrimaryActionButton>
+    <PagePrimaryActionButton
+      className="makeStyles-button-6"
+      color="primary"
+      href="mailto:test@test.com"
+    >
+      Email 
+      test@test.com
+    </PagePrimaryActionButton>
+  </div>
+</div>
+`;

--- a/code/workspaces/web-app/src/pages/SignUpPage.js
+++ b/code/workspaces/web-app/src/pages/SignUpPage.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import SignUp from '../components/welcome/SignUp';
+
+const useStyles = makeStyles(theme => ({
+  page: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: theme.palette.backgroundDark,
+    minHeight: '100vh',
+  },
+}));
+
+const SignUpPage = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.page}>
+      <SignUp />
+    </div>
+  );
+};
+
+export default SignUpPage;

--- a/code/workspaces/web-app/src/pages/SignUpPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SignUpPage.spec.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import SignUpPage from './SignUpPage';
+
+describe('SignUpPage', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow();
+  });
+
+  it('renders correct snapshot', () => {
+    expect(shallow(<SignUpPage />)).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/pages/__snapshots__/SignUpPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SignUpPage.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SignUpPage renders correct snapshot 1`] = `
+<div
+  className="makeStyles-page-1"
+>
+  <SignUp />
+</div>
+`;

--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -57,6 +57,7 @@
 			"nbviewer",
 			"noopener",
 			"noreferrer",
+			"oidc",
 			"rshiny",
 			"rstudio",
 			"setup",


### PR DESCRIPTION
* The web_auth_config.json file has been updated, adding in a signUp configuration object.  The previous object, which was just for the OIDC userManager, is now in oidc.userManager.
* This change will be replicated in the oidc-configmap.template.yml file in datalab-k8s-manifests.
* The new parameters are described in oidc-deployment-and-configuration.md.
* If there is no self-service sign up, the 'Sign Up' button takes you to a new public page at /sign-up.

To test locally, modify code/development-env/config/local/web_auth_config.json.