### PR TITLE
NERCDL-863 fix: change "600" to 600, i.e. number not string

### DIFF
--- a/architecture/deployment/oidc-deployment-and-configuration.md
+++ b/architecture/deployment/oidc-deployment-and-configuration.md
@@ -66,7 +66,7 @@ of different OIDC providers and associated configuration.
       "scope": "openid profile",
       "authority": "https://example.eu.auth0.com",
       "automaticSilentRenew": true,
-      "accessTokenExpiringNotificationTime": "600",
+      "accessTokenExpiringNotificationTime": 600,
       "filterProtocolClaims": true,
       "loadUserInfo": true,
       "extraQueryParams": {
@@ -95,7 +95,7 @@ of different OIDC providers and associated configuration.
       "scope": "openid profile email",
       "authority": "http://keycloak:8080/auth/realms/DataLabs",
       "automaticSilentRenew": true,
-      "accessTokenExpiringNotificationTime": "600",
+      "accessTokenExpiringNotificationTime": 600,
       "filterProtocolClaims": true,
       "loadUserInfo": true,
       "metadata": {

--- a/code/development-env/config/local/web_auth_config.json
+++ b/code/development-env/config/local/web_auth_config.json
@@ -7,7 +7,7 @@
       "scope": "openid profile",
       "authority": "https://mjbr.eu.auth0.com",
       "automaticSilentRenew": true,
-      "accessTokenExpiringNotificationTime": "600",
+      "accessTokenExpiringNotificationTime": 600,
       "filterProtocolClaims": true,
       "loadUserInfo": true,
       "extraQueryParams": {

--- a/code/development-env/config/local/web_auth_config_keycloak.json
+++ b/code/development-env/config/local/web_auth_config_keycloak.json
@@ -7,7 +7,7 @@
       "scope": "openid profile email",
       "authority": "http://keycloak:8080/auth/realms/DataLabs",
       "automaticSilentRenew": true,
-      "accessTokenExpiringNotificationTime": "600",
+      "accessTokenExpiringNotificationTime": 600,
       "filterProtocolClaims": true,
       "loadUserInfo": true,
       "metadata": {


### PR DESCRIPTION
In validating the configmaps (see https://github.com/NERC-CEH/datalab-k8s-manifests/pull/122), spotted a minor error in the JSON config, corrected here - accessTokenExpiringNotificationTime should be a number not a string.