### PR TITLE
test: add tsc static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 .DS_Store
 .idea/
+ts-build
 
 docs/book/
 docs/src/version.md

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"runOptions": {
+				"runOn": "folderOpen"
+			},
+			"type": "typescript",
+			"tsconfig": "code/workspaces/tsconfig.json",
+			"option": "watch",
+			"problemMatcher": [
+				"$tsc-watch"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "tsc static analysis"
+		}
+	]
+}

--- a/code/workspaces/tsconfig.json
+++ b/code/workspaces/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  // vscode:
+  // There is a build task in .vscode/tasks.json which will run tsc in watch mode and report problems.
+  // To enable the task to run automatically, run the command 'Tasks: Manage Automatic Tasks in Folder', and allow.
+  // To stop the task, go to Terminal > Task - tsc static analysis and press ctrl-c.
+  "compilerOptions": {
+    "outDir": "./ts-build",
+    "composite": true,
+    "allowJs": true,
+    "checkJs": true,
+    "jsx": "preserve",
+    "target": "es2019",
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "./*/src/**/*"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/*.spec.js",
+    "**/__mocks__",
+    "**/*.min.js"
+  ]
+}


### PR DESCRIPTION
Allows you to perform typescript static analysis of the javascript code, as a potential way of reducing bugs.
In vscode, you can choose to have the analysis run automatically, and to stop it, as required - instructions are in tsconfig.json.