### PR TITLE
NERCDL-908 add dataManager role

### DIFF
--- a/code/development-env/insomnia/datalabs-apis.yaml
+++ b/code/development-env/insomnia/datalabs-apis.yaml
@@ -1,7 +1,7 @@
 _type: export
 __export_format: 4
-__export_date: 2020-12-07T15:46:57.648Z
-__export_source: insomnia.desktop.app:v2020.4.2
+__export_date: 2021-01-28T09:05:14.704Z
+__export_source: insomnia.desktop.app:v2020.5.2
 resources:
   - _id: req_f69cc29ea22447988e34b96b7312ded1
     parentId: fld_8f24d304923241198bc95c2a94678530
@@ -561,12 +561,12 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
-  - _id: req_fdf512d577e04ab3bc508a587e9b0ff3
+  - _id: req_6522ae5b82a848a6b356ac9afe337e57
     parentId: fld_aedf6e0439314b319e879aec69a4f251
-    modified: 1606841094958
-    created: 1606836653049
-    url: "{{ auth_url  }}/roles/dummy/instanceAdmin"
-    name: Set instanceAdmin
+    modified: 1611823800407
+    created: 1611822830439
+    url: "{{ auth_url  }}/roles/dummy/systemRole"
+    name: Set systemRole
     description: ""
     method: PUT
     body:
@@ -583,38 +583,7 @@ resources:
     authentication:
       token: "{{ internal_token  }}"
       type: bearer
-    metaSortKey: -1567085050753.75
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: req_9a1d915c746c4261a523138578870d25
-    parentId: fld_aedf6e0439314b319e879aec69a4f251
-    modified: 1606841108436
-    created: 1606836877259
-    url: "{{ auth_url  }}/roles/dummy/catalogueRole"
-    name: Set catalogueRole
-    description: ""
-    method: PUT
-    body:
-      mimeType: application/json
-      text: |-
-        {
-        	"catalogueRole": "blah"
-        }
-    parameters: []
-    headers:
-      - id: pair_f5281c8ea2a943e8938927aaf4b42734
-        name: Content-Type
-        value: application/json
-    authentication:
-      token: "{{ internal_token  }}"
-      type: bearer
-    metaSortKey: -1566995492864.875
+    metaSortKey: -1567062661281.5312
     isPrivate: false
     settingStoreCookies: true
     settingSendCookies: true
@@ -693,7 +662,7 @@ resources:
     _type: request
   - _id: req_fd40b641d5de46da8cfa9eab9968c4f5
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1576247929346
+    modified: 1611744419404
     created: 1568024223786
     url: "{{ client_api_url  }}/api"
     name: Stacks
@@ -1140,7 +1109,7 @@ resources:
     _type: request
   - _id: req_ac4015a6432b46a9bba80a0f5e200a63
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1607353213912
+    modified: 1611746821205
     created: 1606145410033
     url: "{{ client_api_url  }}/api"
     name: All users and roles
@@ -1149,7 +1118,7 @@ resources:
     body:
       mimeType: application/graphql
       text: '{"query":"query {\n  allUsersAndRoles
-        {\n    userId,\n    name,\n    instanceAdmin,\n    catalogueRole,\n    projectRoles
+        {\n    userId,\n    name,\n    instanceAdmin,\n    dataManager,\n    catalogueRole,\n    projectRoles
         {\n      projectKey,\n      role\n    }\n  }\n}"}'
     parameters: []
     headers:
@@ -1201,7 +1170,7 @@ resources:
     _type: request
   - _id: req_c742c2e35deb496693c5ccaaef9c4248
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1607355961889
+    modified: 1611824375438
     created: 1606922497352
     url: "{{ client_api_url  }}/api"
     name: Set instanceAdmin
@@ -1228,9 +1197,38 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_57856de0db4946ca892bededff23fed8
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    modified: 1611824373317
+    created: 1611746389202
+    url: "{{ client_api_url  }}/api"
+    name: Set dataManager
+    description: ""
+    method: POST
+    body:
+      mimeType: application/graphql
+      text: '{"query":"mutation {\n  setDataManager(userId:\"dummy\",
+        dataManager:true) {\n    userId,\n    dataManager\n  }\n}"}'
+    parameters: []
+    headers:
+      - id: pair_420491f04c4d4360a1d824ef4dcbf6d8
+        name: Content-Type
+        value: application/json
+    authentication:
+      token: "{{ access_token  }}"
+      type: bearer
+    metaSortKey: 1025
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: req_26dad2999d1a421e8dbfdc7e4dcf0f45
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1607355986944
+    modified: 1611824378438
     created: 1606922876464
     url: "{{ client_api_url  }}/api"
     name: Set catalogueRole

--- a/code/workspaces/auth-service/src/config/routes.js
+++ b/code/workspaces/auth-service/src/config/routes.js
@@ -26,8 +26,7 @@ function configureRoutes(app) {
   app.get('/projects/:projectKey/is-member', dtMW, ew(projectController.isMember));
   app.get('/projects/:projectKey/users', dtMW, projectPermissionChecker(PROJECT_KEY_PROJECTS_READ), ew(projectController.getUserRoles));
   app.put('/projects/:projectKey/users/:userId/roles', dtMW, projectPermissionChecker(PROJECT_KEY_PERMISSIONS_CREATE), addRoleValidator, ew(projectController.addUserRole));
-  app.put('/roles/:userId/instanceAdmin', dtMW, permissionChecker(SYSTEM_INSTANCE_ADMIN), userIdValidator, userManagement.setInstanceAdmin);
-  app.put('/roles/:userId/catalogueRole', dtMW, permissionChecker(SYSTEM_INSTANCE_ADMIN), userIdValidator, userManagement.setCatalogueRole);
+  app.put('/roles/:userId/systemRole', dtMW, permissionChecker(SYSTEM_INSTANCE_ADMIN), userIdValidator, userManagement.setSystemRole);
   app.delete('/projects/:projectKey/users/:userId/role', dtMW, projectPermissionChecker(PROJECT_KEY_PERMISSIONS_DELETE), removeRoleValidator, ew(projectController.removeUserRole));
 }
 

--- a/code/workspaces/auth-service/src/controllers/userManagement.js
+++ b/code/workspaces/auth-service/src/controllers/userManagement.js
@@ -38,27 +38,24 @@ async function getAllUsersAndRoles(req, res) {
   }
 }
 
-async function setInstanceAdmin(req, res) {
+// Note - roleKey must exist in UserRolesSchema in userRoles.model.js
+async function setSystemRole(req, res) {
   const { params: { userId } } = req;
-  const { body: { instanceAdmin } } = req;
-  try {
-    const roles = await userRolesRepository.setInstanceAdmin(userId, instanceAdmin);
-    res.status(200).send(roles);
-  } catch (err) {
-    logger.error(`setInstanceAdmin: ${err.message}`);
-    res.status(500);
+  const systemRoles = req.body;
+  const roleKeys = Object.keys(req.body);
+  if (roleKeys.length !== 1) {
+    logger.error(`setSystemRole: expected one role, found ${roleKeys.length}`);
+    res.status(400);
     res.send({});
+    return;
   }
-}
-
-async function setCatalogueRole(req, res) {
-  const { params: { userId } } = req;
-  const { body: { catalogueRole } } = req;
+  const roleKey = roleKeys[0];
+  const roleValue = systemRoles[roleKey];
   try {
-    const roles = await userRolesRepository.setCatalogueRole(userId, catalogueRole);
+    const roles = await userRolesRepository.setSystemRole(userId, roleKey, roleValue);
     res.status(200).send(roles);
   } catch (err) {
-    logger.error(`setCatalogueRole: ${err.message}`);
+    logger.error(`setSystemRole: ${err.message}`);
     res.status(500);
     res.send({});
   }
@@ -68,4 +65,4 @@ export const userIdValidator = validator([
   check('userId').isAscii(),
 ]);
 
-export default { getUsers, getUser, getAllUsersAndRoles, setInstanceAdmin, setCatalogueRole };
+export default { getUsers, getUser, getAllUsersAndRoles, setSystemRole };

--- a/code/workspaces/auth-service/src/controllers/userManagement.spec.js
+++ b/code/workspaces/auth-service/src/controllers/userManagement.spec.js
@@ -8,13 +8,11 @@ const roles = { ...user, instanceAdmin: true };
 const getUsersMock = jest.fn().mockResolvedValue([user]);
 const getUserMock = jest.fn().mockResolvedValue(user);
 const getAllUsersAndRolesMock = jest.fn().mockResolvedValue([{ ...roles }]);
-const setInstanceAdminMock = jest.fn().mockResolvedValue(roles);
-const setCatalogueRoleMock = jest.fn().mockResolvedValue(roles);
+const setSystemRoleMock = jest.fn().mockResolvedValue(roles);
 userRolesRepository.getUsers = getUsersMock;
 userRolesRepository.getUser = getUserMock;
 userRolesRepository.getAllUsersAndRoles = getAllUsersAndRolesMock;
-userRolesRepository.setInstanceAdmin = setInstanceAdminMock;
-userRolesRepository.setCatalogueRole = setCatalogueRoleMock;
+userRolesRepository.setSystemRole = setSystemRoleMock;
 
 describe('user management controller', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -104,58 +102,49 @@ describe('user management controller', () => {
     });
   });
 
-  describe('setInstanceAdmin', () => {
+  describe('setSystemRole', () => {
     it('should return roles as JSON', async () => {
       // Arrange
       const request = httpMocks.createRequest();
+      request.params = { userId: '123' };
+      request.body = { instanceAdmin: true };
       const response = httpMocks.createResponse();
+      setSystemRoleMock.mockResolvedValue(roles);
 
       // Act
-      await userManagement.setInstanceAdmin(request, response);
+      await userManagement.setSystemRole(request, response);
 
       // Assert
+      expect(setSystemRoleMock).toBeCalledWith('123', 'instanceAdmin', true);
       expect(response.statusCode).toBe(200);
       expect(response._getData()) // eslint-disable-line no-underscore-dangle
         .toEqual(roles);
     });
 
-    it('should return 500 if error', async () => {
+    it('should return 400 if invalid input', async () => {
       // Arrange
-      setInstanceAdminMock.mockRejectedValue('no such catalogue');
       const request = httpMocks.createRequest();
+      request.params = { userId: '123' };
+      request.body = {};
       const response = httpMocks.createResponse();
+      setSystemRoleMock.mockResolvedValue(roles);
 
       // Act
-      await userManagement.setInstanceAdmin(request, response);
+      await userManagement.setSystemRole(request, response);
 
       // Assert
-      expect(response.statusCode).toBe(500);
+      expect(response.statusCode).toBe(400);
     });
-  });
-
-  describe('setCatalogueRole', () => {
-    it('should return roles as JSON', async () => {
-      // Arrange
-      const request = httpMocks.createRequest();
-      const response = httpMocks.createResponse();
-
-      // Act
-      await userManagement.setCatalogueRole(request, response);
-
-      // Assert
-      expect(response.statusCode).toBe(200);
-      expect(response._getData()) // eslint-disable-line no-underscore-dangle
-        .toEqual(roles);
-    });
-
     it('should return 500 if error', async () => {
       // Arrange
-      setCatalogueRoleMock.mockRejectedValue('no such catalogue');
       const request = httpMocks.createRequest();
+      request.params = { userId: '123' };
+      request.body = { instanceAdmin: true };
       const response = httpMocks.createResponse();
+      setSystemRoleMock.mockRejectedValue('no such catalogue');
 
       // Act
-      await userManagement.setCatalogueRole(request, response);
+      await userManagement.setSystemRole(request, response);
 
       // Assert
       expect(response.statusCode).toBe(500);

--- a/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
+++ b/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
@@ -4,6 +4,7 @@ exports[`userRolesRepository read operations getAllUsersAndRoles returns expecte
 Array [
   Object {
     "catalogueRole": "user",
+    "dataManager": false,
     "instanceAdmin": false,
     "projectRoles": Array [
       Object {
@@ -20,6 +21,7 @@ Array [
   },
   Object {
     "catalogueRole": "publisher",
+    "dataManager": true,
     "instanceAdmin": true,
     "projectRoles": Array [
       Object {
@@ -41,6 +43,7 @@ exports[`userRolesRepository read operations getProjectUsers returns expected sn
 Array [
   Object {
     "catalogueRole": "user",
+    "dataManager": false,
     "instanceAdmin": false,
     "projectRoles": Array [
       Object {
@@ -57,6 +60,7 @@ Array [
   },
   Object {
     "catalogueRole": "publisher",
+    "dataManager": true,
     "instanceAdmin": true,
     "projectRoles": Array [
       Object {
@@ -69,6 +73,7 @@ Array [
   },
   Object {
     "catalogueRole": "user",
+    "dataManager": false,
     "instanceAdmin": false,
     "projectRoles": Array [
       Object {
@@ -81,6 +86,7 @@ Array [
   },
   Object {
     "catalogueRole": "user",
+    "dataManager": false,
     "instanceAdmin": false,
     "projectRoles": Array [
       Object {

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -1,11 +1,15 @@
+import { permissionTypes } from 'common';
 import userRoleRepository from './userRolesRepository';
 import database from '../config/database';
 import databaseMock from './testUtil/databaseMock';
+
+const { INSTANCE_ADMIN_ROLE_KEY } = permissionTypes;
 
 const user1 = {
   userId: 'uid1',
   userName: 'user1',
   instanceAdmin: false,
+  dataManager: false,
   projectRoles: [
     { projectKey: 'project 1', role: 'admin' },
     { projectKey: 'project 2', role: 'user' },
@@ -16,6 +20,7 @@ const user2 = {
   userId: 'uid2',
   userName: 'user2',
   instanceAdmin: true,
+  dataManager: true,
   catalogueRole: 'publisher',
   projectRoles: [
     { projectKey: 'project 2', role: 'viewer' },
@@ -133,6 +138,7 @@ describe('userRolesRepository', () => {
           userId: 'uid1',
           userName: 'user1',
           instanceAdmin: false,
+          dataManager: false,
           projectRoles: [
             { projectKey: 'project 1', role: 'admin' },
             { projectKey: 'project 2', role: 'user' },
@@ -153,6 +159,7 @@ describe('userRolesRepository', () => {
         userId: 'uid1',
         userName: 'user1',
         instanceAdmin: false,
+        dataManager: false,
         projectRoles: [
           { projectKey: 'project 1', role: 'admin' },
           { projectKey: 'project 2', role: 'admin' },
@@ -261,6 +268,7 @@ describe('userRolesRepository', () => {
         userName: 'user999',
         catalogueRole: 'user',
         instanceAdmin: false,
+        dataManager: false,
         projectRoles: [],
       });
     });
@@ -286,6 +294,7 @@ describe('userRolesRepository', () => {
         userName: 'user999',
         catalogueRole: 'user',
         instanceAdmin: true,
+        dataManager: false,
         projectRoles: [],
       });
     });
@@ -305,6 +314,7 @@ describe('userRolesRepository', () => {
         userId: 'uid1',
         userName: 'user1',
         instanceAdmin: false,
+        dataManager: false,
         projectRoles: [
           { projectKey: 'project 1', role: 'admin' },
         ],
@@ -326,7 +336,7 @@ describe('userRolesRepository', () => {
     });
   });
 
-  describe('setInstanceAdmin', () => {
+  describe('setSystemRole', () => {
     beforeEach(() => {
       mockDatabase = databaseMock(testUserRoles());
       database.getModel = mockDatabase;
@@ -336,31 +346,12 @@ describe('userRolesRepository', () => {
     it('should reject if the user is not in roles collection', async () => {
       mockDatabase = databaseMock([]);
       database.getModel = mockDatabase;
-      await expect(userRoleRepository.setInstanceAdmin('uid1', false)).rejects.toThrow('Unrecognised user uid1');
+      await expect(userRoleRepository.setSystemRole('uid1', INSTANCE_ADMIN_ROLE_KEY, false)).rejects.toThrow('Unrecognised user uid1');
     });
 
     it('should set instanceAdmin', async () => {
-      await userRoleRepository.setInstanceAdmin('uid1', true);
-      expect(mockDatabase().entity().instanceAdmin).toEqual(true);
-    });
-  });
-
-  describe('setCatalogueRole', () => {
-    beforeEach(() => {
-      mockDatabase = databaseMock(testUserRoles());
-      database.getModel = mockDatabase;
-      mockDatabase().clear();
-    });
-
-    it('should reject if the user is not in roles collection', async () => {
-      mockDatabase = databaseMock([]);
-      database.getModel = mockDatabase;
-      await expect(userRoleRepository.setCatalogueRole('uid1', 'user')).rejects.toThrow('Unrecognised user uid1');
-    });
-
-    it('should set catalogueRole', async () => {
-      await userRoleRepository.setCatalogueRole('uid1', 'user');
-      expect(mockDatabase().entity().catalogueRole).toEqual('user');
+      await userRoleRepository.setSystemRole('uid1', INSTANCE_ADMIN_ROLE_KEY, true);
+      expect(mockDatabase().entity()[INSTANCE_ADMIN_ROLE_KEY]).toEqual(true);
     });
   });
 

--- a/code/workspaces/auth-service/src/models/userRoles.model.js
+++ b/code/workspaces/auth-service/src/models/userRoles.model.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import { permissionTypes } from 'common';
-import { CATALOGUE_ROLE_KEY, INSTANCE_ADMIN_ROLE_KEY } from 'common/src/permissionTypes';
+import { CATALOGUE_ROLE_KEY, INSTANCE_ADMIN_ROLE_KEY, DATA_MANAGER_ROLE_KEY } from 'common/src/permissionTypes';
 
 const { Schema } = mongoose;
 const { CATALOGUE_ROLES, PROJECT_ROLES } = permissionTypes;
@@ -9,6 +9,7 @@ const UserRolesSchema = new Schema({
   userId: String,
   userName: String,
   [INSTANCE_ADMIN_ROLE_KEY]: { type: Boolean, default: false },
+  [DATA_MANAGER_ROLE_KEY]: { type: Boolean, default: false },
   [CATALOGUE_ROLE_KEY]: { type: String, enum: CATALOGUE_ROLES },
   projectRoles: [{
     projectKey: String,

--- a/code/workspaces/client-api/src/dataaccess/usersService.js
+++ b/code/workspaces/client-api/src/dataaccess/usersService.js
@@ -42,14 +42,21 @@ async function isMemberOfProject(projectKey, token) {
 async function setInstanceAdmin(userId, instanceAdmin, token) {
   logger.debug(`Setting instanceAdmin of ${userId} to ${instanceAdmin}`);
   const body = { instanceAdmin };
-  const { data } = await axios.put(`${authServiceUrl}/roles/${userId}/instanceAdmin`, body, generateOptions(token));
+  const { data } = await axios.put(`${authServiceUrl}/roles/${userId}/systemRole`, body, generateOptions(token));
   return { userId, instanceAdmin: data.instanceAdmin };
+}
+
+async function setDataManager(userId, dataManager, token) {
+  logger.debug(`Setting dataManager of ${userId} to ${dataManager}`);
+  const body = { dataManager };
+  const { data } = await axios.put(`${authServiceUrl}/roles/${userId}/systemRole`, body, generateOptions(token));
+  return { userId, dataManager: data.dataManager };
 }
 
 async function setCatalogueRole(userId, catalogueRole, token) {
   logger.debug(`Setting catalogueRole of ${userId} to ${catalogueRole}`);
   const body = { catalogueRole };
-  const { data } = await axios.put(`${authServiceUrl}/roles/${userId}/catalogueRole`, body, generateOptions(token));
+  const { data } = await axios.put(`${authServiceUrl}/roles/${userId}/systemRole`, body, generateOptions(token));
   return { userId, catalogueRole: data.catalogueRole };
 }
 
@@ -59,4 +66,4 @@ const generateOptions = token => ({
   },
 });
 
-export default { getAll, getProjectUsers, getUserName, isMemberOfProject, setInstanceAdmin, setCatalogueRole };
+export default { getAll, getProjectUsers, getUserName, isMemberOfProject, setInstanceAdmin, setDataManager, setCatalogueRole };

--- a/code/workspaces/client-api/src/dataaccess/usersService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/usersService.spec.js
@@ -42,7 +42,7 @@ describe('userService', () => {
     // Arrange
     const userId = 'one';
     const instanceAdmin = true;
-    httpMock.onPut(`${AUTH_URL_BASE}/roles/one/instanceAdmin`)
+    httpMock.onPut(`${AUTH_URL_BASE}/roles/one/systemRole`)
       .reply(200, { instanceAdmin });
 
     // Act
@@ -52,11 +52,25 @@ describe('userService', () => {
     expect(response).toEqual({ userId, instanceAdmin });
   });
 
+  it('setDataManager makes an api request', async () => {
+    // Arrange
+    const userId = 'one';
+    const dataManager = true;
+    httpMock.onPut(`${AUTH_URL_BASE}/roles/one/systemRole`)
+      .reply(200, { dataManager });
+
+    // Act
+    const response = await usersService.setDataManager(userId, dataManager, context.token);
+
+    // Assert
+    expect(response).toEqual({ userId, dataManager });
+  });
+
   it('setCatalogueRole makes an api request', async () => {
     // Arrange
     const userId = 'one';
     const catalogueRole = 'publisher';
-    httpMock.onPut(`${AUTH_URL_BASE}/roles/one/catalogueRole`)
+    httpMock.onPut(`${AUTH_URL_BASE}/roles/one/systemRole`)
       .reply(200, { catalogueRole });
 
     // Act

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -76,6 +76,7 @@ const resolvers = {
     updateProject: (obj, { project }, { user, token }) => projectPermissionWrapper({ projectKey: project.projectKey }, SETTINGS_EDIT, user, () => projectService.updateProject(project, token)),
     deleteProject: (obj, { project: { projectKey } }, { user, token }) => instanceAdminWrapper(user, () => projectService.deleteProject(projectKey, token)),
     setInstanceAdmin: (obj, { userId, instanceAdmin }, { user, token }) => instanceAdminWrapper(user, () => userService.setInstanceAdmin(userId, instanceAdmin, token)),
+    setDataManager: (obj, { userId, dataManager }, { user, token }) => instanceAdminWrapper(user, () => userService.setDataManager(userId, dataManager, token)),
     setCatalogueRole: (obj, { userId, catalogueRole }, { user, token }) => instanceAdminWrapper(user, () => userService.setCatalogueRole(userId, catalogueRole, token)),
   },
 

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -99,6 +99,9 @@ type Mutation {
     # Set instanceAdmin role
     setInstanceAdmin(userId: ID!, instanceAdmin: Boolean!): UserAndRoles!
 
+    # Set dataManager role
+    setDataManager(userId: ID!, dataManager: Boolean!): UserAndRoles!
+
     # Set catalogueRole
     setCatalogueRole(userId: ID!, catalogueRole: CatalogueRole!): UserAndRoles!
 }
@@ -300,7 +303,8 @@ type ProjectPermission {
 
 type UserAndRoles {
     instanceAdmin: Boolean
-    catalogueRole: CatalogueRole,
+    dataManager: Boolean
+    catalogueRole: CatalogueRole
     userId: ID!
     name: String
     projectRoles: [ProjectPermission]

--- a/code/workspaces/common/src/permissionTypes.js
+++ b/code/workspaces/common/src/permissionTypes.js
@@ -27,6 +27,9 @@ const SYSTEM = 'system';
 // key name used for admin role boolean in auth
 const INSTANCE_ADMIN_ROLE_KEY = 'instanceAdmin';
 
+// key name used for data manager role boolean in auth
+const DATA_MANAGER_ROLE_KEY = 'dataManager';
+
 const CATALOGUE_ROLE_KEY = 'catalogueRole';
 const CATALOGUE = 'catalogue';
 const CATALOGUE_ADMIN_ROLE = 'admin';
@@ -35,8 +38,8 @@ const CATALOGUE_EDITOR_ROLE = 'editor';
 const CATALOGUE_USER_ROLE = 'user';
 const CATALOGUE_ROLES = [CATALOGUE_ADMIN_ROLE, CATALOGUE_PUBLISHER_ROLE, CATALOGUE_EDITOR_ROLE, CATALOGUE_USER_ROLE];
 
-const keyDelim = '_';
-const permissionDelim = ':';
+const keyDelimiter = '_';
+const permissionDelimiter = ':';
 
 const elementsPermissionList = {
   READ,
@@ -59,7 +62,7 @@ const elements = {
   PROJECTS,
 };
 
-const PROJECT_KEY = `${PROJECT_NAMESPACE}${permissionDelim}${KEY_TOKEN}`;
+const PROJECT_KEY = `${PROJECT_NAMESPACE}${permissionDelimiter}${KEY_TOKEN}`;
 const projectKeys = {
   PROJECT_KEY,
 };
@@ -67,7 +70,7 @@ const projectKeys = {
 const concatPermissions = (head, tail, char) => `${head}${char}${tail}`;
 
 const makePermissionObj = ([outerKey, outerValue], [innerKey, innerValue]) => ({
-  [concatPermissions(outerKey, innerKey, keyDelim)]: concatPermissions(outerValue, innerValue, permissionDelim),
+  [concatPermissions(outerKey, innerKey, keyDelimiter)]: concatPermissions(outerValue, innerValue, permissionDelimiter),
 });
 
 const flatMapPermissions = (outer, inner) => Object.entries(outer)
@@ -90,6 +93,7 @@ const { SYSTEM_INSTANCE_ADMIN } = systemPermissions;
 
 export {
   INSTANCE_ADMIN_ROLE_KEY,
+  DATA_MANAGER_ROLE_KEY,
   SYSTEM_INSTANCE_ADMIN,
   PROJECT_ROLES_KEY,
   CATALOGUE_ROLE_KEY,
@@ -110,6 +114,6 @@ export {
   usersPermissions,
   projectPermissions,
   systemPermissions,
-  permissionDelim as delimiter,
+  permissionDelimiter as delimiter,
   projectKeyPermission,
 };

--- a/code/workspaces/web-app/src/actions/roleActions.js
+++ b/code/workspaces/web-app/src/actions/roleActions.js
@@ -2,6 +2,7 @@ import rolesService from '../api/rolesService';
 
 export const GET_ALL_USERS_AND_ROLES_ACTION = 'GET_ALL_USERS_AND_ROLES_ACTION';
 export const SET_INSTANCE_ADMIN_ACTION = 'SET_INSTANCE_ADMIN_ACTION';
+export const SET_DATA_MANAGER_ACTION = 'SET_DATA_MANAGER_ACTION';
 export const SET_CATALOGUE_ROLE_ACTION = 'SET_CATALOGUE_ROLE_ACTION';
 
 const getAllUsersAndRoles = () => ({
@@ -14,9 +15,14 @@ const setInstanceAdmin = (userId, instanceAdmin) => ({
   payload: rolesService.setInstanceAdmin(userId, instanceAdmin),
 });
 
+const setDataManager = (userId, dataManager) => ({
+  type: SET_DATA_MANAGER_ACTION,
+  payload: rolesService.setDataManager(userId, dataManager),
+});
+
 const setCatalogueRole = (userId, catalogueRole) => ({
   type: SET_CATALOGUE_ROLE_ACTION,
   payload: rolesService.setCatalogueRole(userId, catalogueRole),
 });
 
-export default { getAllUsersAndRoles, setInstanceAdmin, setCatalogueRole };
+export default { getAllUsersAndRoles, setInstanceAdmin, setDataManager, setCatalogueRole };

--- a/code/workspaces/web-app/src/actions/roleActions.spec.js
+++ b/code/workspaces/web-app/src/actions/roleActions.spec.js
@@ -1,5 +1,5 @@
 import roleActions, {
-  GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_CATALOGUE_ROLE_ACTION,
+  GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_DATA_MANAGER_ACTION, SET_CATALOGUE_ROLE_ACTION,
 } from './roleActions';
 import rolesService from '../api/rolesService';
 
@@ -35,6 +35,20 @@ describe('roleActions', () => {
       expect(setInstanceAdminMock).toHaveBeenCalledWith('one', false);
       expect(output.type).toBe(SET_INSTANCE_ADMIN_ACTION);
       expect(output.payload).toBe('expectedSetInstanceAdminPayload');
+    });
+
+    it('setDataManager', () => {
+      // Arrange
+      const setDataManagerMock = jest.fn().mockReturnValue('expectedSetDataManagerPayload');
+      rolesService.setDataManager = setDataManagerMock;
+
+      // Act
+      const output = roleActions.setDataManager('one', false);
+
+      // Assert
+      expect(setDataManagerMock).toHaveBeenCalledWith('one', false);
+      expect(output.type).toBe(SET_DATA_MANAGER_ACTION);
+      expect(output.payload).toBe('expectedSetDataManagerPayload');
     });
 
     it('setCatalogueRole', () => {

--- a/code/workspaces/web-app/src/api/__snapshots__/rolesService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/rolesService.spec.js.snap
@@ -3,10 +3,11 @@
 exports[`rolesService getAllUsersAndRoles should build the correct query and unpack the results 1`] = `
 "
     GetAllUsersAndRoles {
-      allUsersAndRoles {
+      allUsersAndRoles { 
         userId,
         name,
         instanceAdmin,
+        dataManager,
         catalogueRole,
         projectRoles {
           projectKey,
@@ -22,6 +23,16 @@ exports[`rolesService setCatalogueRole should build the correct query and unpack
       setCatalogueRole(userId: $userId, catalogueRole: $catalogueRole) {
         userId,
         catalogueRole
+      }
+    }"
+`;
+
+exports[`rolesService setDataManager should build the correct query and unpack the results 1`] = `
+"
+    SetDataManager($userId: ID!, $dataManager: Boolean!) {
+      setDataManager(userId: $userId, dataManager: $dataManager) {
+        userId,
+        dataManager
       }
     }"
 `;

--- a/code/workspaces/web-app/src/api/rolesService.js
+++ b/code/workspaces/web-app/src/api/rolesService.js
@@ -4,10 +4,11 @@ import errorHandler from './graphqlErrorHandler';
 async function getAllUsersAndRoles() {
   const query = `
     GetAllUsersAndRoles {
-      allUsersAndRoles {
+      allUsersAndRoles { 
         userId,
         name,
         instanceAdmin,
+        dataManager,
         catalogueRole,
         projectRoles {
           projectKey,
@@ -35,6 +36,20 @@ async function setInstanceAdmin(userId, instanceAdmin) {
   return newInstanceAdmin;
 }
 
+async function setDataManager(userId, dataManager) {
+  const mutation = `
+    SetDataManager($userId: ID!, $dataManager: Boolean!) {
+      setDataManager(userId: $userId, dataManager: $dataManager) {
+        userId,
+        dataManager
+      }
+    }`;
+
+  const newDataManager = await gqlMutation(mutation, { userId, dataManager })
+    .then(errorHandler('data.setDataManager'));
+  return newDataManager;
+}
+
 async function setCatalogueRole(userId, catalogueRole) {
   const mutation = `
     SetCatalogueRole($userId: ID!, $catalogueRole: CatalogueRole!) {
@@ -49,4 +64,4 @@ async function setCatalogueRole(userId, catalogueRole) {
   return newCatalogueRole;
 }
 
-export default { getAllUsersAndRoles, setInstanceAdmin, setCatalogueRole };
+export default { getAllUsersAndRoles, setInstanceAdmin, setDataManager, setCatalogueRole };

--- a/code/workspaces/web-app/src/api/rolesService.spec.js
+++ b/code/workspaces/web-app/src/api/rolesService.spec.js
@@ -44,6 +44,25 @@ describe('rolesService', () => {
     });
   });
 
+  describe('setDataManager', () => {
+    it('should build the correct query and unpack the results', () => {
+      mockClient.prepareSuccess({ setDataManager: 'expectedValue' });
+
+      return rolesService.setDataManager('one', true).then((response) => {
+        expect(response).toEqual('expectedValue');
+        expect(mockClient.lastQuery()).toMatchSnapshot();
+      });
+    });
+
+    it('should throw an error if the query fails', () => {
+      mockClient.prepareFailure('error');
+
+      return rolesService.setDataManager('one', true).catch((error) => {
+        expect(error).toEqual({ error: 'error' });
+      });
+    });
+  });
+
   describe('setCatalogueRole', () => {
     it('should build the correct query and unpack the results', () => {
       mockClient.prepareSuccess({ setCatalogueRole: 'expectedValue' });

--- a/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.js
@@ -56,6 +56,7 @@ function AdminUsersContainer() {
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [filters, setFilters] = useState({
     instanceAdmin: false,
+    dataManager: false,
     catalogueAdmin: false,
     cataloguePublisher: false,
     catalogueEditor: false,
@@ -119,6 +120,7 @@ function AdminUsersContainer() {
         >
           <div className={classes.filterColumn}>
             <FilterCheckBox label="Instance admin" checked={filters.instanceAdmin} name="instanceAdmin" />
+            <FilterCheckBox label="Data manager" checked={filters.dataManager} name="dataManager" />
           </div>
           {catalogueAvailable.value && <div className={classes.filterColumn}>
             <FilterCheckBox label="Catalogue admin" checked={filters.catalogueAdmin} name="catalogueAdmin" />

--- a/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/AdminUsersContainer.spec.js
@@ -28,8 +28,8 @@ const users = [
   user2,
 ];
 const roles = [
-  { ...user1, instanceAdmin: true, catalogueRole: 'admin' },
-  { ...user2, instanceAdmin: false, catalogueRole: 'user' },
+  { ...user1, instanceAdmin: true, dataManager: true, catalogueRole: 'admin' },
+  { ...user2, instanceAdmin: false, dataManager: false, catalogueRole: 'user' },
 ];
 
 useDispatch.mockReturnValue(jest.fn().mockName('dispatch'));

--- a/code/workspaces/web-app/src/containers/adminListUsers/UserResources.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/UserResources.js
@@ -75,7 +75,15 @@ export default function UserResources({ user, filters, roles }) {
     </div>];
 
   const handleSystemCheckbox = (event) => {
-    dispatch(roleActions.setInstanceAdmin(user.userId, event.target.checked));
+    switch (event.target.name) {
+      case 'instanceAdmin':
+        dispatch(roleActions.setInstanceAdmin(user.userId, event.target.checked));
+        break;
+      case 'dataManager':
+        dispatch(roleActions.setDataManager(user.userId, event.target.checked));
+        break;
+      default:
+    }
   };
 
   const handleSystemSelect = (event) => {
@@ -116,6 +124,7 @@ export default function UserResources({ user, filters, roles }) {
             <div className={classes.systemRoles}>
               <PromisedContentSkeletonWrapper promises={catalogueAvailable} skeletonComponent={GridSkeleton} skeletonProps={{ rows: 1, columns: 2 }}>
                 <SystemCheckbox label="Instance admin" checked={roles.instanceAdmin} name="instanceAdmin" disabled={user.userId === currentUserId} />
+                <SystemCheckbox label="Data manager" checked={roles.dataManager} name="dataManager" />
                 {catalogueAvailable.value && <SystemSelect itemPrefix="Catalogue" current={roles.catalogueRole} items={CATALOGUE_ROLES} name="catalogue" />}
               </PromisedContentSkeletonWrapper>
             </div>

--- a/code/workspaces/web-app/src/containers/adminListUsers/UserResources.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/UserResources.spec.js
@@ -22,6 +22,7 @@ describe('UserResources', () => {
   const shallowRender = () => {
     const filters = {
       instanceAdmin: false,
+      dataManager: false,
       projectAdmin: false,
       projectUser: false,
       projectViewer: false,
@@ -31,6 +32,7 @@ describe('UserResources', () => {
     };
     const roles = {
       instanceAdmin: true,
+      dataManager: true,
       projectAdmin: [projectKey],
       projectUser: [projectKey],
       projectViewer: [projectKey],

--- a/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/AdminUsersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/AdminUsersContainer.spec.js.snap
@@ -44,6 +44,11 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
           label="Instance admin"
           name="instanceAdmin"
         />
+        <FilterCheckBox
+          checked={false}
+          label="Data manager"
+          name="dataManager"
+        />
       </div>
       <div
         className="makeStyles-filterColumn-2"
@@ -95,12 +100,14 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
             "value": Array [
               Object {
                 "catalogueRole": "admin",
+                "dataManager": true,
                 "instanceAdmin": true,
                 "name": "Test User 1",
                 "userId": "user1",
               },
               Object {
                 "catalogueRole": "user",
+                "dataManager": false,
                 "instanceAdmin": false,
                 "name": "Test User 2",
                 "userId": "user2",
@@ -123,6 +130,7 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
                   "catalogueAdmin": false,
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": false,
                   "projectAdmin": false,
@@ -138,6 +146,7 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
                   "catalogueRole": "admin",
+                  "dataManager": true,
                   "instanceAdmin": true,
                   "notebookOwner": Array [],
                   "projectAdmin": Array [],
@@ -160,6 +169,7 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
                   "catalogueAdmin": false,
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": false,
                   "projectAdmin": false,
@@ -175,6 +185,7 @@ exports[`AdminUsersContainer does not render catalogue permission filters when t
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
                   "catalogueRole": "user",
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": Array [],
                   "projectAdmin": Array [],
@@ -244,6 +255,11 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
           checked={false}
           label="Instance admin"
           name="instanceAdmin"
+        />
+        <FilterCheckBox
+          checked={false}
+          label="Data manager"
+          name="dataManager"
         />
       </div>
       <div
@@ -315,12 +331,14 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
             "value": Array [
               Object {
                 "catalogueRole": "admin",
+                "dataManager": true,
                 "instanceAdmin": true,
                 "name": "Test User 1",
                 "userId": "user1",
               },
               Object {
                 "catalogueRole": "user",
+                "dataManager": false,
                 "instanceAdmin": false,
                 "name": "Test User 2",
                 "userId": "user2",
@@ -343,6 +361,7 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
                   "catalogueAdmin": false,
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": false,
                   "projectAdmin": false,
@@ -358,6 +377,7 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
                   "catalogueRole": "admin",
+                  "dataManager": true,
                   "instanceAdmin": true,
                   "notebookOwner": Array [],
                   "projectAdmin": Array [],
@@ -380,6 +400,7 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
                   "catalogueAdmin": false,
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": false,
                   "projectAdmin": false,
@@ -395,6 +416,7 @@ exports[`AdminUsersContainer renders correctly passing correct props to children
                   "catalogueEditor": false,
                   "cataloguePublisher": false,
                   "catalogueRole": "user",
+                  "dataManager": false,
                   "instanceAdmin": false,
                   "notebookOwner": Array [],
                   "projectAdmin": Array [],

--- a/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminListUsers/__snapshots__/UserResources.spec.js.snap
@@ -52,6 +52,11 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               label="Instance admin"
               name="instanceAdmin"
             />
+            <SystemCheckbox
+              checked={true}
+              label="Data manager"
+              name="dataManager"
+            />
             <SystemSelect
               itemPrefix="Catalogue"
               items={
@@ -72,6 +77,7 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               <mockConstructor
                 filters={
                   Object {
+                    "dataManager": false,
                     "instanceAdmin": false,
                     "notebookOwner": false,
                     "projectAdmin": false,
@@ -84,6 +90,7 @@ exports[`UserResources renders to match snapshot passing correct props to childr
                 projectKey="proj-1234"
                 roles={
                   Object {
+                    "dataManager": true,
                     "instanceAdmin": true,
                     "notebookOwner": Array [
                       Object {
@@ -179,6 +186,11 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               label="Instance admin"
               name="instanceAdmin"
             />
+            <SystemCheckbox
+              checked={true}
+              label="Data manager"
+              name="dataManager"
+            />
           </PromisedContentSkeletonWrapper>
         </div>
         <Pagination
@@ -187,6 +199,7 @@ exports[`UserResources renders to match snapshot passing correct props to childr
               <mockConstructor
                 filters={
                   Object {
+                    "dataManager": false,
                     "instanceAdmin": false,
                     "notebookOwner": false,
                     "projectAdmin": false,
@@ -199,6 +212,7 @@ exports[`UserResources renders to match snapshot passing correct props to childr
                 projectKey="proj-1234"
                 roles={
                   Object {
+                    "dataManager": true,
                     "instanceAdmin": true,
                     "notebookOwner": Array [
                       Object {

--- a/code/workspaces/web-app/src/containers/adminListUsers/createUserRoles.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/createUserRoles.js
@@ -1,7 +1,7 @@
 import { NOTEBOOK_CATEGORY, SITE_CATEGORY } from 'common/src/config/images';
 import { permissionTypes } from 'common';
 
-const { INSTANCE_ADMIN_ROLE_KEY, CATALOGUE_ROLE_KEY, CATALOGUE_ADMIN_ROLE, CATALOGUE_PUBLISHER_ROLE, CATALOGUE_EDITOR_ROLE,
+const { INSTANCE_ADMIN_ROLE_KEY, DATA_MANAGER_ROLE_KEY, CATALOGUE_ROLE_KEY, CATALOGUE_ADMIN_ROLE, CATALOGUE_PUBLISHER_ROLE, CATALOGUE_EDITOR_ROLE,
   PROJECT_ADMIN_ROLE, PROJECT_USER_ROLE, PROJECT_VIEWER_ROLE } = permissionTypes;
 
 function filterMapProjectRoleToProjectKeys(projectRoles, role) {
@@ -35,6 +35,7 @@ function createUserRoles(usersProjectRoles, stacksArray, dataStorageArray) {
   usersProjectRoles.value.forEach((userProjectRoles) => {
     userRoles[userProjectRoles.userId] = {
       instanceAdmin: userProjectRoles[INSTANCE_ADMIN_ROLE_KEY],
+      dataManager: userProjectRoles[DATA_MANAGER_ROLE_KEY],
       catalogueRole: userProjectRoles[CATALOGUE_ROLE_KEY],
       catalogueAdmin: userProjectRoles[CATALOGUE_ROLE_KEY] === CATALOGUE_ADMIN_ROLE,
       cataloguePublisher: userProjectRoles[CATALOGUE_ROLE_KEY] === CATALOGUE_PUBLISHER_ROLE,

--- a/code/workspaces/web-app/src/containers/adminListUsers/createUserRoles.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/createUserRoles.spec.js
@@ -29,6 +29,7 @@ describe('createUserRoles', () => {
           userId,
           name: 'user name',
           instanceAdmin: true,
+          dataManager: true,
           catalogueRole: 'admin',
           projectRoles: [{
             projectKey,
@@ -72,6 +73,7 @@ describe('createUserRoles', () => {
     expect(userRoles).toEqual({
       'user-1234': {
         instanceAdmin: true,
+        dataManager: true,
         catalogueRole: 'admin',
         catalogueAdmin: true,
         cataloguePublisher: false,

--- a/code/workspaces/web-app/src/containers/adminListUsers/filterUserByRoles.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/filterUserByRoles.js
@@ -10,6 +10,7 @@ function filterUserByRoles(userId, filters, otherUserRoles) {
 
   // see if we match a filter
   if (filters.instanceAdmin && roles.instanceAdmin) { return true; }
+  if (filters.dataManager && roles.dataManager) { return true; }
   if (filters.catalogueAdmin && roles.catalogueAdmin) { return true; }
   if (filters.cataloguePublisher && roles.cataloguePublisher) { return true; }
   if (filters.catalogueEditor && roles.catalogueEditor) { return true; }

--- a/code/workspaces/web-app/src/containers/adminListUsers/filterUserByRoles.spec.js
+++ b/code/workspaces/web-app/src/containers/adminListUsers/filterUserByRoles.spec.js
@@ -32,6 +32,15 @@ describe('filterUserByRoles', () => {
     expect(filterUserByRoles(userId, filters, otherUserRoles)).toEqual(true);
   });
 
+  it('shows user if match dataManager filter', () => {
+    // Arrange
+    const filters = { dataManager: true };
+    const otherUserRoles = { [userId]: { dataManager: true } };
+
+    // Act/Assert
+    expect(filterUserByRoles(userId, filters, otherUserRoles)).toEqual(true);
+  });
+
   it('shows user if match catalogueAdmin filter', () => {
     // Arrange
     const filters = { catalogueAdmin: true };

--- a/code/workspaces/web-app/src/reducers/rolesReducer.js
+++ b/code/workspaces/web-app/src/reducers/rolesReducer.js
@@ -1,10 +1,13 @@
 import typeToReducer from 'type-to-reducer';
+import { permissionTypes } from 'common';
 import {
   PROMISE_TYPE_PENDING,
   PROMISE_TYPE_SUCCESS,
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
-import { GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_CATALOGUE_ROLE_ACTION } from '../actions/roleActions';
+import { GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_DATA_MANAGER_ACTION, SET_CATALOGUE_ROLE_ACTION } from '../actions/roleActions';
+
+const { INSTANCE_ADMIN_ROLE_KEY, DATA_MANAGER_ROLE_KEY, CATALOGUE_ROLE_KEY } = permissionTypes;
 
 const initialState = {
   fetching: false,
@@ -13,19 +16,11 @@ const initialState = {
   error: null,
 };
 
-export function updateInstanceAdmin(value, { userId, instanceAdmin }) {
+export function setSystemRole(value, roleKey, payload) {
+  const { userId } = payload;
+  const roleValue = payload[roleKey];
   const matchingUsers = value.filter(item => item.userId === userId);
-  const updatedUser = matchingUsers.length > 0 ? { ...matchingUsers[0], instanceAdmin } : { userId, instanceAdmin };
-  const users = [
-    ...value.filter(item => item.userId !== userId), // other users
-    updatedUser,
-  ];
-  return users;
-}
-
-export function updateCatalogueRole(value, { userId, catalogueRole }) {
-  const matchingUsers = value.filter(item => item.userId === userId);
-  const updatedUser = matchingUsers.length > 0 ? { ...matchingUsers[0], catalogueRole } : { userId, catalogueRole };
+  const updatedUser = matchingUsers.length > 0 ? { ...matchingUsers[0], [roleKey]: roleValue } : { userId, [roleKey]: roleValue };
   const users = [
     ...value.filter(item => item.userId !== userId), // other users
     updatedUser,
@@ -42,11 +37,16 @@ export default typeToReducer({
   [SET_INSTANCE_ADMIN_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, updating: true, value: state.value }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: state.value }),
-    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: updateInstanceAdmin(state.value, action.payload) }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: setSystemRole(state.value, INSTANCE_ADMIN_ROLE_KEY, action.payload) }),
+  },
+  [SET_DATA_MANAGER_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, updating: true, value: state.value }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: state.value }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: setSystemRole(state.value, DATA_MANAGER_ROLE_KEY, action.payload) }),
   },
   [SET_CATALOGUE_ROLE_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, updating: true, value: state.value }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: state.value }),
-    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: updateCatalogueRole(state.value, action.payload) }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: setSystemRole(state.value, CATALOGUE_ROLE_KEY, action.payload) }),
   },
 }, initialState);

--- a/code/workspaces/web-app/src/reducers/rolesReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/rolesReducer.spec.js
@@ -1,6 +1,9 @@
-import rolesReducer, { updateInstanceAdmin, updateCatalogueRole } from './rolesReducer';
+import { permissionTypes } from 'common';
+import rolesReducer, { setSystemRole } from './rolesReducer';
 import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
-import { GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_CATALOGUE_ROLE_ACTION } from '../actions/roleActions';
+import { GET_ALL_USERS_AND_ROLES_ACTION, SET_INSTANCE_ADMIN_ACTION, SET_DATA_MANAGER_ACTION, SET_CATALOGUE_ROLE_ACTION } from '../actions/roleActions';
+
+const { INSTANCE_ADMIN_ROLE_KEY } = permissionTypes;
 
 describe('rolesReducer', () => {
   it('should return the initial state', () => {
@@ -20,10 +23,10 @@ describe('rolesReducer', () => {
       const action = { type };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: true, updating: false, value: [] });
+      expect(nextState).toEqual({ error: null, fetching: true, updating: false, value: [] });
     });
 
     it('should handle GET_ALL_USERS_AND_ROLES_ACTION_SUCCESS', () => {
@@ -33,10 +36,10 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: true, updating: false, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: true, updating: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: action.payload });
+      expect(nextState).toEqual({ error: null, fetching: false, updating: false, value: action.payload });
     });
 
     it('should handle GET_ALL_USERS_AND_ROLES_ACTION_FAILURE', () => {
@@ -46,10 +49,10 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: true, updating: false, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: true, updating: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+      expect(nextState).toEqual({ error: payload, fetching: false, updating: false, value: [] });
     });
   });
 
@@ -60,10 +63,10 @@ describe('rolesReducer', () => {
       const action = { type };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, updating: true, value: [] });
+      expect(nextState).toEqual({ error: null, fetching: false, updating: true, value: [] });
     });
 
     it('should handle SET_INSTANCE_ADMIN_ACTION_SUCCESS', () => {
@@ -73,10 +76,10 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: [action.payload] });
+      expect(nextState).toEqual({ error: null, fetching: false, updating: false, value: [action.payload] });
     });
 
     it('should handle SET_INSTANCE_ADMIN_ACTION_FAILURE', () => {
@@ -86,10 +89,50 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+      expect(nextState).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+    });
+  });
+
+  describe('SET_DATA_MANAGER_ACTION', () => {
+    it('should handle SET_DATA_MANAGER_ACTION_PENDING', () => {
+      // Arrange
+      const type = `${SET_DATA_MANAGER_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextState = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
+
+      // Assert
+      expect(nextState).toEqual({ error: null, fetching: false, updating: true, value: [] });
+    });
+
+    it('should handle SET_DATA_MANAGER_ACTION_SUCCESS', () => {
+      // Arrange
+      const type = `${SET_DATA_MANAGER_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = { userId: 'user1', dataManager: true };
+      const action = { type, payload };
+
+      // Act
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+
+      // Assert
+      expect(nextState).toEqual({ error: null, fetching: false, updating: false, value: [action.payload] });
+    });
+
+    it('should handle SET_DATA_MANAGER_ACTION_FAILURE', () => {
+      // Arrange
+      const type = `${SET_DATA_MANAGER_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+
+      // Assert
+      expect(nextState).toEqual({ error: payload, fetching: false, updating: false, value: [] });
     });
   });
 
@@ -100,10 +143,10 @@ describe('rolesReducer', () => {
       const action = { type };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: false, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, updating: true, value: [] });
+      expect(nextState).toEqual({ error: null, fetching: false, updating: true, value: [] });
     });
 
     it('should handle SET_CATALOGUE_ROLE_ACTION_SUCCESS', () => {
@@ -113,10 +156,10 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: null, fetching: false, updating: false, value: [action.payload] });
+      expect(nextState).toEqual({ error: null, fetching: false, updating: false, value: [action.payload] });
     });
 
     it('should handle SET_CATALOGUE_ROLE_ACTION_FAILURE', () => {
@@ -126,38 +169,24 @@ describe('rolesReducer', () => {
       const action = { type, payload };
 
       // Act
-      const nextstate = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
+      const nextState = rolesReducer({ error: null, fetching: false, updating: true, value: [] }, action);
 
       // Assert
-      expect(nextstate).toEqual({ error: payload, fetching: false, updating: false, value: [] });
+      expect(nextState).toEqual({ error: payload, fetching: false, updating: false, value: [] });
     });
   });
 
-  describe('updateInstanceAdmin', () => {
+  describe('setSystemRole', () => {
     it('updates existing user', () => {
       // Arrange
       const value = [{ userId: 'user1', instanceAdmin: 'false', catalogueRole: 'publisher' }];
       const payload = { userId: 'user1', instanceAdmin: 'true' };
 
       // Act
-      const newValue = updateInstanceAdmin(value, payload);
+      const newValue = setSystemRole(value, INSTANCE_ADMIN_ROLE_KEY, payload);
 
       // Assert
       expect(newValue).toEqual([{ userId: 'user1', instanceAdmin: 'true', catalogueRole: 'publisher' }]);
-    });
-  });
-
-  describe('updateCatalogueRole', () => {
-    it('updates existing user', () => {
-      // Arrange
-      const value = [{ userId: 'user1', instanceAdmin: 'false', catalogueRole: 'publisher' }];
-      const payload = { userId: 'user1', catalogueRole: 'editor' };
-
-      // Act
-      const newValue = updateCatalogueRole(value, payload);
-
-      // Assert
-      expect(newValue).toEqual([{ userId: 'user1', instanceAdmin: 'false', catalogueRole: 'editor' }]);
     });
   });
 });


### PR DESCRIPTION
Adds the new dataManager role needed for the central asset repo, and allows management on the admin page.
Rather than having individual auth endpoints for instanceAdmin, dataManager and catalogueRole, there's now just a single endpoint: systemRole.