### PR TITLE
fix: ensure correct tag is pushed

### DIFF
--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -61,7 +61,7 @@ if [[ ($# -eq 1 || $# -eq 2 && $2 == "--push" ) ]] && [[ "$1" =~ ^(docs|api|app|
   docker tag nerc/$IMAGE:latest nerc/$IMAGE:$GIT_DESCRIBE
   if [ "$#" -eq 2 ]; then
     echo "Attempting to push image..."
-    docker push nerc/$IMAGE
+    docker push nerc/$IMAGE:$GIT_DESCRIBE
   fi
   echo "Success!"
 else

--- a/build/build-container.sh
+++ b/build/build-container.sh
@@ -61,7 +61,7 @@ if [[ ($# -eq 1 || $# -eq 2 && $2 == "--push" ) ]] && [[ "$1" =~ ^(docs|api|app|
   docker tag nerc/$IMAGE:latest nerc/$IMAGE:$GIT_DESCRIBE
   if [ "$#" -eq 2 ]; then
     echo "Attempting to push image..."
-    docker push nerc/$IMAGE:$GIT_DESCRIBE
+    docker push nerc/$IMAGE --all-tags
   fi
   echo "Success!"
 else


### PR DESCRIPTION
Looks like even though we are tagging the release the default being chosen is latest, hence specify to push the specific tag instead.

```
Successfully built f9b97c0aa10f
Successfully tagged nerc/datalab-api:latest
Attempting to push image...
Using default tag: latest
The push refers to repository [docker.io/nerc/datalab-api]
```

The "Using default tag" message didn't seem to appear in older builds, so may be a difference in the build environment somehow.