### PR TITLE
Nercdl 934 list asset repo metadata

### DIFF
--- a/code/development-env/insomnia/datalabs-apis.yaml
+++ b/code/development-env/insomnia/datalabs-apis.yaml
@@ -1,6 +1,6 @@
 _type: export
 __export_format: 4
-__export_date: 2021-02-05T11:43:18.438Z
+__export_date: 2021-02-11T12:10:12.244Z
 __export_source: insomnia.desktop.app:v2020.5.2
 resources:
   - _id: req_f69cc29ea22447988e34b96b7312ded1
@@ -707,7 +707,7 @@ resources:
     _type: request
   - _id: req_fd40b641d5de46da8cfa9eab9968c4f5
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1612525380676
+    modified: 1612539765015
     created: 1568024223786
     url: "{{ client_api_url  }}/api"
     name: Stacks
@@ -1302,7 +1302,7 @@ resources:
     _type: request
   - _id: req_d53d1acb6d8d44d2ae24c2ca4ebde198
     parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
-    modified: 1612525269561
+    modified: 1613045234439
     created: 1612177227190
     url: "{{ _.client_api_url }}/api"
     name: createCentralAssetMetadata
@@ -1313,7 +1313,7 @@ resources:
       text: '{"query":"mutation {\n  createCentralAssetMetadata (metadata:
         {\n    name: \"newAsset\",\n    version: \"0.1.0\",\n    type:
         \"DATA\",\n    owners: [\"owner-id\"],\n    visible:
-        \"PUBLIC\",\n    fileLocation: \"/path/to/file1\"\n  })
+        \"PUBLIC\",\n    fileLocation: \"/path/to/file4\"\n  })
         {\n    assetId\n    name\n    version\n  }\n}"}'
     parameters: []
     headers:
@@ -1332,9 +1332,124 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_7099ece7dd0b432eaf509b917cf1cb92
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    modified: 1613045240745
+    created: 1613039989749
+    url: "{{ _.client_api_url }}/api"
+    name: centralAssets
+    description: ""
+    method: POST
+    body:
+      mimeType: application/graphql
+      text: '{"query":"{\n  centralAssets
+        {\n    assetId\n    name\n    version\n    projects\n    visible\n    registrationDate\n  }\n}\n"}'
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+        id: pair_fb5cad234ec740fb93082a22a157410b
+    authentication:
+      type: bearer
+      token: "{{ _.access_token }}"
+    metaSortKey: 1125
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_71f237bc68554522b9f09071d6a3854e
+    parentId: fld_93c229dfaaf045de8b9e9f7f51c56d41
+    modified: 1613045272327
+    created: 1612539520337
+    url: "{{ _.client_api_url }}/api"
+    name: centralAssetMetadataAvailableToProject
+    description: ""
+    method: POST
+    body:
+      mimeType: application/graphql
+      text: '{"query":"query {\n  centralAssetsAvailableToProject(projectKey:
+        \"project\")
+        {\n    assetId\n    name\n    version\n    projects\n    visible\n    registrationDate\n  }\n}"}'
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+        id: pair_bd504b415b124fe897d4835b18931abe
+    authentication:
+      type: bearer
+      token: "{{ _.access_token }}"
+    metaSortKey: 1150
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_915578952e9843f5835a9d69a7c50481
+    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    modified: 1612955767916
+    created: 1612535281048
+    url: "{{ _.infra_api_url }}/centralAssetRepo/metadata/"
+    name: List Central Asset Metadata
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers: []
+    authentication:
+      type: bearer
+      token: "{{ _.internal_token }}"
+    metaSortKey: -1612535281048
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: fld_13d24c525db74595ba879650f2fb4a60
+    parentId: wrk_19ed8d51a0ec4d659f9962bcf31a741b
+    modified: 1568899594162
+    created: 1568395892632
+    name: Infrastructure
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1567588463167
+    _type: request_group
+  - _id: req_ad644d95a4dd467f842fc58b856ca7f2
+    parentId: fld_13d24c525db74595ba879650f2fb4a60
+    modified: 1613045354019
+    created: 1613045349531
+    url: "{{ _.infra_api_url }}/centralAssetRepo/metadata/project"
+    name: List Central Asset Metadata Available to Project
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers: []
+    authentication:
+      type: bearer
+      token: "{{ _.internal_token }}"
+    metaSortKey: -1612368044205
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: req_3184cef31d3a49c097475deadbb28e6f
     parentId: fld_13d24c525db74595ba879650f2fb4a60
-    modified: 1612525347319
+    modified: 1613045314241
     created: 1612200807362
     url: "{{ _.infra_api_url }}/centralAssetRepo/metadata"
     name: Create Central Asset Metadata
@@ -1344,12 +1459,13 @@ resources:
       mimeType: application/json
       text: |-
         {
-          "name": "Test URL",
-          "version": "0.4.0",
+          "name": "Project DataSet",
+          "version": "0.1.0",
           "type": "DATA",
-          "owners": [],
-          "visible": "PUBLIC",
-          "fileLocation": "file/location"
+          "owners": ["test-owner"],
+          "visible": "BY_PROJECT",
+          "fileLocation": "file/location",
+          "projects": ["project"]
         }
     parameters: []
     headers:

--- a/code/workspaces/client-api/src/auth/permissionChecker.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.js
@@ -1,7 +1,7 @@
 import logger from 'winston';
 import { permissionTypes } from 'common';
 
-const { SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER, delimiter, PROJECT_NAMESPACE } = permissionTypes;
+const { SYSTEM_INSTANCE_ADMIN, delimiter, PROJECT_NAMESPACE } = permissionTypes;
 
 export const permissionWrapper = (permissionSuffix, ...rest) => permissionCheck(
   [

--- a/code/workspaces/client-api/src/auth/permissionChecker.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.js
@@ -48,11 +48,6 @@ export const instanceAdminWrapper = (...rest) => permissionCheck(
   ...rest,
 );
 
-export const dataManagerPermissionWrapper = (...rest) => permissionCheck(
-  [SYSTEM_DATA_MANAGER],
-  ...rest,
-);
-
 function permissionCheck(requiredPermissions, { permissions }, done) {
   const userPermissions = permissions || [];
 

--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
@@ -2,29 +2,35 @@ import axios from 'axios';
 import config from '../config';
 import axiosErrorHandler from '../util/errorHandlers';
 
-const infrastructureApi = config.get('infrastructureApi');
+const infrastructureApi = () => axios.create({
+  baseURL: config.get('infrastructureApi'),
+});
 
 async function createAssetMetadata(metadata, token) {
-  try {
-    const { data } = await axios.post(
-      `${infrastructureApi}/centralAssetRepo/metadata`,
-      metadata,
-      generateOptions(token),
-    );
-    return data;
-  } catch (err) {
-    return axiosErrorHandler('Error creating metadata')(err);
-  }
+  const { data } = await infrastructureApi().post(
+    '/centralAssetRepo/metadata',
+    metadata,
+    generateRequestConfig(token),
+  );
+  return data;
 }
 
-function generateOptions(token) {
+async function listCentralAssetsAvailableToProject(projectKey, token) {
+  const { data } = await infrastructureApi().get(
+    '/centralAssetRepo/metadata',
+    generateRequestConfig(token, { projectKey }),
+  );
+  return data;
+}
+
+function generateRequestConfig(token, params) {
   return {
-    headers: {
-      authorization: token,
-    },
+    headers: { authorization: token },
+    params,
   };
 }
 
 export default {
   createAssetMetadata,
+  listCentralAssetsAvailableToProject,
 };

--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
@@ -38,28 +38,28 @@ function generateRequestConfig(token) {
   };
 }
 
-async function axiosErrorWrapper(callback, ...args) {
+async function axiosErrorWrapper(message, fn, ...args) {
   try {
-    return await callback(...args);
+    return await fn(...args);
   } catch (error) {
-    handleAxiosError(error);
+    return handleAxiosError(message, error);
   }
 }
 
-function handleAxiosError(error) {
+function handleAxiosError(message, error) {
   const { response: { status, data } } = error;
   if (status === 401 || status === 403) {
     throw new ApolloError(data.errors, 'UNAUTHORISED');
   }
-  throw error;
+  axiosErrorHandler(message)(error);
 }
 
-function wrapWithAxiosErrorWrapper(fn) {
-  return (...args) => axiosErrorWrapper(fn, ...args);
+function wrapWithAxiosErrorWrapper(message, fn) {
+  return (...args) => axiosErrorWrapper(message, fn, ...args);
 }
 
 export default {
-  createAssetMetadata: wrapWithAxiosErrorWrapper(createAssetMetadata),
-  listCentralAssets: wrapWithAxiosErrorWrapper(listCentralAssets),
-  listCentralAssetsAvailableToProject: wrapWithAxiosErrorWrapper(listCentralAssetsAvailableToProject),
+  createAssetMetadata: wrapWithAxiosErrorWrapper('Error creating metadata.', createAssetMetadata),
+  listCentralAssets: wrapWithAxiosErrorWrapper('Error listing metadata.', listCentralAssets),
+  listCentralAssetsAvailableToProject: wrapWithAxiosErrorWrapper('Error listing metadata from project.', listCentralAssetsAvailableToProject),
 };

--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
@@ -20,16 +20,16 @@ const metadataResponse = {
   assetId: 'asset-id',
 };
 
+beforeEach(() => {
+  httpMock.reset();
+});
+
+afterAll(() => {
+  httpMock.restore();
+});
+
 describe('createAssetMetadata', () => {
   const { createAssetMetadata } = centralAssetRepoService;
-
-  beforeEach(() => {
-    httpMock.reset();
-  });
-
-  afterAll(() => {
-    httpMock.restore();
-  });
 
   it('calls infrastructure-api to create metadata with correct data and returns result data', async () => {
     httpMock
@@ -43,5 +43,24 @@ describe('createAssetMetadata', () => {
     const [postMock] = httpMock.history.post;
     expect(postMock.data).toEqual(JSON.stringify(metadata));
     expect(postMock.headers.authorization).toEqual(token);
+  });
+});
+
+describe('listCentralAssetsAvailableToProject', () => {
+  const { listCentralAssetsAvailableToProject } = centralAssetRepoService;
+  const projectKey = 'test-project';
+
+  it('calls infrastructure-api to get metadata of assets visible to the provided project', async () => {
+    httpMock
+      .onGet(`${infrastructureApi}/centralAssetRepo/metadata`)
+      .reply(200, [metadataResponse]);
+
+    const returnValue = await listCentralAssetsAvailableToProject(projectKey, token);
+
+    expect(returnValue).toEqual([metadataResponse]);
+    expect(httpMock.history.get.length).toBe(1);
+    const [getMock] = httpMock.history.get;
+    expect(getMock.params).toEqual({ projectKey });
+    expect(getMock.headers.authorization).toEqual(token);
   });
 });

--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
@@ -46,13 +46,30 @@ describe('createAssetMetadata', () => {
   });
 });
 
+describe('listCentralAssets', () => {
+  const { listCentralAssets } = centralAssetRepoService;
+
+  it('calls infrastructure-api to get all metadata assets', async () => {
+    httpMock
+      .onGet(`${infrastructureApi}/centralAssetRepo/metadata`)
+      .reply(200, [metadataResponse]);
+
+    const returnValue = await listCentralAssets(token);
+
+    expect(returnValue).toEqual([metadataResponse]);
+    expect(httpMock.history.get.length).toBe(1);
+    const [getMock] = httpMock.history.get;
+    expect(getMock.headers.authorization).toEqual(token);
+  });
+});
+
 describe('listCentralAssetsAvailableToProject', () => {
   const { listCentralAssetsAvailableToProject } = centralAssetRepoService;
   const projectKey = 'test-project';
 
   it('calls infrastructure-api to get metadata of assets visible to the provided project', async () => {
     httpMock
-      .onGet(`${infrastructureApi}/centralAssetRepo/metadata`)
+      .onGet(`${infrastructureApi}/centralAssetRepo/metadata/${projectKey}`)
       .reply(200, [metadataResponse]);
 
     const returnValue = await listCentralAssetsAvailableToProject(projectKey, token);
@@ -60,7 +77,6 @@ describe('listCentralAssetsAvailableToProject', () => {
     expect(returnValue).toEqual([metadataResponse]);
     expect(httpMock.history.get.length).toBe(1);
     const [getMock] = httpMock.history.get;
-    expect(getMock.params).toEqual({ projectKey });
     expect(getMock.headers.authorization).toEqual(token);
   });
 });

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -45,12 +45,8 @@ const resolvers = {
     project: (obj, args, { token }) => projectService.getProjectByKey(args.projectKey, token),
     checkProjectKeyUniqueness: (obj, { projectKey }, { user, token }) => instanceAdminWrapper(user, () => projectService.isProjectKeyUnique(projectKey, token)),
     logs: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_CREATE, user, () => logsService.getLogsByName(args.projectKey, args.name, token)),
-    centralAssetsAvailableToProject: (obj, { projectKey }, { user, token }) => projectPermissionWrapper(
-      { projectKey },
-      [STACKS_CREATE],
-      user,
-      () => centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token),
-    ),
+    centralAssets: (obj, args, { token }) => centralAssetRepoService.listCentralAssets(token),
+    centralAssetsAvailableToProject: (obj, { projectKey }, { token }) => centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token),
   },
 
   Mutation: {
@@ -82,7 +78,7 @@ const resolvers = {
     createProject: (obj, { project }, { user, token }) => instanceAdminWrapper(user, () => projectService.createProject(project, user, token)),
     updateProject: (obj, { project }, { user, token }) => projectPermissionWrapper({ projectKey: project.projectKey }, SETTINGS_EDIT, user, () => projectService.updateProject(project, token)),
     deleteProject: (obj, { project: { projectKey } }, { user, token }) => instanceAdminWrapper(user, () => projectService.deleteProject(projectKey, token)),
-    createCentralAssetMetadata: (obj, { metadata }, { user, token }) => dataManagerPermissionWrapper(user, () => centralAssetRepoService.createAssetMetadata(metadata, token)),
+    createCentralAssetMetadata: (obj, { metadata }, { token }) => centralAssetRepoService.createAssetMetadata(metadata, token),
     setInstanceAdmin: (obj, { userId, instanceAdmin }, { user, token }) => instanceAdminWrapper(user, () => userService.setInstanceAdmin(userId, instanceAdmin, token)),
     setDataManager: (obj, { userId, dataManager }, { user, token }) => instanceAdminWrapper(user, () => userService.setDataManager(userId, dataManager, token)),
     setCatalogueRole: (obj, { userId, catalogueRole }, { user, token }) => instanceAdminWrapper(user, () => userService.setCatalogueRole(userId, catalogueRole, token)),

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -45,6 +45,12 @@ const resolvers = {
     project: (obj, args, { token }) => projectService.getProjectByKey(args.projectKey, token),
     checkProjectKeyUniqueness: (obj, { projectKey }, { user, token }) => instanceAdminWrapper(user, () => projectService.isProjectKeyUnique(projectKey, token)),
     logs: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_CREATE, user, () => logsService.getLogsByName(args.projectKey, args.name, token)),
+    centralAssetsAvailableToProject: (obj, { projectKey }, { user, token }) => projectPermissionWrapper(
+      { projectKey },
+      [STACKS_CREATE],
+      user,
+      () => centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token),
+    ),
   },
 
   Mutation: {

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -1,7 +1,7 @@
 import { statusTypes, permissionTypes } from 'common';
 import config from '../config';
 import { version } from '../version';
-import { dataManagerPermissionWrapper, instanceAdminWrapper, projectPermissionWrapper } from '../auth/permissionChecker';
+import { instanceAdminWrapper, projectPermissionWrapper } from '../auth/permissionChecker';
 import stackService from '../dataaccess/stackService';
 import datalabRepository from '../dataaccess/datalabRepository';
 import permissionsService from '../dataaccess/userPermissionsService';

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -51,6 +51,10 @@ type Query {
     # Checks project key is unique
     checkProjectKeyUniqueness(projectKey: String!): Boolean
 
+    # Returns all central asset repo metadata items
+    centralAssets: [CentralAssetMetadata]
+
+    # Return all central asset repo metadata items that are available to given project
     centralAssetsAvailableToProject(projectKey: String!): [CentralAssetMetadata]
 }
 

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -50,6 +50,8 @@ type Query {
 
     # Checks project key is unique
     checkProjectKeyUniqueness(projectKey: String!): Boolean
+
+    centralAssetsAvailableToProject(projectKey: String!): [CentralAssetMetadata]
 }
 
 # Root mutation methods for Datalabs.

--- a/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.js
@@ -8,7 +8,9 @@ export function projectPermissionWrapper(permissionSuffix) {
   return (request, response, next) => {
     logger.debug('Auth: checking permissions');
 
-    const requestedProject = get(request, 'params.projectKey') || get(request, 'body.projectKey');
+    const requestedProject = get(request, 'params.projectKey')
+      || get(request, 'body.projectKey')
+      || get(request, 'query.projectKey');
     const grantedPermissions = get(request, 'user.permissions') || [];
 
     if (!requestedProject) {

--- a/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.js
@@ -1,6 +1,9 @@
 import { get } from 'lodash';
 import { permissionTypes } from 'common';
 import logger from '../config/logger';
+import systemPermissionMiddleware from './subPermissionMiddleware/systemPermissionMiddleware';
+import projectPermissionMiddleware from './subPermissionMiddleware/projectPermissionMiddleware';
+import { ensurePermissionGrantedMiddleware, initRequestPermissionInfoStructureMiddleware } from './subPermissionMiddleware/utils';
 
 const { projectKeyPermission, SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER } = permissionTypes;
 
@@ -62,3 +65,34 @@ export function systemAdminPermissionWrapper() {
 export function systemDataManagerPermissionWrapper() {
   return permissionWrapper(SYSTEM_DATA_MANAGER, false);
 }
+
+function permissionMiddleware(...acceptedPermissions) {
+  // Currently instance admin can do everything on system
+  acceptedPermissions.push(SYSTEM_INSTANCE_ADMIN);
+
+  // array of objects containing
+  // getPermissionsHandled: function that takes list of permissions and filters to
+  //    return array of permissions that the middleware will handle
+  // getMiddleware: function that takes list of permissions and returns a middleware
+  //    function configured to check those permissions
+  const permissionMiddlewares = [
+    systemPermissionMiddleware,
+    projectPermissionMiddleware,
+  ];
+
+  return [
+    // Must be first - adds information to the incoming request used by the following middleware
+    initRequestPermissionInfoStructureMiddleware,
+    ...permissionMiddlewares
+      // remove middleware that won't be handling any requests based on the permissions they handle
+      .filter(({ getPermissionsHandled }) => getPermissionsHandled(acceptedPermissions).length > 0)
+      // get middleware configured to check the permissions it can handle
+      .map(
+        ({ getPermissionsHandled, getMiddleware }) => getMiddleware(getPermissionsHandled(acceptedPermissions)),
+      ),
+    // Must be last - ensures that one of the middleware functions has granted permission
+    ensurePermissionGrantedMiddleware,
+  ];
+}
+
+export default permissionMiddleware;

--- a/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
@@ -1,6 +1,13 @@
 import { permissionTypes } from 'common';
 import httpMocks from 'node-mocks-http';
-import { projectPermissionWrapper, systemAdminPermissionWrapper, systemDataManagerPermissionWrapper } from './permissionMiddleware';
+import permissionMiddleware, { projectPermissionWrapper, systemAdminPermissionWrapper, systemDataManagerPermissionWrapper } from './permissionMiddleware';
+import systemPermissionMiddlewareMock from './subPermissionMiddleware/systemPermissionMiddleware';
+import projectPermissionMiddlewareMock from './subPermissionMiddleware/projectPermissionMiddleware';
+import * as permissionMiddlewareUtilsMock from './subPermissionMiddleware/utils';
+
+jest.mock('./subPermissionMiddleware/systemPermissionMiddleware');
+jest.mock('./subPermissionMiddleware/projectPermissionMiddleware');
+jest.mock('./subPermissionMiddleware/utils');
 
 const { projectPermissions: { PROJECT_KEY_STACKS_LIST }, SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER } = permissionTypes;
 
@@ -165,5 +172,51 @@ describe('systemDataManagerPermissionWrapper', () => {
       expect(responseMock._getData()).toMatchSnapshot(); // eslint-disable-line no-underscore-dangle
       expect(nextMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('permissionMiddleware', () => {
+  systemPermissionMiddlewareMock.getPermissionsHandled.mockReturnValue(['system:test:permission']);
+  projectPermissionMiddlewareMock.getPermissionsHandled.mockReturnValue(['project:test:permission']);
+
+  const configuredSystemPermissionMiddleware = jest.fn();
+  const configuredProjectPermissionMiddleware = jest.fn();
+
+  systemPermissionMiddlewareMock.getMiddleware.mockReturnValue(configuredSystemPermissionMiddleware);
+  projectPermissionMiddlewareMock.getMiddleware.mockReturnValue(configuredProjectPermissionMiddleware);
+
+  it('has middleware to initialise the permission infrastructure on the request as first middleware', () => {
+    const middleware = permissionMiddleware();
+    expect(middleware[0]).toBe(permissionMiddlewareUtilsMock.initRequestPermissionInfoStructureMiddleware);
+  });
+
+  it('has middleware to ensure that permission has been granted on the request as the last middleware', () => {
+    const middleware = permissionMiddleware();
+    expect(middleware[middleware.length - 1]).toBe(permissionMiddlewareUtilsMock.ensurePermissionGrantedMiddleware);
+  });
+
+  it('filters middleware that does not handle any of the accepted permissions', () => {
+    projectPermissionMiddlewareMock.getPermissionsHandled.mockReturnValueOnce([]);
+
+    const middleware = permissionMiddleware();
+
+    expect(middleware).toContain(configuredSystemPermissionMiddleware);
+    expect(middleware).not.toContain(configuredProjectPermissionMiddleware);
+  });
+
+  it('calls to find the permissions that the middleware handles out of provided accepted permissions and system admin', () => {
+    const acceptedPermissions = ['test:accepted:permission'];
+    const expectedPermissions = [...acceptedPermissions, SYSTEM_INSTANCE_ADMIN];
+
+    permissionMiddleware(...acceptedPermissions);
+
+    expect(systemPermissionMiddlewareMock.getPermissionsHandled).toHaveBeenCalledWith(expectedPermissions);
+    expect(projectPermissionMiddlewareMock.getPermissionsHandled).toHaveBeenCalledWith(expectedPermissions);
+  });
+
+  it('calls to configure middleware with permissions the middleware handles', () => {
+    permissionMiddleware();
+    expect(systemPermissionMiddlewareMock.getMiddleware).toHaveBeenCalledWith(['system:test:permission']);
+    expect(projectPermissionMiddlewareMock.getMiddleware).toHaveBeenCalledWith(['project:test:permission']);
   });
 });

--- a/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
@@ -52,6 +52,19 @@ describe('projectPermissionWrapper', () => {
         expect(nextMock).toHaveBeenCalledTimes(1);
       });
 
+      it('extracts and uses the projectKey from the params to pass check', () => {
+        const requestMock = httpMocks.createRequest({
+          query: { projectKey: 'testkey' },
+          user: { permissions: userPermissions },
+        });
+        const responseMock = httpMocks.createResponse();
+        const nextMock = jest.fn();
+
+        projectPermissionWrapper(PROJECT_KEY_STACKS_LIST)(requestMock, responseMock, nextMock);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+      });
+
       it('extracts and uses the projectKey from the body to pass check', () => {
         const requestMock = httpMocks.createRequest({
           body: { projectKey: 'testkey' },

--- a/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/permissionMiddleware.spec.js
@@ -1,13 +1,21 @@
 import { permissionTypes } from 'common';
 import httpMocks from 'node-mocks-http';
 import permissionMiddleware, { projectPermissionWrapper, systemAdminPermissionWrapper, systemDataManagerPermissionWrapper } from './permissionMiddleware';
+import * as permissionMiddlewareUtilsMock from './subPermissionMiddleware/utils';
 import systemPermissionMiddlewareMock from './subPermissionMiddleware/systemPermissionMiddleware';
 import projectPermissionMiddlewareMock from './subPermissionMiddleware/projectPermissionMiddleware';
-import * as permissionMiddlewareUtilsMock from './subPermissionMiddleware/utils';
 
-jest.mock('./subPermissionMiddleware/systemPermissionMiddleware');
-jest.mock('./subPermissionMiddleware/projectPermissionMiddleware');
 jest.mock('./subPermissionMiddleware/utils');
+
+// Due to the way jest.mock works, unable to split out anything common between these mocks
+jest.mock('./subPermissionMiddleware/systemPermissionMiddleware', () => ({
+  default: { getPermissionsHandled: jest.fn(), getMiddleware: jest.fn() },
+  __esModule: true,
+}));
+jest.mock('./subPermissionMiddleware/projectPermissionMiddleware', () => ({
+  default: { getPermissionsHandled: jest.fn(), getMiddleware: jest.fn() },
+  __esModule: true,
+}));
 
 const { projectPermissions: { PROJECT_KEY_STACKS_LIST }, SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER } = permissionTypes;
 

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/projectPermissionMiddleware.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/projectPermissionMiddleware.spec.js.snap
@@ -8,6 +8,6 @@ Array [
 
 exports[`getMiddleware returns middleware that keeps permission as not granted, adds error to error array and calls next if user does not have required permission 1`] = `
 Array [
-  "User missing acceptable project permission. Requires one of: projects:testproj:stacks:list.",
+  "User missing acceptable project permission. Requires one of: [projects:testproj:stacks:list].",
 ]
 `;

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/projectPermissionMiddleware.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/projectPermissionMiddleware.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getMiddleware returns middleware that keeps permission as not granted, adds an error to error array and calls next if there is no projectKey in the request 1`] = `
+Array [
+  "'projectKey' must be defined in either URL or request body",
+]
+`;
+
+exports[`getMiddleware returns middleware that keeps permission as not granted, adds error to error array and calls next if user does not have required permission 1`] = `
+Array [
+  "User missing acceptable project permission. Requires one of: projects:testproj:stacks:list.",
+]
+`;

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/systemPermissionMiddleware.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/systemPermissionMiddleware.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getMiddleware returns middleware that keeps permission as not granted, adds error to error array and calls next if user does not have required permission 1`] = `
+Array [
+  "User missing acceptable system permission. Requires one of: system:instance:admin.",
+]
+`;

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/systemPermissionMiddleware.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/systemPermissionMiddleware.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`getMiddleware returns middleware that keeps permission as not granted, adds error to error array and calls next if user does not have required permission 1`] = `
 Array [
-  "User missing acceptable system permission. Requires one of: system:instance:admin.",
+  "User missing acceptable system permission. Requires one of: [system:instance:admin].",
 ]
 `;

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/utils.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/__snapshots__/utils.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`permissionsArrayToString creates a easily human readable string representation of an array of permissions 1`] = `"[project:permission:one, project:permission:two, system:permission:one]"`;

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.js
@@ -1,6 +1,9 @@
 import { get } from 'lodash';
 import { permissionTypes } from 'common';
-import { permissionGranted, addPermissionError, containsPermission, getUserPermissionsFromRequest, grantPermission, exportMiddleware, permissionsMatchingRegExp, logHelper } from './utils';
+import {
+  permissionGranted, addPermissionError, containsPermission, getUserPermissionsFromRequest,
+  grantPermission, exportMiddleware, permissionsMatchingRegExp, logHelper, permissionsArrayToString,
+} from './utils';
 
 const { projectKeyPermission, PROJECT_NAMESPACE } = permissionTypes;
 
@@ -33,7 +36,7 @@ function projectPermissionMiddleware(acceptedPermissions) {
       logHelper.permissionCheckFailed(middlewareName, 'no acceptable permission found.');
       addPermissionError(
         request,
-        `User missing acceptable project permission. Requires one of: ${processedPermissions}.`,
+        `User missing acceptable project permission. Requires one of: ${permissionsArrayToString(processedPermissions)}.`,
       );
     }
 

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.js
@@ -1,0 +1,57 @@
+import { get } from 'lodash';
+import { permissionTypes } from 'common';
+import { permissionGranted, addPermissionError, containsPermission, getUserPermissionsFromRequest, grantPermission, exportMiddleware, permissionsMatchingRegExp, logHelper } from './utils';
+
+const { projectKeyPermission, PROJECT_NAMESPACE } = permissionTypes;
+
+function projectPermissionMiddleware(acceptedPermissions) {
+  const middlewareName = 'projectPermissionMiddleware';
+
+  return (request, response, next) => {
+    if (permissionGranted(request)) {
+      logHelper.alreadyGranted(middlewareName);
+      return next();
+    }
+
+    const projectKey = getProjectKeyFromRequest(request);
+    if (!projectKey) {
+      logHelper.permissionCheckFailed(middlewareName, 'projectKey not defined in request.');
+      addPermissionError(
+        request,
+        "'projectKey' must be defined in either URL or request body",
+      );
+      return next();
+    }
+
+    const processedPermissions = processProjectPermissions(acceptedPermissions, projectKey);
+    const userPermissions = getUserPermissionsFromRequest(request);
+    logHelper.checkingPermission(middlewareName, processedPermissions, userPermissions);
+    if (containsPermission(processedPermissions, userPermissions)) {
+      logHelper.permissionCheckPassed(middlewareName);
+      grantPermission(request);
+    } else {
+      logHelper.permissionCheckFailed(middlewareName, 'no acceptable permission found.');
+      addPermissionError(
+        request,
+        `User missing acceptable project permission. Requires one of: ${processedPermissions}.`,
+      );
+    }
+
+    return next();
+  };
+}
+
+export const getProjectKeyFromRequest = request => get(request, 'params.projectKey')
+  || get(request, 'body.projectKey')
+  || get(request, 'query.projectKey');
+
+const processProjectPermissions = (rawProjectPermissions, projectKey) => (
+  rawProjectPermissions.map(permission => projectKeyPermission(permission, projectKey))
+);
+
+const permissionsHandled = permissions => permissionsMatchingRegExp(permissions, new RegExp(`^${PROJECT_NAMESPACE}`));
+
+export default exportMiddleware(
+  permissionsHandled,
+  projectPermissionMiddleware,
+);

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/projectPermissionMiddleware.spec.js
@@ -1,0 +1,120 @@
+import { permissionTypes } from 'common';
+import projectPermissionMiddleware, { getProjectKeyFromRequest } from './projectPermissionMiddleware';
+import * as utils from './utils';
+
+const {
+  projectPermissions: { PROJECT_KEY_STACKS_CREATE, PROJECT_KEY_STACKS_LIST },
+  SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER,
+  projectKeyPermission,
+} = permissionTypes;
+
+const { getPermissionsHandled, getMiddleware } = projectPermissionMiddleware;
+
+describe('getPermissionsHandled', () => {
+  it('filters out any permissions that are not project permissions', () => {
+    const permissions = [PROJECT_KEY_STACKS_CREATE, PROJECT_KEY_STACKS_LIST, SYSTEM_DATA_MANAGER, SYSTEM_INSTANCE_ADMIN];
+    const returnValue = getPermissionsHandled(permissions);
+    expect(returnValue).toEqual([PROJECT_KEY_STACKS_CREATE, PROJECT_KEY_STACKS_LIST]);
+  });
+});
+
+describe('getMiddleware', () => {
+  const responseMock = jest.fn();
+  const nextMock = jest.fn();
+
+  const initPermissionStructureOnRequest = (requestMock) => {
+    utils.initRequestPermissionInfoStructureMiddleware(requestMock, responseMock, nextMock);
+    nextMock.mockClear(); // clear the call to next in the init structure middleware
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('returns middleware that', () => {
+    it('keeps permission as granted, does not add an error to error array and calls next if permission already granted', () => {
+      const requestMock = {};
+      initPermissionStructureOnRequest(requestMock);
+      utils.grantPermission(requestMock);
+      const middleware = getMiddleware([]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeTruthy();
+      expect(utils.permissionErrors(requestMock)).toEqual([]);
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+
+    it('keeps permission as not granted, adds an error to error array and calls next if there is no projectKey in the request', () => {
+      const requestMock = {};
+      initPermissionStructureOnRequest(requestMock);
+      const middleware = getMiddleware([]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeFalsy();
+      expect(utils.permissionErrors(requestMock)).toMatchSnapshot();
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+
+    it('grants permission, does not add error to error array and calls next if user has permission', () => {
+      const projectKey = 'testproj';
+      const requestMock = {
+        user: { permissions: [projectKeyPermission(PROJECT_KEY_STACKS_LIST, projectKey)] },
+        body: { projectKey },
+      };
+      initPermissionStructureOnRequest(requestMock);
+      const middleware = getMiddleware([PROJECT_KEY_STACKS_LIST]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeTruthy();
+      expect(utils.permissionErrors(requestMock)).toEqual([]);
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+
+    it('keeps permission as not granted, adds error to error array and calls next if user does not have required permission', () => {
+      const requestMock = {
+        user: { permissions: ['unacceptable:permission'] },
+        body: { projectKey: 'testproj' },
+      };
+      initPermissionStructureOnRequest(requestMock);
+      const middleware = getMiddleware([PROJECT_KEY_STACKS_LIST]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeFalsy();
+      expect(utils.permissionErrors(requestMock)).toMatchSnapshot();
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+  });
+});
+
+describe('getProjectKeyFromRequest', () => {
+  it('returns projectKey when provided in request body', () => {
+    const projectKey = 'testproj';
+    const requestMock = { body: { projectKey } };
+    const returnValue = getProjectKeyFromRequest(requestMock);
+    expect(returnValue).toEqual(projectKey);
+  });
+
+  it('returns projectKey when provided in request params', () => {
+    const projectKey = 'testproj';
+    const requestMock = { params: { projectKey } };
+    const returnValue = getProjectKeyFromRequest(requestMock);
+    expect(returnValue).toEqual(projectKey);
+  });
+
+  it('returns projectKey when provided in request query', () => {
+    const projectKey = 'testproj';
+    const requestMock = { query: { projectKey } };
+    const returnValue = getProjectKeyFromRequest(requestMock);
+    expect(returnValue).toEqual(projectKey);
+  });
+
+  it('returns undefined if projectKey not provided in request', () => {
+    const requestMock = {};
+    const returnValue = getProjectKeyFromRequest(requestMock);
+    expect(returnValue).toBeUndefined();
+  });
+});

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.js
@@ -1,0 +1,37 @@
+import { permissionTypes } from 'common';
+import {
+  permissionGranted, getUserPermissionsFromRequest, containsPermission, grantPermission, addPermissionError, logHelper, permissionsMatchingRegExp, exportMiddleware,
+} from './utils';
+
+function systemPermissionMiddleware(acceptedPermissions) {
+  const middlewareName = 'systemPermissionMiddleware';
+
+  return (request, response, next) => {
+    if (permissionGranted(request)) {
+      logHelper.alreadyGranted(middlewareName);
+      return next();
+    }
+
+    const userPermissions = getUserPermissionsFromRequest(request);
+    logHelper.checkingPermission(middlewareName, acceptedPermissions, userPermissions);
+    if (containsPermission(acceptedPermissions, userPermissions)) {
+      logHelper.permissionCheckPassed(middlewareName);
+      grantPermission(request);
+    } else {
+      logHelper.permissionCheckFailed(middlewareName, 'no acceptable permission found.');
+      addPermissionError(
+        request,
+        `User missing acceptable system permission. Requires one of: ${acceptedPermissions}.`,
+      );
+    }
+
+    return next();
+  };
+}
+
+const permissionsHandled = permissions => permissionsMatchingRegExp(permissions, new RegExp(`^${permissionTypes.SYSTEM}`));
+
+export default exportMiddleware(
+  permissionsHandled,
+  systemPermissionMiddleware,
+);

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.js
@@ -1,6 +1,6 @@
 import { permissionTypes } from 'common';
 import {
-  permissionGranted, getUserPermissionsFromRequest, containsPermission, grantPermission, addPermissionError, logHelper, permissionsMatchingRegExp, exportMiddleware,
+  permissionGranted, getUserPermissionsFromRequest, containsPermission, grantPermission, addPermissionError, logHelper, permissionsMatchingRegExp, exportMiddleware, permissionsArrayToString,
 } from './utils';
 
 function systemPermissionMiddleware(acceptedPermissions) {
@@ -21,7 +21,7 @@ function systemPermissionMiddleware(acceptedPermissions) {
       logHelper.permissionCheckFailed(middlewareName, 'no acceptable permission found.');
       addPermissionError(
         request,
-        `User missing acceptable system permission. Requires one of: ${acceptedPermissions}.`,
+        `User missing acceptable system permission. Requires one of: ${permissionsArrayToString(acceptedPermissions)}.`,
       );
     }
 

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/systemPermissionMiddleware.spec.js
@@ -1,0 +1,75 @@
+import { permissionTypes } from 'common';
+import systemPermissionMiddleware from './systemPermissionMiddleware';
+import * as utils from './utils';
+
+const {
+  projectPermissions: { PROJECT_KEY_STACKS_CREATE, PROJECT_KEY_STACKS_LIST },
+  SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER,
+} = permissionTypes;
+
+const { getPermissionsHandled, getMiddleware } = systemPermissionMiddleware;
+
+describe('getPermissionsHandled', () => {
+  it('filters out any permissions that are not system permissions', () => {
+    const permissions = [PROJECT_KEY_STACKS_CREATE, PROJECT_KEY_STACKS_LIST, SYSTEM_DATA_MANAGER, SYSTEM_INSTANCE_ADMIN];
+    const returnValue = getPermissionsHandled(permissions);
+    expect(returnValue).toEqual([SYSTEM_DATA_MANAGER, SYSTEM_INSTANCE_ADMIN]);
+  });
+});
+
+describe('getMiddleware', () => {
+  const responseMock = jest.fn();
+  const nextMock = jest.fn();
+
+  const initPermissionStructureOnRequest = (requestMock) => {
+    utils.initRequestPermissionInfoStructureMiddleware(requestMock, responseMock, nextMock);
+    nextMock.mockClear(); // clear the call to next in the init structure middleware
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('returns middleware that', () => {
+    it('keeps permission as granted, does not add an error to error array and calls next if permission already granted', () => {
+      const requestMock = {};
+      initPermissionStructureOnRequest(requestMock);
+      utils.grantPermission(requestMock);
+      const middleware = getMiddleware([]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeTruthy();
+      expect(utils.permissionErrors(requestMock)).toEqual([]);
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+
+    it('grants permission, does not add error to error array and calls next if user has permission', () => {
+      const requestMock = {
+        user: { permissions: [SYSTEM_INSTANCE_ADMIN] },
+      };
+      initPermissionStructureOnRequest(requestMock);
+      const middleware = getMiddleware([SYSTEM_INSTANCE_ADMIN]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeTruthy();
+      expect(utils.permissionErrors(requestMock)).toEqual([]);
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+
+    it('keeps permission as not granted, adds error to error array and calls next if user does not have required permission', () => {
+      const requestMock = {
+        user: { permissions: ['unacceptable:permission'] },
+      };
+      initPermissionStructureOnRequest(requestMock);
+      const middleware = getMiddleware([SYSTEM_INSTANCE_ADMIN]);
+
+      middleware(requestMock, responseMock, nextMock);
+
+      expect(utils.permissionGranted(requestMock)).toBeFalsy();
+      expect(utils.permissionErrors(requestMock)).toMatchSnapshot();
+      expect(nextMock).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
@@ -47,12 +47,16 @@ export const permissionsMatchingRegExp = (permissions, regexp) => permissions.fi
 
 export const exportMiddleware = (getPermissionsHandled, getMiddleware) => ({ getPermissionsHandled, getMiddleware });
 
+export const permissionsArrayToString = permissions => `[${permissions.join(', ')}]`;
+
 export const logHelper = {
   alreadyGranted: (middlewareName) => {
     logger.debug(`Auth: ${middlewareName}: permission already granted. Skipping check.`);
   },
   checkingPermission: (middlewareName, acceptedPermissions, userPermissions) => {
-    logger.debug(`Auth: ${middlewareName}: checking permissions - accepted permissions: [${acceptedPermissions.join(', ')}] user permissions: [${userPermissions.join(', ')}]`);
+    logger.debug(
+      `Auth: ${middlewareName}: checking permissions - accepted permissions: ${permissionsArrayToString(acceptedPermissions)} user permissions: ${permissionsArrayToString(userPermissions)}`,
+    );
   },
   permissionCheckPassed: (middlewareName) => {
     logger.debug(`Auth: ${middlewareName}: permission check PASSED`);

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
@@ -1,0 +1,66 @@
+import { get } from 'lodash';
+import logger from '../../config/logger';
+
+export const REQUEST_PERMISSION_INFO_KEY = 'datalabs';
+
+export const initRequestPermissionInfoStructureMiddleware = (request, response, next) => {
+  request[REQUEST_PERMISSION_INFO_KEY] = {
+    granted: false,
+    errors: [],
+  };
+  return next();
+};
+
+export const ensurePermissionGrantedMiddleware = (request, response, next) => {
+  if (permissionGranted(request)) {
+    logger.debug('Auth: permission check PASSED');
+    return next();
+  }
+
+  const granted = permissionGranted(request);
+  const errors = permissionErrors(request);
+  logger.warn(`Auth: permission check FAILED with errors: [${errors.join(', ')}]`);
+  return response.status(401).send({ permissionGranted: granted, errors });
+};
+
+export const getRequestPermissionInfo = request => request[REQUEST_PERMISSION_INFO_KEY];
+
+export const permissionGranted = request => getRequestPermissionInfo(request).granted;
+
+export const grantPermission = (request) => {
+  getRequestPermissionInfo(request).granted = true;
+};
+
+export const permissionErrors = request => getRequestPermissionInfo(request).errors;
+
+export const addPermissionError = (request, message) => {
+  getRequestPermissionInfo(request).errors.push(message);
+};
+
+export const containsPermission = (acceptedPermissions, grantedPermissions) => (
+  acceptedPermissions.some(permission => grantedPermissions.includes(permission))
+);
+
+export const getUserPermissionsFromRequest = request => get(request, 'user.permissions') || [];
+
+export const permissionsMatchingRegExp = (permissions, regexp) => permissions.filter(permission => permission.match(regexp));
+
+export const exportMiddleware = (getPermissionsHandled, getMiddleware) => ({ getPermissionsHandled, getMiddleware });
+
+export const logHelper = {
+  alreadyGranted: (middlewareName) => {
+    logger.debug(`Auth: ${middlewareName}: permission already granted. Skipping check.`);
+  },
+  checkingPermission: (middlewareName, acceptedPermissions, userPermissions) => {
+    logger.debug(`Auth: ${middlewareName}: checking permissions - accepted permissions: [${acceptedPermissions.join(', ')}] user permissions: [${userPermissions.join(', ')}]`);
+  },
+  permissionCheckPassed: (middlewareName) => {
+    logger.debug(`Auth: ${middlewareName}: permission check PASSED`);
+  },
+  permissionCheckFailed: (middlewareName, optionalMessage) => {
+    let message = `Auth: ${middlewareName}: permission check FAILED`;
+    if (optionalMessage) message += ` - ${optionalMessage}`;
+    logger.debug(message);
+  },
+};
+

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
@@ -170,3 +170,10 @@ describe('exportMiddleware', () => {
     expect(returnValue.getMiddleware).toBe(middlewareMock);
   });
 });
+
+describe('permissionsArrayToString', () => {
+  it('creates a easily human readable string representation of an array of permissions', () => {
+    const permissions = ['project:permission:one', 'project:permission:two', 'system:permission:one'];
+    expect(utils.permissionsArrayToString(permissions)).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
@@ -1,0 +1,172 @@
+import * as utils from './utils';
+
+const { REQUEST_PERMISSION_INFO_KEY } = utils;
+
+const getConfiguredRequestMock = ({ granted, errors }) => ({
+  [REQUEST_PERMISSION_INFO_KEY]: { granted, errors },
+});
+
+const responseMock = {
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn().mockReturnThis(),
+};
+const nextMock = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('initRequestPermissionInfoStructureMiddleware', () => {
+  it('adds request info permission structure to request and calls next', () => {
+    const requestMock = {};
+
+    utils.initRequestPermissionInfoStructureMiddleware(requestMock, responseMock, nextMock);
+
+    expect(requestMock).toEqual({ [REQUEST_PERMISSION_INFO_KEY]: { granted: false, errors: [] } });
+    expect(nextMock).toHaveBeenCalledWith();
+  });
+});
+
+describe('ensurePermissionGrantedMiddleware', () => {
+  const { ensurePermissionGrantedMiddleware } = utils;
+
+  it('calls next if permission has been granted and response not sent', () => {
+    const requestMock = getConfiguredRequestMock({ granted: true, errors: [] });
+
+    ensurePermissionGrantedMiddleware(requestMock, responseMock, nextMock);
+
+    expect(nextMock).toHaveBeenCalledWith();
+    expect(responseMock.send).not.toHaveBeenCalled();
+  });
+
+  it('returns response configured with 401 status and error message when permission not granted and next not called', () => {
+    const requestMock = getConfiguredRequestMock({ granted: false, errors: ['expected error'] });
+
+    ensurePermissionGrantedMiddleware(requestMock, responseMock, nextMock);
+
+    expect(responseMock.status).toHaveBeenCalledWith(401);
+    expect(responseMock.send).toHaveBeenCalledWith({ permissionGranted: false, errors: ['expected error'] });
+    expect(nextMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRequestPermissionInfo', () => {
+  it('returns the permission information stored on the request', () => {
+    const permissionInfo = { granted: true, errors: [] };
+    const requestMock = getConfiguredRequestMock(permissionInfo);
+    const returnValue = utils.getRequestPermissionInfo(requestMock);
+    expect(returnValue).toEqual(permissionInfo);
+  });
+});
+
+describe('permissionGranted', () => {
+  it('returns the value of granted from the permission info object on the request', () => {
+    const permissionGranted = true;
+    const requestMock = getConfiguredRequestMock({
+      granted: permissionGranted,
+      errors: [],
+    });
+    const returnValue = utils.permissionGranted(requestMock);
+    expect(returnValue).toEqual(permissionGranted);
+  });
+});
+
+describe('grantPermission', () => {
+  it('sets the value of granted to true when the current value is false', () => {
+    const requestMock = getConfiguredRequestMock({ granted: false, errors: [] });
+    utils.grantPermission(requestMock);
+    expect(utils.permissionGranted(requestMock)).toBeTruthy();
+  });
+
+  it('keeps the value of granted as true if it is already set to be true', () => {
+    const requestMock = getConfiguredRequestMock({ granted: true, errors: [] });
+    utils.grantPermission(requestMock);
+    expect(utils.permissionGranted(requestMock)).toBeTruthy();
+  });
+});
+
+describe('permissionErrors', () => {
+  it('returns array of errors from the permission info object on the request', () => {
+    const requestMock = getConfiguredRequestMock({ granted: false, errors: ['expected test error'] });
+    const returnValue = utils.permissionErrors(requestMock);
+    expect(returnValue).toEqual(['expected test error']);
+  });
+});
+
+describe('addPermissionError', () => {
+  it('adds permission error to the array of errors in the permission info object on the request', () => {
+    const requestMock = getConfiguredRequestMock({ granted: false, errors: [] });
+    const errorMessage = 'expected test error';
+    utils.addPermissionError(requestMock, errorMessage);
+    expect(utils.permissionErrors(requestMock)).toEqual([errorMessage]);
+  });
+
+  it('can be used to add more than one error to the errors array', () => {
+    const requestMock = getConfiguredRequestMock({ granted: false, errors: [] });
+    utils.addPermissionError(requestMock, 'error-one');
+    utils.addPermissionError(requestMock, 'error-two');
+    utils.addPermissionError(requestMock, 'error-three');
+    expect(utils.permissionErrors(requestMock)).toEqual(['error-one', 'error-two', 'error-three']);
+  });
+});
+
+describe('containsPermission', () => {
+  const { containsPermission } = utils;
+  const acceptedPermissions = ['accepted-one', 'accepted-two', 'accepted-three'];
+  const grantedPermissions = ['granted-one', 'granted-two', 'granted-three'];
+
+  it('returns true if an item in granted permissions is in the accepted permissions array', () => {
+    const result = containsPermission(acceptedPermissions, [...grantedPermissions, 'accepted-three']);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false if non of the items in granted permissions are in the accepted permissions array', () => {
+    const result = containsPermission(acceptedPermissions, grantedPermissions);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false if the accepted permissions array is empty', () => {
+    const result = containsPermission([], grantedPermissions);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false if the granted permissions array is empty', () => {
+    const result = containsPermission(acceptedPermissions, []);
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('getUserPermissionsFromRequest', () => {
+  it('returns the user permissions from the request when there are permissions', () => {
+    const request = { user: { permissions: ['user-permission-one', 'user-permission-two'] } };
+    const returnValue = utils.getUserPermissionsFromRequest(request);
+    expect(returnValue).toEqual(['user-permission-one', 'user-permission-two']);
+  });
+
+  it('returns an empty array if there are no user-permissions on the request', () => {
+    const request = {};
+    const returnValue = utils.getUserPermissionsFromRequest(request);
+    expect(returnValue).toEqual([]);
+  });
+});
+
+describe('permissionsMatchingRegExp', () => {
+  it('returns array of permissions that match the passed regular expression', () => {
+    const permissions = ['match-one', 'no-match-one', 'match-two', 'no-match-two', 'no-match-three'];
+    const regexp = new RegExp('^match'); // match any permission starting with 'match'
+    const returnValue = utils.permissionsMatchingRegExp(permissions, regexp);
+    expect(returnValue).toEqual(['match-one', 'match-two']);
+  });
+});
+
+describe('exportMiddleware', () => {
+  it('puts provided arguments into object with expected keys', () => {
+    const handledPermissionsMock = jest.fn();
+    const middlewareMock = jest.fn();
+
+    const returnValue = utils.exportMiddleware(handledPermissionsMock, middlewareMock);
+
+    expect(returnValue.getPermissionsHandled).toBe(handledPermissionsMock);
+    expect(returnValue.getMiddleware).toBe(middlewareMock);
+  });
+});

--- a/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
@@ -1,11 +1,10 @@
-import { matchedData, body } from 'express-validator';
+import { matchedData, body, query } from 'express-validator';
 import { service } from 'service-chassis';
 import centralAssetRepoRepository from '../dataaccess/centralAssetRepoRepository';
 import centralAssetRepoModel from '../models/centralAssetRepo.model';
 import logger from '../config/logger';
 import ValidationChainHelper from './utils/validationChainHelper';
 
-// eslint-disable-next-line consistent-return
 async function createAssetMetadata(request, response, next) {
   const metadata = matchedData(request);
 
@@ -16,7 +15,18 @@ async function createAssetMetadata(request, response, next) {
     const createdMetadata = await centralAssetRepoRepository.createMetadata(metadata);
     return response.status(201).send(createdMetadata);
   } catch (error) {
-    next(new Error(`Error creating asset metadata - failed to create new document: ${error.message}`));
+    return next(new Error(`Error creating asset metadata - failed to create new document: ${error.message}`));
+  }
+}
+
+async function assetMetadataAvailableToProject(request, response, next) {
+  const { projectKey } = matchedData(request);
+
+  try {
+    const result = await centralAssetRepoRepository.metadataAvailableToProject(projectKey);
+    return response.status(200).send(result);
+  } catch (error) {
+    return next(new Error(`Error listing asset metadata by key: ${error.message}`));
   }
 }
 
@@ -44,7 +54,7 @@ async function handleExistingMetadata(metadata, response, next) {
   return null;
 }
 
-const getMetadataValidator = () => {
+const metadataValidator = () => {
   const validations = [
     new ValidationChainHelper(body('name'))
       .exists()
@@ -86,7 +96,16 @@ const getMetadataValidator = () => {
   return service.middleware.validator(validationChains, logger);
 };
 
+const listByProjectKeyValidator = () => service.middleware.validator([
+  new ValidationChainHelper(query('projectKey'))
+    .exists()
+    .notEmpty()
+    .getValidationChain(),
+], logger);
+
 export default {
   createAssetMetadata,
-  getMetadataValidator,
+  assetMetadataAvailableToProject,
+  metadataValidator,
+  listByProjectKeyValidator,
 };

--- a/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
@@ -1,4 +1,4 @@
-import { matchedData, body, query } from 'express-validator';
+import { matchedData, body, param } from 'express-validator';
 import { service } from 'service-chassis';
 import centralAssetRepoRepository from '../dataaccess/centralAssetRepoRepository';
 import centralAssetRepoModel from '../models/centralAssetRepo.model';
@@ -19,12 +19,21 @@ async function createAssetMetadata(request, response, next) {
   }
 }
 
+async function listAssetMetadata(request, response, next) {
+  try {
+    const metadata = await centralAssetRepoRepository.listMetadata();
+    return response.status(200).send(metadata);
+  } catch (error) {
+    return next(new Error(`Error listing asset metadata: ${error.message}`));
+  }
+}
+
 async function assetMetadataAvailableToProject(request, response, next) {
   const { projectKey } = matchedData(request);
 
   try {
-    const result = await centralAssetRepoRepository.metadataAvailableToProject(projectKey);
-    return response.status(200).send(result);
+    const metadata = await centralAssetRepoRepository.metadataAvailableToProject(projectKey);
+    return response.status(200).send(metadata);
   } catch (error) {
     return next(new Error(`Error listing asset metadata by key: ${error.message}`));
   }
@@ -97,7 +106,7 @@ const metadataValidator = () => {
 };
 
 const listByProjectKeyValidator = () => service.middleware.validator([
-  new ValidationChainHelper(query('projectKey'))
+  new ValidationChainHelper(param('projectKey'))
     .exists()
     .notEmpty()
     .getValidationChain(),
@@ -105,6 +114,7 @@ const listByProjectKeyValidator = () => service.middleware.validator([
 
 export default {
   createAssetMetadata,
+  listAssetMetadata,
   assetMetadataAvailableToProject,
   metadataValidator,
   listByProjectKeyValidator,

--- a/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.spec.js
@@ -9,8 +9,8 @@ const matchedDataMock = jest
   .mockImplementation(request => request);
 
 const responseMock = {
-  status: jest.fn().mockImplementation(() => responseMock),
-  send: jest.fn().mockImplementation(() => responseMock),
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn().mockReturnThis(),
 };
 const nextMock = jest.fn();
 
@@ -82,6 +82,28 @@ describe('createAssetMetadata', () => {
     centralAssetRepoRepository.createMetadata.mockRejectedValueOnce(new Error('Expected test error'));
     await createAssetMetadata(requestMock, responseMock, nextMock);
     expect(nextMock).toHaveBeenCalledWith(new Error('Error creating asset metadata - failed to create new document: Expected test error'));
+  });
+});
+
+describe('listAssetMetadata', () => {
+  const { listAssetMetadata } = centralAssetRepoController;
+  const requestMock = jest.fn();
+
+  it('calls to list metadata and returns response configured with 200 status and array of metadata', async () => {
+    const availableMetadata = [{ ...getMinimalMetadata(), assetId: 'asset-id' }];
+    centralAssetRepoRepository.listMetadata.mockResolvedValueOnce(availableMetadata);
+
+    const returnValue = await listAssetMetadata(requestMock, responseMock, nextMock);
+
+    expect(returnValue).toBe(responseMock);
+    expect(responseMock.status).toHaveBeenCalledWith(200);
+    expect(responseMock.send).toHaveBeenCalledWith(availableMetadata);
+  });
+
+  it('calls next with an error if there is an error when listing the metadata', async () => {
+    centralAssetRepoRepository.listMetadata.mockRejectedValueOnce(new Error('Expected test error'));
+    await listAssetMetadata(requestMock, responseMock, nextMock);
+    expect(nextMock).toHaveBeenCalledWith(new Error('Error listing asset metadata: Expected test error'));
   });
 });
 

--- a/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.spec.js
@@ -14,7 +14,7 @@ const responseMock = {
 };
 const nextMock = jest.fn();
 
-const getMinimalRequestMock = () => ({
+const getMinimalMetadata = () => ({
   name: 'Test Metadata',
   version: '0.1.0',
   type: 'DATA',
@@ -47,7 +47,7 @@ describe('createAssetMetadata', () => {
   it('returns response configured with 409 status and result of metadataExists check if metadata already exists', async () => {
     const metadataExistsResponse = { conflicts: ['Expected test conflict'] };
     centralAssetRepoRepository.metadataExists.mockResolvedValueOnce(metadataExistsResponse);
-    const requestMock = getMinimalRequestMock();
+    const requestMock = getMinimalMetadata();
 
     const returnValue = await createAssetMetadata(requestMock, responseMock, nextMock);
 
@@ -58,13 +58,13 @@ describe('createAssetMetadata', () => {
 
   it('calls next with an error if there is an error checking if the metadata exists', async () => {
     centralAssetRepoRepository.metadataExists.mockRejectedValueOnce(new Error('Expected test error'));
-    const requestMock = getMinimalRequestMock();
+    const requestMock = getMinimalMetadata();
     await createAssetMetadata(requestMock, responseMock, nextMock);
     expect(nextMock).toHaveBeenCalledWith(new Error('Error creating asset metadata - failed to check if document already exists: Expected test error'));
   });
 
   it('creates new metadata document and returns the newly created document with 201 status', async () => {
-    const requestMock = getMinimalRequestMock();
+    const requestMock = getMinimalMetadata();
     const newMetaDocument = { ...requestMock, assetId: 'test-asset-id' };
     centralAssetRepoRepository.createMetadata.mockResolvedValueOnce(newMetaDocument);
 
@@ -78,9 +78,34 @@ describe('createAssetMetadata', () => {
   });
 
   it('calls next with an error if there is an error when creating the new metadata document', async () => {
-    const requestMock = getMinimalRequestMock();
+    const requestMock = getMinimalMetadata();
     centralAssetRepoRepository.createMetadata.mockRejectedValueOnce(new Error('Expected test error'));
     await createAssetMetadata(requestMock, responseMock, nextMock);
     expect(nextMock).toHaveBeenCalledWith(new Error('Error creating asset metadata - failed to create new document: Expected test error'));
+  });
+});
+
+describe('assetMetadataAvailableToProject', () => {
+  const { assetMetadataAvailableToProject } = centralAssetRepoController;
+  const projectKey = 'test-project';
+
+  it('calls to get metadata available to project and returns response configured with 200 status and available projects', async () => {
+    const requestMock = { projectKey };
+    const availableMetadata = [{ ...getMinimalMetadata(), assetId: 'asset-id' }];
+    centralAssetRepoRepository.metadataAvailableToProject.mockResolvedValueOnce(availableMetadata);
+
+    const returnValue = await assetMetadataAvailableToProject(requestMock, responseMock, nextMock);
+
+    expect(returnValue).toBe(responseMock);
+    expect(responseMock.status).toHaveBeenCalledWith(200);
+    expect(responseMock.send).toHaveBeenCalledWith(availableMetadata);
+    expect(centralAssetRepoRepository.metadataAvailableToProject).toHaveBeenCalledWith(projectKey);
+  });
+
+  it('calls next with error if there is an error when querying metadata', async () => {
+    const requestMock = { projectKey };
+    centralAssetRepoRepository.metadataAvailableToProject.mockRejectedValueOnce(new Error('Expected test error'));
+    await assetMetadataAvailableToProject(requestMock, responseMock, nextMock);
+    expect(nextMock).toHaveBeenCalledWith(new Error('Error listing asset metadata by key: Expected test error'));
   });
 });

--- a/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.js
@@ -8,6 +8,16 @@ async function createMetadata(metadata) {
   return document;
 }
 
+async function metadataAvailableToProject(projectKey) {
+  return CentralAssetMetadata()
+    .find()
+    .or([
+      { visible: 'PUBLIC' },
+      { visible: 'BY_PROJECT', projects: { $elemMatch: { $eq: projectKey } } },
+    ])
+    .exec();
+}
+
 async function metadataExists(metadata) {
   const checkingFunctions = [
     metadataWithNameVersionCombinationExists,
@@ -50,5 +60,6 @@ async function metadataWithMasterUrlMasterVersionCombinationExists({ masterUrl, 
 
 export default {
   createMetadata,
+  metadataAvailableToProject,
   metadataExists,
 };

--- a/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.js
@@ -8,6 +8,10 @@ async function createMetadata(metadata) {
   return document;
 }
 
+async function listMetadata() {
+  return CentralAssetMetadata().find().exec();
+}
+
 async function metadataAvailableToProject(projectKey) {
   return CentralAssetMetadata()
     .find()
@@ -60,6 +64,7 @@ async function metadataWithMasterUrlMasterVersionCombinationExists({ masterUrl, 
 
 export default {
   createMetadata,
+  listMetadata,
   metadataAvailableToProject,
   metadataExists,
 };

--- a/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
@@ -4,23 +4,28 @@ import database from '../config/database';
 const centralAssetMetadataModelMock = {
   create: jest.fn(),
   exists: jest.fn(),
+  find: jest.fn().mockReturnThis(),
+  or: jest.fn().mockReturnThis(),
+  exec: jest.fn(),
 };
 
 jest.mock('../config/database');
 database.getModel.mockReturnValue(centralAssetMetadataModelMock);
 
+const getMinimalMetadata = () => ({
+  name: 'Test Metadata',
+  version: '0.1.0',
+  type: 'DATA',
+  owners: [],
+  visible: 'PUBLIC',
+  fileLocation: 'path/to/file',
+});
+
 const { createMetadata, metadataExists } = centralAssetRepoRepository;
 
 describe('createMetadata', () => {
   it('calls to create new metadata document and returns the newly created document', async () => {
-    const metadata = {
-      name: 'Test Metadata',
-      version: '0.1.0',
-      type: 'DATA',
-      owners: [],
-      visible: 'PUBLIC',
-      fileLocation: 'path/to/file',
-    };
+    const metadata = getMinimalMetadata();
     const createdDocument = { ...metadata, assetId: 'test-asset-id' };
     centralAssetMetadataModelMock.create.mockReturnValueOnce([createdDocument]);
 
@@ -28,6 +33,24 @@ describe('createMetadata', () => {
 
     expect(centralAssetMetadataModelMock.create).toHaveBeenCalledWith([metadata], { setDefaultsOnInsert: true });
     expect(response).toBe(createdDocument);
+  });
+});
+
+describe('metadataAvailableToProject', () => {
+  it('performs correct query on central asset metadata model and returns the result', async () => {
+    const projectKey = 'test-project';
+    const metadata = getMinimalMetadata();
+    centralAssetMetadataModelMock.exec.mockResolvedValueOnce([metadata]);
+
+    const returnValue = await centralAssetRepoRepository.metadataAvailableToProject(projectKey);
+
+    expect(returnValue).toEqual([metadata]);
+    expect(centralAssetMetadataModelMock.find).toHaveBeenCalledWith();
+    expect(centralAssetMetadataModelMock.or).toHaveBeenCalledWith([
+      { visible: 'PUBLIC' },
+      { visible: 'BY_PROJECT', projects: { $elemMatch: { $eq: projectKey } } },
+    ]);
+    expect(centralAssetMetadataModelMock.exec).toHaveBeenCalledWith();
   });
 });
 

--- a/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
@@ -36,6 +36,19 @@ describe('createMetadata', () => {
   });
 });
 
+describe('listMetadata', () => {
+  it('performs the correct query on central asset metadata model and returns the result', async () => {
+    const metadata = getMinimalMetadata();
+    centralAssetMetadataModelMock.exec.mockResolvedValueOnce([metadata]);
+
+    const returnValue = await centralAssetRepoRepository.listMetadata();
+
+    expect(returnValue).toEqual([metadata]);
+    expect(centralAssetMetadataModelMock.find).toHaveBeenCalledWith();
+    expect(centralAssetMetadataModelMock.exec).toHaveBeenCalledWith();
+  });
+});
+
 describe('metadataAvailableToProject', () => {
   it('performs correct query on central asset metadata model and returns the result', async () => {
     const projectKey = 'test-project';

--- a/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
@@ -2,9 +2,9 @@ import { service } from 'service-chassis';
 import express from 'express';
 import { permissionTypes } from 'common';
 import centralAssetRepo from '../controllers/centralAssetRepoController';
-import { projectPermissionWrapper, systemDataManagerPermissionWrapper } from '../auth/permissionMiddleware';
+import permissionMiddleware from '../auth/permissionMiddleware';
 
-const { projectPermissions: { PROJECT_KEY_STACKS_CREATE } } = permissionTypes;
+const { projectPermissions: { PROJECT_KEY_STACKS_CREATE }, SYSTEM_DATA_MANAGER } = permissionTypes;
 
 const { errorWrapper } = service.middleware;
 
@@ -12,14 +12,14 @@ const centralAssetRepoRouter = express.Router();
 
 centralAssetRepoRouter.post(
   '/metadata',
-  systemDataManagerPermissionWrapper(),
+  permissionMiddleware(SYSTEM_DATA_MANAGER),
   centralAssetRepo.metadataValidator(),
   errorWrapper(centralAssetRepo.createAssetMetadata),
 );
 
 centralAssetRepoRouter.get(
   '/metadata',
-  projectPermissionWrapper(PROJECT_KEY_STACKS_CREATE),
+  permissionMiddleware(PROJECT_KEY_STACKS_CREATE, SYSTEM_DATA_MANAGER),
   centralAssetRepo.listByProjectKeyValidator(),
   errorWrapper(centralAssetRepo.assetMetadataAvailableToProject),
 );

--- a/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
@@ -19,6 +19,12 @@ centralAssetRepoRouter.post(
 
 centralAssetRepoRouter.get(
   '/metadata',
+  permissionMiddleware(SYSTEM_DATA_MANAGER),
+  errorWrapper(centralAssetRepo.listAssetMetadata),
+);
+
+centralAssetRepoRouter.get(
+  '/metadata/:projectKey',
   permissionMiddleware(PROJECT_KEY_STACKS_CREATE, SYSTEM_DATA_MANAGER),
   centralAssetRepo.listByProjectKeyValidator(),
   errorWrapper(centralAssetRepo.assetMetadataAvailableToProject),

--- a/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
@@ -1,7 +1,10 @@
 import { service } from 'service-chassis';
 import express from 'express';
+import { permissionTypes } from 'common';
 import centralAssetRepo from '../controllers/centralAssetRepoController';
-import { systemDataManagerPermissionWrapper } from '../auth/permissionMiddleware';
+import { projectPermissionWrapper, systemDataManagerPermissionWrapper } from '../auth/permissionMiddleware';
+
+const { projectPermissions: { PROJECT_KEY_STACKS_CREATE } } = permissionTypes;
 
 const { errorWrapper } = service.middleware;
 
@@ -10,8 +13,15 @@ const centralAssetRepoRouter = express.Router();
 centralAssetRepoRouter.post(
   '/metadata',
   systemDataManagerPermissionWrapper(),
-  centralAssetRepo.getMetadataValidator(),
+  centralAssetRepo.metadataValidator(),
   errorWrapper(centralAssetRepo.createAssetMetadata),
+);
+
+centralAssetRepoRouter.get(
+  '/metadata',
+  projectPermissionWrapper(PROJECT_KEY_STACKS_CREATE),
+  centralAssetRepo.listByProjectKeyValidator(),
+  errorWrapper(centralAssetRepo.assetMetadataAvailableToProject),
 );
 
 export default centralAssetRepoRouter;


### PR DESCRIPTION
* Added ability to list central asset metadata. This can be done in one of two ways:
  * Get all of the metadata (if data manager)
  * Get all of the metadata visible to a project (if data manager or have notebook create permission within project)
* Added new permission middleware function that handles multiple permissions of differing types e.g. can handle project permissions alongside system permissions. (note: rather than updating the permissions handling in the client api to be able to do the same thing, I have relied on the infrastructure service's permissions check).  