### PR TITLE
NERCDL-958: cluster volume mount should be optional

### DIFF
--- a/code/workspaces/web-app/src/components/cluster/CreateClusterForm.js
+++ b/code/workspaces/web-app/src/components/cluster/CreateClusterForm.js
@@ -44,7 +44,7 @@ export const CreateClusterFormContent = ({
       <Field
         {...commonFieldProps}
         name={VOLUME_MOUNT_FIELD_NAME}
-        label="Data Store to Mount"
+        label="Data Store to Mount (optional)"
         component={renderSelectField}
         options={[noneOption, ...dataStorageOptions]}
       />

--- a/code/workspaces/web-app/src/components/cluster/__snapshots__/CreateClusterForm.spec.js.snap
+++ b/code/workspaces/web-app/src/components/cluster/__snapshots__/CreateClusterForm.spec.js.snap
@@ -29,7 +29,7 @@ exports[`CreateClusterForm it renders to match snapshot with condaPath field whe
       }
     }
     component={[Function]}
-    label="Data Store to Mount"
+    label="Data Store to Mount (optional)"
     name="volumeMount"
     options={
       Array [
@@ -158,7 +158,7 @@ exports[`CreateClusterForm it renders to match snapshot without condaPath field 
       }
     }
     component={[Function]}
-    label="Data Store to Mount"
+    label="Data Store to Mount (optional)"
     name="volumeMount"
     options={
       Array [
@@ -275,7 +275,7 @@ exports[`CreateClusterForm it renders to match snapshot without condaPath field 
       }
     }
     component={[Function]}
-    label="Data Store to Mount"
+    label="Data Store to Mount (optional)"
     name="volumeMount"
     options={
       Array [

--- a/code/workspaces/web-app/src/components/cluster/createClusterValidator.js
+++ b/code/workspaces/web-app/src/components/cluster/createClusterValidator.js
@@ -16,9 +16,6 @@ const constraints = {
       maximum: 16,
     },
   },
-  volumeMount: {
-    presence: true,
-  },
   maxWorkers: {
     presence: true,
     numericality: { onlyInteger: true, noStrings: true },

--- a/code/workspaces/web-app/src/components/cluster/createClusterValidator.spec.js
+++ b/code/workspaces/web-app/src/components/cluster/createClusterValidator.spec.js
@@ -69,10 +69,9 @@ describe('syncValidate', () => {
   describe('validates volumeMount', () => {
     const validValues = [
       'teststore',
+      undefined,
     ];
-    const invalidValues = [
-      undefined, // must be present
-    ];
+    const invalidValues = [];
     testValues('volumeMount', validValues, invalidValues);
   });
 

--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -71,6 +71,7 @@
 			"networkpolicies",
 			"noopener",
 			"noreferrer",
+			"numericality",
 			"oidc",
 			"placeholder",
 			"rshiny",


### PR DESCRIPTION
Minor fix, it isn't necessary to specify a volume mount when creating a Dask cluster. If it is omitted, no volume mount is made.