### PR TITLE
NERCDL-1049 single host minio

### DIFF
--- a/code/development-env/README.md
+++ b/code/development-env/README.md
@@ -69,6 +69,9 @@ In this folder:
 # Use VirtualBox as the driver, as ingress will expect the VirtualBox IP addresses
 minikube config set driver virtualbox
 
+# Check for running minikubes - stop any which use the IP 192.168.99.100
+minikube profile list
+
 # Ensure default IP addresses are used
 rm ~/Library/VirtualBox/HostInterfaceNetworking-vboxnet0-Dhcpd.*
 
@@ -80,6 +83,8 @@ minikube ip
 
 # Create devtest namespace
 kubectl apply -f ./config/manifests/minikube-namespace.yml
+
+# Set default namespace (replace 'minikube' with your minikube name)
 kubectl config set-context minikube --namespace=devtest
 
 # Create Gluster and NFS storage classes
@@ -230,6 +235,13 @@ This is not well suited for local development as you cannot change files within 
 However, it is useful when testing the Helm chart configuration.
 A script exists at `./scripts/helm-install-datalabs-locally.sh` which will create the necessary secrets within minikube for the Helm install to work (note that this builds off of the items that have already been installed into minikube such as the storage classes etc.).
 There are values that can be used to configure the installation at the top of the script, some of which will need to be set before first use.
+It also assumes that the `datalab-k8s-manifests` repo is checked out parallel to this (`datalab`) repo.
+
+```bash
+kubectl delete -f ./config/manifests/minikube-proxy.yml
+helm delete datalab -n devtest
+./scripts/helm-install-datalabs-locally.sh
+```
 
 **Warning:** Before running this script ensure that your `kubectl` is configured to operate on the correct cluster.
 `kubectl` is used throughout the script to create new secrets etc.

--- a/code/development-env/README.md
+++ b/code/development-env/README.md
@@ -238,9 +238,13 @@ There are values that can be used to configure the installation at the top of th
 It also assumes that the `datalab-k8s-manifests` repo is checked out parallel to this (`datalab`) repo.
 
 ```bash
-kubectl delete -f ./config/manifests/minikube-proxy.yml
-helm delete datalab -n devtest
+kubectl delete -f ./config/manifests/minikube-proxy.yml # remove if applied from above instructions
+./config/dnsmasq/configure-dnsmasq.sh datalabs.internal <ingress-nginx-controller external ip>
+minikube tunnel # run this in a different terminal
 ./scripts/helm-install-datalabs-locally.sh
+
+# if you want to re-install helm, do the following and wait for pods to terminate
+helm uninstall datalab -n devtest
 ```
 
 **Warning:** Before running this script ensure that your `kubectl` is configured to operate on the correct cluster.

--- a/code/development-env/datalabs-internal-setup.md
+++ b/code/development-env/datalabs-internal-setup.md
@@ -39,7 +39,7 @@ To handle HTTPS requests to items running the cluster, we need to configure TLS 
 The first step of this is to create a TLS secret in our minikube cluster in the `devtest` namespace which will later be used in the ingress.
 
 ```bash
-kubectl delete secret tls-secret
+kubectl delete secret tls-secret -n devtest
 kubectl create secret tls tls-secret --key ./config/ca/datalabs.internal.key --cert ./config/ca/datalabs.internal.crt -n devtest
 ```
 

--- a/code/workspaces/client-api/src/dataaccess/minioTokenService.js
+++ b/code/workspaces/client-api/src/dataaccess/minioTokenService.js
@@ -22,7 +22,7 @@ const minioLogin = storage => (accessKeys) => {
     return Promise.reject(new Error('access_key or secret_key not defined'));
   }
 
-  return axios.post(getMinioLoginUrl(storage), createLoginPayload(accessKeys))
+  return axios.post(getMinioLoginUrl(storage), createLoginPayload(accessKeys), generateOptions())
     .then(processLoginResponse);
 };
 
@@ -42,6 +42,14 @@ function createLoginPayload(accessKeys) {
       password: accessKeys.secret_key,
     },
     method: 'Web.Login',
+  };
+}
+
+function generateOptions() {
+  return {
+    headers: {
+      'User-Agent': 'Mozilla',
+    },
   };
 }
 


### PR DESCRIPTION
In updating the minio image to https://hub.docker.com/layers/minio/minio/RELEASE.2017-11-22T19-55-46Z/images/sha256-28cbd73844f89766512b2194198574b49582d6056dfb06e6738bda3744d7a473?context=explore ,
which corresponds to https://github.com/minio/minio/releases/tag/RELEASE.2017-11-22T19-55-46Z,
the token download from minio's webrpc endpoint fails.  However, adding a User-Agent helps it work again.  This has been observed elsewhere, see https://bastide.org/minio-tips/