### PR TITLE
fix: list clusters breaks when user does not have permission to see users on datastore

### DIFF
--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -94,8 +94,13 @@ const resolvers = {
 
   DataStore: {
     id: obj => (obj._id), // eslint-disable-line no-underscore-dangle
-    users: (obj, args, { user }) => (obj.projectKey
-      ? projectPermissionWrapper({ projectKey: obj.projectKey }, STORAGE_EDIT, user, () => obj.users, 'DataStore.users') : []),
+    users: async ({ projectKey, users }, args, { user }) => {
+      try {
+        return await projectPermissionWrapper({ projectKey }, STORAGE_EDIT, user, () => users);
+      } catch (error) {
+        return [];
+      }
+    },
     accessKey: (obj, args, { token }) => minioTokenService.requestMinioToken(obj, token),
     stacksMountingStore: ({ name, projectKey }, args, { user, token }) => (projectKey
       ? stackService.getAllByVolumeMount(projectKey, name, { user, token }) : []),

--- a/code/workspaces/web-app/src/hooks/dataStorageHooks.js
+++ b/code/workspaces/web-app/src/hooks/dataStorageHooks.js
@@ -7,6 +7,6 @@ export const useDataStorageForUserInProject = (userId, projectKey) => {
   const dataStores = useDataStorageArray();
   return {
     ...dataStores,
-    value: dataStores.value.filter(store => store.projectKey === projectKey && store.users.includes(userId)),
+    value: dataStores.value.filter(store => store.projectKey === projectKey && store.users && store.users.includes(userId)),
   };
 };

--- a/code/workspaces/web-app/src/hooks/dataStorageHooks.spec.js
+++ b/code/workspaces/web-app/src/hooks/dataStorageHooks.spec.js
@@ -18,10 +18,10 @@ describe('useDataStorageArray', () => {
 });
 
 describe('useDataStorageForUserInProject', () => {
-  it('returns list of storage filtered to only contain storage for provided user and project', () => {
-    const desiredUser = 'desired-user';
-    const projectKey = 'testproj';
+  const projectKey = 'testproj';
+  const desiredUser = 'desired-user';
 
+  it('returns list of storage filtered to only contain storage for provided user and project', () => {
     // use expected flag to indicate in the test which stores should be returned
     const stores = [
       { expected: true, projectKey, users: [desiredUser] }, // has correct project and user
@@ -35,5 +35,14 @@ describe('useDataStorageForUserInProject', () => {
     const result = useDataStorageForUserInProject(desiredUser, projectKey);
 
     expect(result.value).toEqual(expectedResult);
+  });
+
+  it('handles users array being not defined', () => {
+    const stores = [{ projectKey, users: undefined }];
+    useShallowSelector.mockReturnValueOnce({ value: stores });
+
+    const result = useDataStorageForUserInProject(desiredUser, projectKey);
+
+    expect(result.value).toEqual([]); // removes stores with undefined users array
   });
 });


### PR DESCRIPTION
The bug seems to happen due to the following:

1. As a project user, you have the list cluster permissions so are able to load the Dask page.
2. When the Dask Page loads, it loads datastores that can be mounted into a cluster.
3. If the project user has a data store that could be mounted, an error will be thrown in the client api DataStore resolver for the users field as a project user doesn't have the required permission to see the list of users on a DataStore