### PR TITLE
NERCDL-916 - minor fixes for editing asset permissions

### DIFF
--- a/code/workspaces/web-app/src/components/modal/EditSiteDialog.js
+++ b/code/workspaces/web-app/src/components/modal/EditSiteDialog.js
@@ -8,7 +8,7 @@ const EditSiteDialog = ({ title, onSubmit, onCancel, stack, formComponent: Form 
   <Dialog open={true} maxWidth="md">
     <DialogTitle>{title}</DialogTitle>
     <DialogContent>
-      <Form onSubmit={onSubmit} onCancel={onCancel} initialValues={stack} />
+      <Form onSubmit={onSubmit} onCancel={onCancel} initialValues={stack} projectKey={stack.projectKey} />
     </DialogContent>
   </Dialog>
 );

--- a/code/workspaces/web-app/src/containers/assetRepo/AssetRepoFindContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AssetRepoFindContainer.js
@@ -29,7 +29,14 @@ function AssetRepoFindContainer({ userPermissions }) {
   const [selectedAssets, setSelectedAssets] = useState([]);
   const classes = useStyles();
   const assetRepo = useAssetRepo();
-  const shownAssets = (selectedAssets && selectedAssets.length > 0) ? selectedAssets : sortByName(assetRepo.value.assets);
+
+  // @ts-ignore - no way to let tsc know the shape of selectedAssets
+  const selectedAssetIds = selectedAssets ? selectedAssets.map(asset => asset.assetId) : [];
+
+  // recalculate shownAssets in case edited
+  const shownAssets = (selectedAssetIds.length > 0)
+    ? sortByName(assetRepo.value.assets.filter(asset => selectedAssetIds.includes(asset.assetId)))
+    : sortByName(assetRepo.value.assets);
 
   useEffect(() => {
     dispatch(assetRepoActions.loadAllAssets());


### PR DESCRIPTION
Some minor fixes performed as I was outlining the test steps for editing asset permissions.
Commit 1) On the Find Asset page, if you'd used the asset multi select, the assets weren't updated after editing them.
Commit 2) On the Edit Sites dialog, only public assets were showing, because the form didn't have a projectKey passed to it.