### PR TITLE
fix: enforce permission requirements for direct navigation to dask page

### DIFF
--- a/code/workspaces/web-app/src/containers/app/ProjectNavigationContainer.js
+++ b/code/workspaces/web-app/src/containers/app/ProjectNavigationContainer.js
@@ -20,7 +20,7 @@ import { useCurrentProjectKey } from '../../hooks/currentProjectHooks';
 
 const {
   projectKeyPermission,
-  projectPermissions: { PROJECT_KEY_PROJECTS_READ, PROJECT_KEY_STORAGE_LIST, PROJECT_KEY_STACKS_LIST, PROJECT_KEY_SETTINGS_LIST },
+  projectPermissions: { PROJECT_KEY_PROJECTS_READ, PROJECT_KEY_STORAGE_LIST, PROJECT_KEY_STACKS_LIST, PROJECT_KEY_SETTINGS_LIST, PROJECT_KEY_CLUSTERS_LIST },
   SYSTEM_INSTANCE_ADMIN,
 } = permissionTypes;
 
@@ -84,9 +84,12 @@ function PureProjectNavigationContainer({ path, promisedUserPermissions, project
           component={SettingsPage}
           permission={projectKeyPermission(PROJECT_KEY_SETTINGS_LIST, projectKey.value)}
           redirectTo={redirectPath} />
-        <Route exact path={`${path}/dask`}>
-          <DaskPage />
-        </Route>
+        <RoutePermissions
+          exact
+          path={`${path}/dask`}
+          component={DaskPage}
+          permission={projectKeyPermission(PROJECT_KEY_CLUSTERS_LIST, projectKey.value)}
+          redirectTo={redirectPath} />
         <Route exact path={`${path}/spark`}>
           <SparkPage />
         </Route>

--- a/code/workspaces/web-app/src/containers/app/__snapshots__/ProjectNavigationContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/app/__snapshots__/ProjectNavigationContainer.spec.js.snap
@@ -70,12 +70,13 @@ exports[`PureProjectNavigationContainer renders correct snapshot passing props o
       permission="projects:testproj:settings:list"
       redirectTo="projects/testproj/info"
     />
-    <Route
+    <RoutePermissionWrapper
+      component={[Function]}
       exact={true}
       path="projects/:projectKey/dask"
-    >
-      <DaskPage />
-    </Route>
+      permission="projects:testproj:clusters:list"
+      redirectTo="projects/testproj/info"
+    />
     <Route
       exact={true}
       path="projects/:projectKey/spark"


### PR DESCRIPTION
Small fix that prevents a user from navigating directly to `/project/:projectKey/dask` unless they have cluster list permissions.