### PR TITLE
NERCDL-919 only show assets with fileLocations

### DIFF
--- a/code/workspaces/web-app/src/hooks/assetRepoHooks.js
+++ b/code/workspaces/web-app/src/hooks/assetRepoHooks.js
@@ -7,7 +7,7 @@ export const useAssetRepo = () => useShallowSelector(assetRepoSelectors.assetRep
 export const useVisibleAssets = (projectKey) => {
   const assetRepo = useAssetRepo();
   const visibleAssets = assetRepo.value.assets
-    ? assetRepo.value.assets.filter(asset => asset.visible === 'PUBLIC' || asset.projects.includes(projectKey))
+    ? assetRepo.value.assets.filter(asset => (asset.visible === 'PUBLIC' || asset.projects.includes(projectKey)) && asset.fileLocation)
     : [];
   return {
     ...assetRepo,

--- a/code/workspaces/web-app/src/hooks/assetRepoHooks.spec.js
+++ b/code/workspaces/web-app/src/hooks/assetRepoHooks.spec.js
@@ -4,10 +4,11 @@ import { useAssetRepo, useVisibleAssets } from './assetRepoHooks';
 
 jest.mock('./useShallowSelector');
 
-const publicAsset = { name: 'publicAsset', visible: 'PUBLIC', projects: [] };
-const project1Asset = { name: 'project1Asset', visible: 'BY_PROJECT', projects: ['project1'] };
-const project2Asset = { name: 'project2Asset', visible: 'BY_PROJECT', projects: ['project2'] };
-const assetRepoState = { value: { assets: [publicAsset, project1Asset, project2Asset] } };
+const publicAsset1 = { name: 'publicAsset1', visible: 'PUBLIC', projects: [], fileLocation: '/public1' };
+const publicAsset2 = { name: 'publicAsset2', visible: 'PUBLIC', projects: [] };
+const project1Asset = { name: 'project1Asset', visible: 'BY_PROJECT', projects: ['project1'], fileLocation: '/project1' };
+const project2Asset = { name: 'project2Asset', visible: 'BY_PROJECT', projects: ['project2'], fileLocation: '/project2' };
+const assetRepoState = { value: { assets: [publicAsset1, publicAsset2, project1Asset, project2Asset] } };
 useShallowSelector.mockReturnValue(assetRepoState);
 beforeEach(() => jest.clearAllMocks());
 
@@ -31,6 +32,6 @@ describe('useVisibleAssets', () => {
     // Assert
     expect(useShallowSelector).toHaveBeenCalledTimes(1);
     expect(useShallowSelector).toHaveBeenCalledWith(assetRepoSelectors.assetRepo);
-    expect(hookResult.value.assets).toEqual([project1Asset, publicAsset]);
+    expect(hookResult.value.assets).toEqual([project1Asset, publicAsset1]);
   });
 });

--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -52,6 +52,7 @@
 			"datalab",
 			"datalabs",
 			"dialog",
+			"elem",
 			"glusterfs",
 			"jupyter",
 			"jupyterlab",


### PR DESCRIPTION
Quick fix - it makes sense to only show assets with paths, when adding assets to notebooks.