### PR TITLE
feat: first user is instanceAdmin

### DIFF
--- a/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
+++ b/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
@@ -93,25 +93,6 @@ Array [
 ]
 `;
 
-exports[`userRolesRepository read operations getRoles returns expected snapshot 1`] = `
-Object {
-  "catalogueRole": "user",
-  "instanceAdmin": false,
-  "projectRoles": Array [
-    Object {
-      "projectKey": "project 1",
-      "role": "admin",
-    },
-    Object {
-      "projectKey": "project 2",
-      "role": "user",
-    },
-  ],
-  "userId": "uid1",
-  "userName": "user1",
-}
-`;
-
 exports[`userRolesRepository read operations getUser returns expected snapshot 1`] = `
 Object {
   "name": "user1",

--- a/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
+++ b/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
@@ -1,15 +1,26 @@
+const cloneUser = user => ({
+  ...user,
+  projectRoles: [...user.projectRoles],
+});
 
-function createDatabaseMock(items) {
+const wrapUser = user => ({
+  ...user,
+  toObject: () => user,
+});
+
+function createDatabaseMock(users) {
+  const documents = users.map(cloneUser).map(wrapUser);
   let lastInvocation;
+  let findOneReturn;
 
   return () => ({
     find: (query) => {
       lastInvocation = { query };
-      return { exec: () => Promise.resolve(items) };
+      return { exec: () => Promise.resolve(documents) };
     },
     findOne: (query) => {
       lastInvocation = { query };
-      return { exec: () => Promise.resolve(items[0]) };
+      return { exec: () => Promise.resolve(findOneReturn) };
     },
     findOneAndUpdate: (query, entity, params) => {
       lastInvocation = { query, entity, params };
@@ -21,20 +32,18 @@ function createDatabaseMock(items) {
     },
     exists: (query) => {
       lastInvocation = { query };
-      return Promise.resolve(items.length > 0);
+      return Promise.resolve(documents.length > 0);
     },
     create: (entity) => {
-      const wrappedEntity = {
-        ...entity,
-        toObject: () => entity,
-      };
+      const document = wrapUser(cloneUser(entity));
       lastInvocation = { entity };
-      return Promise.resolve(wrappedEntity);
+      return Promise.resolve(document);
     },
     invocation: () => lastInvocation,
     query: () => lastInvocation.query,
     entity: () => lastInvocation.entity,
     params: () => lastInvocation.params,
+    setFindOneReturn: (user) => { findOneReturn = user ? wrapUser(cloneUser(user)) : undefined; },
     clear: () => { lastInvocation = undefined; },
   });
 }

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -26,7 +26,10 @@ function addDefaults(roles) {
 async function getRoles(userId, userName) {
   let roles = await UserRoles().findOne({ userId }).exec();
   if (!roles) {
-    roles = await addRecordForNewUser(userId, userName, []);
+    // Need to add this user.  Make the first ever user an instanceAdmin.
+    const allRoles = await UserRoles().find().exec();
+    const instanceAdmin = allRoles.length === 0;
+    roles = await addRecordForNewUser(userId, userName, [], instanceAdmin);
   }
 
   return addDefaults(roles);
@@ -92,12 +95,15 @@ async function getProjectUsers(projectKey) {
   return projectUsers.map(addDefaults);
 }
 
-function addRecordForNewUser(userId, userName, projectRoles) {
+function addRecordForNewUser(userId, userName, projectRoles, instanceAdmin) {
   const user = {
     userId,
     userName,
     projectRoles,
   };
+  if (instanceAdmin) {
+    user.instanceAdmin = true;
+  }
   return UserRoles().create(user);
 }
 

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -179,4 +179,4 @@ async function userIsMember(userId, projectKey) {
   return UserRoles().exists(query);
 }
 
-export default { combineRoles, getRoles, getUser, getUsers, getAllUsersAndRoles, getProjectUsers, setInstanceAdmin, setCatalogueRole, addRole, removeRole, userIsMember };
+export default { combineRoles, getRoles, addRecordForNewUser, getUser, getUsers, getAllUsersAndRoles, getProjectUsers, setInstanceAdmin, setCatalogueRole, addRole, removeRole, userIsMember };

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -1,6 +1,7 @@
 import { permissionTypes } from 'common';
 import findIndex from 'lodash/findIndex';
 import remove from 'lodash/remove';
+import logger from 'winston';
 import database from '../config/database';
 
 const { INSTANCE_ADMIN_ROLE_KEY, CATALOGUE_ROLE_KEY, CATALOGUE_USER_ROLE } = permissionTypes;
@@ -104,6 +105,7 @@ async function addRecordForNewUser(userId, userName) {
   };
   if (allRoles.length === 0) {
     // Make the first ever user an instanceAdmin.
+    logger.info(`${userName} is first user, so making instanceAdmin`);
     user.instanceAdmin = true;
   }
   const roles = await UserRoles().create(user);

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -2,46 +2,49 @@ import userRoleRepository from './userRolesRepository';
 import database from '../config/database';
 import databaseMock from './testUtil/databaseMock';
 
-const wrapDocument = document => ({
-  ...document,
-  toObject: () => document,
-});
+const user1 = {
+  userId: 'uid1',
+  userName: 'user1',
+  instanceAdmin: false,
+  projectRoles: [
+    { projectKey: 'project 1', role: 'admin' },
+    { projectKey: 'project 2', role: 'user' },
+  ],
+};
 
-const testUserRoles = () => [
-  {
-    userId: 'uid1',
-    userName: 'user1',
-    instanceAdmin: false,
-    projectRoles: [
-      { projectKey: 'project 1', role: 'admin' },
-      { projectKey: 'project 2', role: 'user' },
-    ],
-  },
-  {
-    userId: 'uid2',
-    userName: 'user2',
-    instanceAdmin: true,
-    catalogueRole: 'publisher',
-    projectRoles: [
-      { projectKey: 'project 2', role: 'viewer' },
-    ],
-  },
-  {
-    // duplicate user
-    userId: 'uid2',
-    userName: 'user2',
-    projectRoles: [
-      { projectKey: 'project 3', role: 'admin' },
-    ],
-  },
-  {
-    // user without identity
-    userId: 'uid?',
-    projectRoles: [
-      { projectKey: 'project 2', role: 'viewer' },
-    ],
-  },
-];
+const user2 = {
+  userId: 'uid2',
+  userName: 'user2',
+  instanceAdmin: true,
+  catalogueRole: 'publisher',
+  projectRoles: [
+    { projectKey: 'project 2', role: 'viewer' },
+  ],
+};
+
+const duplicateUser2 = {
+  userId: 'uid2',
+  userName: 'user2',
+  projectRoles: [
+    { projectKey: 'project 3', role: 'admin' },
+  ],
+};
+
+const userWithoutIdentity = {
+  // user without identity
+  userId: 'uid?',
+  projectRoles: [
+    { projectKey: 'project 2', role: 'viewer' },
+  ],
+};
+
+const testUserRoles = () => [user1, user2, duplicateUser2, userWithoutIdentity];
+
+const unwrapUser = (user) => {
+  const item = { ...user };
+  delete item.toObject;
+  return item;
+};
 
 let mockDatabase;
 jest.mock('../config/database');
@@ -53,39 +56,34 @@ describe('userRolesRepository', () => {
         { userId: 'uid1', instanceAdmin: true, projectRoles: [{ projectKey: 'project1', role: 'viewer' }] },
         { userId: 'uid1', catalogueRole: 'admin', projectRoles: [{ projectKey: 'project2', role: 'admin' }] },
       )).toEqual(
-        { userId: 'uid1',
+        {
+          userId: 'uid1',
           instanceAdmin: true,
           catalogueRole: 'admin',
           projectRoles: [
             { projectKey: 'project2', role: 'admin' },
             { projectKey: 'project1', role: 'viewer' },
-          ] },
+          ],
+        },
       );
     });
   });
 
   describe('read operations', () => {
     beforeEach(() => {
-      mockDatabase = databaseMock(testUserRoles().map(wrapDocument));
+      mockDatabase = databaseMock(testUserRoles());
       database.getModel = mockDatabase;
       mockDatabase().clear();
     });
 
-    it('getRoles returns expected snapshot', () => userRoleRepository.getRoles('uid1')
-      .then((userRoles) => {
-        expect(mockDatabase().query()).toEqual({
-          userId: 'uid1',
-        });
-        expect(userRoles).toMatchSnapshot();
-      }));
-
-    it('getUser returns expected snapshot', () => userRoleRepository.getUser('uid1')
-      .then((user) => {
-        expect(mockDatabase().query()).toEqual({
-          userId: 'uid1',
-        });
-        expect(user).toMatchSnapshot();
-      }));
+    it('getUser returns expected snapshot', async () => {
+      mockDatabase().setFindOneReturn(user1);
+      const user = await userRoleRepository.getUser('uid1');
+      expect(mockDatabase().query()).toEqual({
+        userId: 'uid1',
+      });
+      expect(user).toMatchSnapshot();
+    });
 
     it('getUsers returns expected snapshot', () => userRoleRepository.getUsers()
       .then((users) => {
@@ -122,6 +120,7 @@ describe('userRolesRepository', () => {
     });
 
     it('should add role to existing user if the user has no role on project', async () => {
+      mockDatabase().setFindOneReturn(user1);
       const addRole = await userRoleRepository.addRole('uid1', 'project', 'admin');
       expect(addRole).toEqual(true);
       expect(mockDatabase()
@@ -130,8 +129,7 @@ describe('userRolesRepository', () => {
           userId: 'uid1',
         });
 
-      expect(mockDatabase()
-        .invocation().entity)
+      expect(unwrapUser(mockDatabase().entity()))
         .toEqual({
           userId: 'uid1',
           userName: 'user1',
@@ -145,13 +143,14 @@ describe('userRolesRepository', () => {
     });
 
     it('should update role on existing user if the user has role on project', async () => {
+      mockDatabase().setFindOneReturn(user1);
       const addRole = await userRoleRepository.addRole('uid1', 'project 2', 'admin');
       expect(addRole).toEqual(false);
       expect(mockDatabase().query()).toEqual({
         userId: 'uid1',
       });
 
-      expect(mockDatabase().invocation().entity).toEqual({
+      expect(unwrapUser(mockDatabase().entity())).toEqual({
         userId: 'uid1',
         userName: 'user1',
         instanceAdmin: false,
@@ -161,15 +160,78 @@ describe('userRolesRepository', () => {
         ],
       });
     });
+  });
+
+  describe('getRoles', () => {
+    beforeEach(() => {
+      mockDatabase = databaseMock(testUserRoles());
+      database.getModel = mockDatabase;
+      mockDatabase().clear();
+    });
+
+    it('getRoles returns expected user', async () => {
+      // Arrange
+      mockDatabase().setFindOneReturn(user1);
+
+      // Act
+      const userRoles = await userRoleRepository.getRoles('uid1');
+
+      // Assert
+      expect(mockDatabase().invocation()).toEqual({
+        // look for user
+        query: { userId: 'uid1' },
+        entity: undefined,
+        params: undefined,
+      });
+      expect(userRoles).toEqual({
+        // add default roles
+        catalogueRole: 'user',
+        ...user1,
+      });
+    });
 
     it('should add an empty record for a user that does not have one when retrieving roles', async () => {
-      mockDatabase = databaseMock([]);
-      database.getModel = mockDatabase;
-      await userRoleRepository.getRoles('uid999', 'user999');
+      // Act
+      const userRoles = await userRoleRepository.getRoles('uid999', 'user999');
 
-      expect(mockDatabase().invocation().entity).toEqual({
+      // Assert
+      expect(mockDatabase().invocation()).toEqual({
+        // create a user
+        query: undefined,
+        entity: { userId: 'uid999', userName: 'user999', projectRoles: [] },
+        params: undefined,
+      });
+      expect(userRoles).toEqual({
+        // add default roles
         userId: 'uid999',
         userName: 'user999',
+        catalogueRole: 'user',
+        instanceAdmin: false,
+        projectRoles: [],
+      });
+    });
+
+    it('should create an instanceAdmin for the first user', async () => {
+      // Arrange
+      mockDatabase = databaseMock([]);
+      database.getModel = mockDatabase;
+
+      // Act
+      const userRoles = await userRoleRepository.getRoles('uid999', 'user999');
+
+      // Assert
+      expect(mockDatabase().invocation()).toEqual({
+        // create a user
+        query: undefined,
+        entity: { userId: 'uid999', userName: 'user999', projectRoles: [], instanceAdmin: true },
+        params: undefined,
+      });
+      expect(userRoles).toEqual({
+        // add default roles
+        userId: 'uid999',
+        userName: 'user999',
+        catalogueRole: 'user',
+        instanceAdmin: true,
         projectRoles: [],
       });
     });
@@ -183,8 +245,9 @@ describe('userRolesRepository', () => {
     });
 
     it('should delete role from user', async () => {
+      mockDatabase().setFindOneReturn(user1);
       await userRoleRepository.removeRole('uid1', 'project 2');
-      expect(mockDatabase().invocation().entity).toEqual({
+      expect(unwrapUser(mockDatabase().entity())).toEqual({
         userId: 'uid1',
         userName: 'user1',
         instanceAdmin: false,
@@ -211,7 +274,7 @@ describe('userRolesRepository', () => {
 
   describe('setInstanceAdmin', () => {
     beforeEach(() => {
-      mockDatabase = databaseMock(testUserRoles().map(wrapDocument));
+      mockDatabase = databaseMock(testUserRoles());
       database.getModel = mockDatabase;
       mockDatabase().clear();
     });
@@ -224,13 +287,13 @@ describe('userRolesRepository', () => {
 
     it('should set instanceAdmin', async () => {
       await userRoleRepository.setInstanceAdmin('uid1', true);
-      expect(mockDatabase().invocation().entity.instanceAdmin).toEqual(true);
+      expect(mockDatabase().entity().instanceAdmin).toEqual(true);
     });
   });
 
   describe('setCatalogueRole', () => {
     beforeEach(() => {
-      mockDatabase = databaseMock(testUserRoles().map(wrapDocument));
+      mockDatabase = databaseMock(testUserRoles());
       database.getModel = mockDatabase;
       mockDatabase().clear();
     });
@@ -243,7 +306,7 @@ describe('userRolesRepository', () => {
 
     it('should set catalogueRole', async () => {
       await userRoleRepository.setCatalogueRole('uid1', 'user');
-      expect(mockDatabase().invocation().entity.catalogueRole).toEqual('user');
+      expect(mockDatabase().entity().catalogueRole).toEqual('user');
     });
   });
 
@@ -256,7 +319,7 @@ describe('userRolesRepository', () => {
 
     it('should query the database with expected arguments', async () => {
       await userRoleRepository.userIsMember('user_id', 'projectKey');
-      expect(mockDatabase().invocation().query).toEqual({
+      expect(mockDatabase().query()).toEqual({
         'projectRoles.projectKey': {
           $eq: 'projectKey',
         },

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -31,7 +31,6 @@ const duplicateUser2 = {
 };
 
 const userWithoutIdentity = {
-  // user without identity
   userId: 'uid?',
   projectRoles: [
     { projectKey: 'project 2', role: 'viewer' },


### PR DESCRIPTION
* Testability is improved by changes to databaseMock
* The first user is automatically an instanceAdmin
* A check is made to help prevent duplicate users
* Dev team users are still created as part of the development environment, as this creates other users for testing purposes, and the users are granted access to the test project.
* Test instance users are not created anymore, see https://github.com/NERC-CEH/datalab-k8s-manifests/pull/121