### PR TITLE
fix: check for null store.users

### DIFF
--- a/code/workspaces/web-app/src/hooks/dataStorageHooks.js
+++ b/code/workspaces/web-app/src/hooks/dataStorageHooks.js
@@ -7,6 +7,6 @@ export const useDataStorageForUserInProject = (userId, projectKey) => {
   const dataStores = useDataStorageArray();
   return {
     ...dataStores,
-    value: dataStores.value.filter(store => store.projectKey === projectKey && store.users.includes(userId)),
+    value: dataStores.value.filter(store => store.projectKey === projectKey && store.users && store.users.includes(userId)),
   };
 };

--- a/code/workspaces/web-app/src/hooks/dataStorageHooks.spec.js
+++ b/code/workspaces/web-app/src/hooks/dataStorageHooks.spec.js
@@ -28,6 +28,7 @@ describe('useDataStorageForUserInProject', () => {
       { expected: true, projectKey, users: ['other-user', desiredUser] }, // has correct project and user
       { expected: false, projectKey, users: ['other-user'] }, // correct project, missing user
       { expected: false, projectKey: 'other-project', users: [desiredUser] }, // correct user, wrong project
+      { expected: false, projectKey, users: null }, // users is null
     ];
     const expectedResult = stores.filter(store => store.expected);
     useShallowSelector.mockReturnValueOnce({ value: stores });


### PR DESCRIPTION
This fixes a bug found in testing, where the Dask page produces an error
```
Cannot read property 'includes' of null
    at dataStorageHooks.js:10
```