### PR TITLE
NERCDL-973 permissions checks

### DIFF
--- a/code/workspaces/client-api/src/auth/permissionChecker.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.js
@@ -3,18 +3,10 @@ import { permissionTypes } from 'common';
 
 const { SYSTEM_INSTANCE_ADMIN, delimiter, PROJECT_NAMESPACE } = permissionTypes;
 
-export const permissionWrapper = (permissionSuffix, ...rest) => permissionCheck(
-  [
-    permissionSuffix,
-    SYSTEM_INSTANCE_ADMIN,
-  ],
-  ...rest,
-);
-
 /*
 Note, 'done' here is nothing to do with the Express middleware, it is simply a call to the data access function providing the data promise.
 */
-export function projectPermissionWrapper(args, permissionSuffix, user, done) {
+export default function projectPermissionWrapper(args, permissionSuffix, user, done) {
   if (!args.projectKey) {
     logger.error(`Auth: permission check: FAILED, projectKey not passed in args, expected suffix: ${permissionSuffix}`);
     return Promise.reject(new Error(`projectKey not passed, expected suffix: ${permissionSuffix}`));
@@ -34,19 +26,6 @@ export function projectPermissionWrapper(args, permissionSuffix, user, done) {
     done,
   );
 }
-
-export const multiPermissionsWrapper = (permissionSuffixes, ...rest) => permissionCheck(
-  [
-    ...permissionSuffixes,
-    SYSTEM_INSTANCE_ADMIN,
-  ],
-  ...rest,
-);
-
-export const instanceAdminWrapper = (...rest) => permissionCheck(
-  [SYSTEM_INSTANCE_ADMIN],
-  ...rest,
-);
 
 function permissionCheck(requiredPermissions, { permissions }, done) {
   const userPermissions = permissions || [];

--- a/code/workspaces/client-api/src/auth/permissionChecker.spec.js
+++ b/code/workspaces/client-api/src/auth/permissionChecker.spec.js
@@ -1,12 +1,12 @@
 import { permissionTypes } from 'common';
-import { permissionWrapper, multiPermissionsWrapper, instanceAdminWrapper, projectPermissionWrapper } from './permissionChecker';
+import projectPermissionWrapper from './permissionChecker';
 
 const { PROJECT_NAMESPACE } = permissionTypes;
 
 const user = {
   permissions: [
     'elementName:actionName',
-    `${PROJECT_NAMESPACE}:testproj:elementName:actionName`,
+    `${PROJECT_NAMESPACE}:testProject:elementName:actionName`,
   ],
 };
 
@@ -22,78 +22,6 @@ const done = () => actionMock('value');
 
 describe('Permission Checker', () => {
   beforeEach(() => jest.clearAllMocks());
-
-  describe('permissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', async () => {
-      let error;
-      try {
-        await permissionWrapper('elementName:missingActionName', user, done);
-      } catch (err) {
-        error = err;
-      }
-      expect(error).toEqual(new Error('User missing expected permission(s): elementName:missingActionName,system:instance:admin'));
-      expect(actionMock).not.toHaveBeenCalled();
-    });
-
-    it('callback to be called if user has correct permission', () => permissionWrapper('elementName:actionName', user, done)
-      .then(() => {
-        expect(actionMock).toHaveBeenCalledTimes(1);
-        expect(actionMock).toHaveBeenCalledWith('value');
-      }));
-
-    it('callback to be called if user has instance admin permission but not project permission', () => {
-      permissionWrapper('elementName:missingActionName', admin, done)
-        .then(() => {
-          expect(actionMock).toHaveBeenCalledTimes(1);
-          expect(actionMock).toHaveBeenCalledWith('value');
-        });
-    });
-  });
-
-  describe('multiPermissionWrapper', () => {
-    it('throws an error if user is lacking correct permission', async () => {
-      let error;
-      try {
-        await multiPermissionsWrapper(['elementName:missingActionName', 'elementName:anotherAction'], user, done);
-      } catch (err) {
-        error = err;
-      }
-      expect(error).toEqual(new Error('User missing expected permission(s): elementName:missingActionName,'
-        .concat('elementName:anotherAction,system:instance:admin')));
-      expect(actionMock).not.toHaveBeenCalled();
-    });
-
-    it('callback to be called if user has correct permission', () => multiPermissionsWrapper(['elementName:actionName', 'elementName:anotherAction'], user, done)
-      .then(() => {
-        expect(actionMock).toHaveBeenCalledTimes(1);
-        expect(actionMock).toHaveBeenCalledWith('value');
-      }));
-
-    it('callback to be called if user has instance admin permission', () => multiPermissionsWrapper(['elementName:missingActionName'], admin, done)
-      .then(() => {
-        expect(actionMock).toHaveBeenCalledTimes(1);
-        expect(actionMock).toHaveBeenCalledWith('value');
-      }));
-  });
-
-  describe('instanceAdminWrapper', () => {
-    it('throws an error if user is lacking correct permission', async () => {
-      let error;
-      try {
-        await instanceAdminWrapper(user, done);
-      } catch (err) {
-        error = err;
-      }
-      expect(error).toEqual(new Error('User missing expected permission(s): system:instance:admin'));
-      expect(actionMock).not.toHaveBeenCalled();
-    });
-
-    it('callback to be called if user has instance admin permission', () => instanceAdminWrapper(admin, done)
-      .then(() => {
-        expect(actionMock).toHaveBeenCalledTimes(1);
-        expect(actionMock).toHaveBeenCalledWith('value');
-      }));
-  });
 
   describe('projectPermissionWrapper', () => {
     it('throws an error if user is lacking correct permission', async () => {
@@ -119,14 +47,14 @@ describe('Permission Checker', () => {
     });
 
     it('callback to be called if user has correct permission when single suffix passed', async () => {
-      await projectPermissionWrapper({ projectKey: 'testproj' }, 'elementName:actionName', user, done);
+      await projectPermissionWrapper({ projectKey: 'testProject' }, 'elementName:actionName', user, done);
 
       expect(actionMock).toHaveBeenCalledTimes(1);
       expect(actionMock).toHaveBeenCalledWith('value');
     });
 
     it('callback to be called if user has correct permission when multiple suffix passed', async () => {
-      await projectPermissionWrapper({ projectKey: 'testproj' }, ['elementName:missingActionName', 'elementName:actionName'], user, done);
+      await projectPermissionWrapper({ projectKey: 'testProject' }, ['elementName:missingActionName', 'elementName:actionName'], user, done);
 
       expect(actionMock).toHaveBeenCalledTimes(1);
       expect(actionMock).toHaveBeenCalledWith('value');

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -1,12 +1,12 @@
 import { statusTypes, permissionTypes } from 'common';
 import config from '../config';
 import { version } from '../version.json';
-import { instanceAdminWrapper, projectPermissionWrapper } from '../auth/permissionChecker';
+import projectPermissionWrapper from '../auth/permissionChecker';
 import stackService from '../dataaccess/stackService';
 import datalabRepository from '../dataaccess/datalabRepository';
 import permissionsService from '../dataaccess/userPermissionsService';
 import internalNameChecker from '../dataaccess/internalNameChecker';
-import userService from '../dataaccess/usersService';
+import usersService from '../dataaccess/usersService';
 import stackApi from '../infrastructure/stackApi';
 import minioTokenService from '../dataaccess/minioTokenService';
 import stackUrlService from '../dataaccess/stackUrlService';
@@ -16,11 +16,9 @@ import logsService from '../dataaccess/logsService';
 import rolesService from '../dataaccess/rolesService';
 import centralAssetRepoService from '../dataaccess/centralAssetRepoService';
 import clustersService from '../dataaccess/clustersService';
+import w from './wrapper';
 
-const { elementPermissions: { STORAGE_CREATE, STORAGE_DELETE, STORAGE_LIST, STORAGE_EDIT, STORAGE_OPEN } } = permissionTypes;
-const { elementPermissions: { STACKS_CREATE, STACKS_EDIT, STACKS_DELETE, STACKS_LIST, STACKS_OPEN } } = permissionTypes;
-const { elementPermissions: { PERMISSIONS_CREATE, PERMISSIONS_DELETE } } = permissionTypes;
-const { elementPermissions: { SETTINGS_EDIT } } = permissionTypes;
+const { elementPermissions: { STORAGE_EDIT } } = permissionTypes;
 const { READY } = statusTypes;
 
 const DATALAB_NAME = config.get('datalabName');
@@ -28,68 +26,52 @@ const DATALAB_NAME = config.get('datalabName');
 const resolvers = {
   Query: {
     status: () => () => `GraphQL server is running version: ${version}`,
-    dataStorage: (obj, args, { user, token }) => projectPermissionWrapper(args, STORAGE_LIST, user, () => storageService.getAllProjectActive(args.projectKey, token)),
-    dataStore: (obj, args, { user, token }) => projectPermissionWrapper(args, STORAGE_OPEN, user, () => storageService.getById(args.projectKey, args.id, token)),
-    stack: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_OPEN, user, () => stackService.getById(args.projectKey, args.id, { token })),
-    stacks: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_LIST, user, () => stackService.getAll(args.projectKey, { token })),
-    stacksByCategory: (obj, { params }, { user, token }) => (
-      projectPermissionWrapper(params, STACKS_LIST, user, () => stackService.getAllByCategory(params.projectKey, params.category, { token }))
-    ),
-    datalab: (obj, { name }, { user }) => datalabRepository.getByName(user, name),
-    datalabs: () => datalabRepository.getAll(),
-    userPermissions: (obj, params, { identity, token }) => permissionsService.getUserPermissions(identity, token),
-    allUsersAndRoles: (obj, args, { token }) => rolesService.getAllUsersAndRoles(token),
-    checkNameUniqueness: (obj, args, { user, token }) => projectPermissionWrapper(args, [STACKS_CREATE, STORAGE_CREATE], user, () => internalNameChecker(args.projectKey, args.name, token)),
-    users: (obj, args, { token }) => userService.getAll({ token }),
-    projects: (obj, args, { token }) => projectService.listProjects(token),
-    allProjectsAndResources: (obj, args, { token }) => projectService.getAllProjectsAndResources(token),
-    project: (obj, args, { token }) => projectService.getProjectByKey(args.projectKey, token),
-    checkProjectKeyUniqueness: (obj, { projectKey }, { user, token }) => instanceAdminWrapper(user, () => projectService.isProjectKeyUnique(projectKey, token)),
-    logs: (obj, args, { user, token }) => projectPermissionWrapper(args, STACKS_CREATE, user, () => logsService.getLogsByName(args.projectKey, args.name, token)),
-    centralAssets: (obj, args, { token }) => centralAssetRepoService.listCentralAssets(token),
-    centralAssetsAvailableToProject: (obj, { projectKey }, { token }) => centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token),
-    clusters: (obj, args, { token }) => clustersService.getClusters(args.projectKey, token),
+    dataStorage: (obj, args, { token }) => w(storageService.getAllProjectActive(args.projectKey, token)),
+    dataStore: (obj, args, { token }) => w(storageService.getById(args.projectKey, args.id, token)),
+    stack: (obj, args, { token }) => w(stackService.getById(args.projectKey, args.id, { token })),
+    stacks: (obj, args, { token }) => w(stackService.getAll(args.projectKey, { token })),
+    stacksByCategory: (obj, { params }, { token }) => w(stackService.getAllByCategory(params.projectKey, params.category, { token })),
+    datalab: (obj, { name }, { user }) => w(datalabRepository.getByName(user, name)),
+    datalabs: () => w(datalabRepository.getAll()),
+    userPermissions: (obj, params, { identity, token }) => w(permissionsService.getUserPermissions(identity, token)),
+    allUsersAndRoles: (obj, args, { token }) => w(rolesService.getAllUsersAndRoles(token)),
+    checkNameUniqueness: (obj, args, { token }) => w(internalNameChecker(args.projectKey, args.name, token)),
+    users: (obj, args, { token }) => w(usersService.getAll({ token })),
+    projects: (obj, args, { token }) => w(projectService.listProjects(token)),
+    allProjectsAndResources: (obj, args, { token }) => w(projectService.getAllProjectsAndResources(token)),
+    project: (obj, args, { token }) => w(projectService.getProjectByKey(args.projectKey, token)),
+    checkProjectKeyUniqueness: (obj, { projectKey }, { token }) => w(projectService.isProjectKeyUnique(projectKey, token)),
+    logs: (obj, args, { token }) => w(logsService.getLogsByName(args.projectKey, args.name, token)),
+    centralAssets: (obj, args, { token }) => w(centralAssetRepoService.listCentralAssets(token)),
+    centralAssetsAvailableToProject: (obj, { projectKey }, { token }) => w(centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token)),
+    clusters: (obj, args, { token }) => w(clustersService.getClusters(args.projectKey, token)),
   },
 
   Mutation: {
-    createStack: (obj, { stack }, { user, token }) => projectPermissionWrapper(stack, STACKS_CREATE, user, () => stackApi.createStack({ user, token }, DATALAB_NAME, stack)),
-    updateStack: (obj, { stack }, { user, token }) => projectPermissionWrapper(stack, STACKS_EDIT, user, () => stackApi.updateStack({ user, token }, DATALAB_NAME, stack)),
-    deleteStack: (obj, { stack }, { user, token }) => projectPermissionWrapper(stack, STACKS_DELETE, user, () => stackApi.deleteStack({ user, token }, DATALAB_NAME, stack)),
-    restartStack: (obj, { stack }, { user, token }) => projectPermissionWrapper(stack, STACKS_EDIT, user, () => stackApi.restartStack({ user, token }, DATALAB_NAME, stack)),
-    createDataStore: (obj, args, { user, token }) => (
-      projectPermissionWrapper(args, STORAGE_CREATE, user, () => storageService.createVolume({ projectKey: args.projectKey, ...args.dataStore }, token))
-    ),
-    deleteDataStore: (obj, args, { user, token }) => (
-      projectPermissionWrapper(args, STORAGE_DELETE, user, () => storageService.deleteVolume({ projectKey: args.projectKey, ...args.dataStore }, token))
-    ),
-    addUserToDataStore: (obj, args, { user, token }) => (
-      projectPermissionWrapper(args, STORAGE_EDIT, user, () => storageService.addUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token))
-    ),
-    removeUserFromDataStore: (obj, args, { user, token }) => (
-      projectPermissionWrapper(args, STORAGE_EDIT, user, () => storageService.removeUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token))
-    ),
-    updateDataStoreDetails: (obj, args, { user, token }) => (
-      projectPermissionWrapper(args, STORAGE_EDIT, user, () => storageService.updateDetails(args.projectKey, args.name, args.updatedDetails, token))
-    ),
-    addProjectPermission: (obj, { permission: { projectKey, userId, role } }, { user, token }) => (
-      projectPermissionWrapper({ projectKey }, PERMISSIONS_CREATE, user, () => projectService.addProjectPermission(projectKey, userId, role, token))
-    ),
-    removeProjectPermission: (obj, { permission: { projectKey, userId } }, { user, token }) => (
-      projectPermissionWrapper({ projectKey }, PERMISSIONS_DELETE, user, () => projectService.removeProjectPermission(projectKey, userId, token))
-    ),
-    createProject: (obj, { project }, { user, token }) => instanceAdminWrapper(user, () => projectService.createProject(project, user, token)),
-    updateProject: (obj, { project }, { user, token }) => projectPermissionWrapper({ projectKey: project.projectKey }, SETTINGS_EDIT, user, () => projectService.updateProject(project, token)),
-    deleteProject: (obj, { project: { projectKey } }, { user, token }) => instanceAdminWrapper(user, () => projectService.deleteProject(projectKey, token)),
-    createCentralAssetMetadata: (obj, { metadata }, { token }) => centralAssetRepoService.createAssetMetadata(metadata, token),
-    setInstanceAdmin: (obj, { userId, instanceAdmin }, { user, token }) => instanceAdminWrapper(user, () => userService.setInstanceAdmin(userId, instanceAdmin, token)),
-    setDataManager: (obj, { userId, dataManager }, { user, token }) => instanceAdminWrapper(user, () => userService.setDataManager(userId, dataManager, token)),
-    setCatalogueRole: (obj, { userId, catalogueRole }, { user, token }) => instanceAdminWrapper(user, () => userService.setCatalogueRole(userId, catalogueRole, token)),
-    createCluster: (obj, { cluster }, { token }) => clustersService.createCluster(cluster, token),
-    deleteCluster: (obj, { cluster }, { token }) => clustersService.deleteCluster(cluster, token),
+    createStack: (obj, { stack }, { user, token }) => w(stackApi.createStack({ user, token }, DATALAB_NAME, stack)),
+    updateStack: (obj, { stack }, { user, token }) => w(stackApi.updateStack({ user, token }, DATALAB_NAME, stack)),
+    deleteStack: (obj, { stack }, { user, token }) => w(stackApi.deleteStack({ user, token }, DATALAB_NAME, stack)),
+    restartStack: (obj, { stack }, { user, token }) => w(stackApi.restartStack({ user, token }, DATALAB_NAME, stack)),
+    createDataStore: (obj, args, { token }) => w(storageService.createVolume({ projectKey: args.projectKey, ...args.dataStore }, token)),
+    deleteDataStore: (obj, args, { token }) => w(storageService.deleteVolume({ projectKey: args.projectKey, ...args.dataStore }, token)),
+    addUserToDataStore: (obj, args, { token }) => w(storageService.addUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token)),
+    removeUserFromDataStore: (obj, args, { token }) => w(storageService.removeUsers(args.projectKey, args.dataStore.name, args.dataStore.users, token)),
+    updateDataStoreDetails: (obj, args, { token }) => w(storageService.updateDetails(args.projectKey, args.name, args.updatedDetails, token)),
+    addProjectPermission: (obj, { permission: { projectKey, userId, role } }, { token }) => w(projectService.addProjectPermission(projectKey, userId, role, token)),
+    removeProjectPermission: (obj, { permission: { projectKey, userId } }, { token }) => w(projectService.removeProjectPermission(projectKey, userId, token)),
+    createProject: (obj, { project }, { user, token }) => w(projectService.createProject(project, user, token)),
+    updateProject: (obj, { project }, { token }) => w(projectService.updateProject(project, token)),
+    deleteProject: (obj, { project: { projectKey } }, { token }) => w(projectService.deleteProject(projectKey, token)),
+    createCentralAssetMetadata: (obj, { metadata }, { token }) => w(centralAssetRepoService.createAssetMetadata(metadata, token)),
+    setInstanceAdmin: (obj, { userId, instanceAdmin }, { token }) => w(usersService.setInstanceAdmin(userId, instanceAdmin, token)),
+    setDataManager: (obj, { userId, dataManager }, { token }) => w(usersService.setDataManager(userId, dataManager, token)),
+    setCatalogueRole: (obj, { userId, catalogueRole }, { token }) => w(usersService.setCatalogueRole(userId, catalogueRole, token)),
+    createCluster: (obj, { cluster }, { token }) => w(clustersService.createCluster(cluster, token)),
+    deleteCluster: (obj, { cluster }, { token }) => w(clustersService.deleteCluster(cluster, token)),
   },
 
   CentralAssetMetadata: {
-    owners: (obj, args, { token }) => (obj.ownerUserIds ? obj.ownerUserIds.map(userId => ({ userId, name: userService.getUserName(userId, token) })) : []),
+    owners: (obj, args, { token }) => (obj.ownerUserIds ? obj.ownerUserIds.map(userId => ({ userId, name: usersService.getUserName(userId, token) })) : []),
     projects: (obj, args, { token }) => (obj.projectKeys ? obj.projectKeys.map(projectKey => projectService.getProjectByKey(projectKey, token)) : []),
   },
 
@@ -117,12 +99,12 @@ const resolvers = {
 
   Project: {
     id: obj => (obj._id), // eslint-disable-line no-underscore-dangle
-    projectUsers: (obj, args, ctx) => userService.getProjectUsers(obj.key, ctx.token),
-    accessible: (obj, args, ctx) => userService.isMemberOfProject(obj.key, ctx.token),
+    projectUsers: (obj, args, ctx) => usersService.getProjectUsers(obj.key, ctx.token),
+    accessible: (obj, args, ctx) => usersService.isMemberOfProject(obj.key, ctx.token),
   },
 
   ProjectUser: {
-    name: (obj, args, ctx) => userService.getUserName(obj.userId, ctx.token),
+    name: (obj, args, ctx) => usersService.getUserName(obj.userId, ctx.token),
   },
 
   Cluster: {

--- a/code/workspaces/client-api/src/schema/wrapper.js
+++ b/code/workspaces/client-api/src/schema/wrapper.js
@@ -1,0 +1,14 @@
+// wrapper - raise more useful exception for authentication errors
+export default async function wrapper(promise) {
+  try {
+    const result = await promise;
+    return result;
+  } catch (err) {
+    if (err.response && err.response.status === 401) {
+      const message = (err.response.data && err.response.data.message) ? err.response.data.message : '';
+      throw new Error(`Unauthorized: ${message}`);
+    }
+    throw err;
+  }
+}
+

--- a/code/workspaces/client-api/src/schema/wrapper.spec.js
+++ b/code/workspaces/client-api/src/schema/wrapper.spec.js
@@ -1,0 +1,43 @@
+import wrapper from './wrapper';
+
+describe('wrapper', () => {
+  it('returns unrejected promises', async () => {
+    // Arrange
+    const promise = Promise.resolve('okay');
+
+    // Act
+    const result = wrapper(promise);
+
+    // Assert
+    await expect(result).resolves.toEqual('okay');
+  });
+
+  it('wraps authorization rejections', async () => {
+    // Arrange
+    const promise = Promise.reject({
+      response: {
+        status: 401,
+        data: {
+          message: 'authorization-message',
+        },
+      },
+    });
+
+    // Act
+    const result = wrapper(promise);
+
+    // Assert
+    await expect(result).rejects.toEqual(new Error('Unauthorized: authorization-message'));
+  });
+
+  it('returns other rejections', async () => {
+    // Arrange
+    const promise = Promise.reject('some-error');
+
+    // Act
+    const result = wrapper(promise);
+
+    // Assert
+    await expect(result).rejects.toEqual('some-error');
+  });
+});

--- a/code/workspaces/client-api/src/server.js
+++ b/code/workspaces/client-api/src/server.js
@@ -51,6 +51,9 @@ function configureAxiosForLocalDevelopment() {
   if (!testingCookie) return;
 
   axios.interceptors.request.use((requestConfig) => {
+    if (!requestConfig.url) {
+      throw new Error('url not defined');
+    }
     const url = new URL(requestConfig.url);
 
     if (url.host.includes('datalabs.internal')) {

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.js
@@ -19,8 +19,9 @@ export const ensurePermissionGrantedMiddleware = (request, response, next) => {
 
   const granted = permissionGranted(request);
   const errors = permissionErrors(request);
-  logger.warn(`Auth: permission check FAILED with errors: [${errors.join(', ')}]`);
-  return response.status(401).send({ permissionGranted: granted, errors });
+  const message = errors.join(', ');
+  logger.warn(`Auth: permission check FAILED with errors: [${message}]`);
+  return response.status(401).send({ permissionGranted: granted, errors, message });
 };
 
 export const getRequestPermissionInfo = request => request[REQUEST_PERMISSION_INFO_KEY];

--- a/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
+++ b/code/workspaces/infrastructure-api/src/auth/subPermissionMiddleware/utils.spec.js
@@ -45,7 +45,7 @@ describe('ensurePermissionGrantedMiddleware', () => {
     ensurePermissionGrantedMiddleware(requestMock, responseMock, nextMock);
 
     expect(responseMock.status).toHaveBeenCalledWith(401);
-    expect(responseMock.send).toHaveBeenCalledWith({ permissionGranted: false, errors: ['expected error'] });
+    expect(responseMock.send).toHaveBeenCalledWith({ permissionGranted: false, errors: ['expected error'], message: 'expected error' });
     expect(nextMock).not.toHaveBeenCalled();
   });
 });

--- a/code/workspaces/infrastructure-api/src/routers/projectsRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/projectsRouter.js
@@ -6,7 +6,7 @@ import permissionMiddleware from '../auth/permissionMiddleware';
 
 const { errorWrapper: ew } = service.middleware;
 
-const { projectPermissions: { PROJECT_KEY_PROJECTS_EDIT } } = permissionTypes;
+const { projectPermissions: { PROJECT_KEY_SETTINGS_EDIT } } = permissionTypes;
 
 const projectsRouter = express.Router();
 
@@ -27,7 +27,7 @@ projectsRouter.get(
 );
 projectsRouter.put(
   '/:projectKey',
-  permissionMiddleware(PROJECT_KEY_PROJECTS_EDIT),
+  permissionMiddleware(PROJECT_KEY_SETTINGS_EDIT),
   projects.projectDocumentValidator(), projects.urlAndBodyProjectKeyMatchValidator(),
   ew(projects.createOrUpdateProject),
 );

--- a/code/workspaces/infrastructure-api/src/routers/stacksRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/stacksRouter.js
@@ -40,7 +40,7 @@ stacksRouter.get(
 );
 stacksRouter.get(
   '/:projectKey/:name/isUnique',
-  permissionMiddleware(PROJECT_KEY_STACKS_LIST),
+  permissionMiddleware(PROJECT_KEY_STORAGE_LIST, PROJECT_KEY_STACKS_LIST),
   stack.withNameValidator,
   ew(names.isUnique),
 );


### PR DESCRIPTION
This technical debt story removes the unnecessary permissions checks from the client api; instead, a wrapper checks for 401 errors from the auth service and infrastructure service, and returns appropriate errors.

The infrastructure service returns a data.message string for the unauthenticated information, just as the auth service does, to make handling easier.

A couple of infrastructure permissions checks were updated to be the same as they were in the client api.