### PR TITLE
chore: add dockerfile linter recommendation

### DIFF
--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -25,7 +25,8 @@
 			"orta.vscode-jest",
 			"firsttris.vscode-jest-runner",
 			"streetsidesoftware.code-spell-checker",
-			"davidanson.vscode-markdownlint"
+			"davidanson.vscode-markdownlint",
+			"dansnow.vscode-dockerfilelint"
 		]
 	},
 	"settings": {


### PR DESCRIPTION
This adds a Dockerfile linter recommendation to VS Code.