### PR TITLE
NERCDL-1050 move jupyter and jupyterlab to single host

### DIFF
--- a/architecture/decisions/0047-remove-need-for-wildcard-certificates.md
+++ b/architecture/decisions/0047-remove-need-for-wildcard-certificates.md
@@ -1,0 +1,27 @@
+# 47. Remove need for wildcard certificates
+
+Date: 2021-05-13
+
+## Status
+
+Accepted
+
+## Context
+
+DataLabs makes extensive use of reverse proxying, to give users access to resources (such as Minio or JupyterLabs).  These resources need individually from an external URL to an internal service URL.  There are four design options for reverse proxying (<http://sawers.com/blog/reverse-proxying-with-nginx/>):
+
+1. Subdomain - this allows the external path and internal path to be the same, probably with a default root base path (/).  Different services are identified by the external URL's hostname.  This has some disadvantages - multiple hostnames require a wildcard certificate, or multiple certificates if a wildcard certificate can not be acquired; and it makes the development environment more difficult, because you can not just use localhost.
+2. Port - this also allows the external path and internal path to be the same, probably with a default root base path (/).  Different services are identified by the external URL's port.  This has the disadvantage that some organisational firewalls restrict http traffic to unusual hosts.
+3. Symmetric Path - this allows the external path and internal path to be the same, but with that path configured.  Different services are identified by the path.  This is the best option, but the internal service must allow the path to be configurable.
+4. Asymmetric Path - here the external and internal paths are different.  Different services are identifiable by the external path.  This requires a search-and-replace of the path on the rendered HTML and JavaScript, so unless these are simple, then this is too fragile.
+
+Historically DataLabs has used Subdomain proxying.
+
+## Decision
+
+Where possible, Symmetric Path or Asymmetric Path proxying should be used.  If this is not possible, a ConfigMap option should determine whether the remaining proxying strategy should be Subdomain or Port proxying.
+
+## Consequences
+
+* Developer effort is required to develop the different proxying strategies.
+* Portability will be improved and local development will be simplified.

--- a/code/workspaces/common/src/config/catalogue.js
+++ b/code/workspaces/common/src/config/catalogue.js
@@ -1,5 +1,5 @@
 import data from './catalogue_asset_repo_config.json';
 
 export const catalogueAvailable = () => data.catalogue && data.catalogue.available;
-export const catalogueServer = () => catalogueAvailable() && data.catalogue.storage.server;
-export const catalogueFileLocation = () => catalogueAvailable() && data.catalogue.storage.rootDirectory;
+export const catalogueServer = () => (catalogueAvailable() ? data.catalogue.storage.server : null);
+export const catalogueFileLocation = () => (catalogueAvailable() ? data.catalogue.storage.rootDirectory : null);

--- a/code/workspaces/common/src/stackTypes.js
+++ b/code/workspaces/common/src/stackTypes.js
@@ -9,6 +9,15 @@ const PROJECT = 'project';
 const RSHINY = 'rshiny';
 const RSTUDIO = 'rstudio';
 const ZEPPELIN = 'zeppelin';
+const singleHostNameTypes = [JUPYTER, JUPYTERLAB];
+
+// returns true if this stack type can be handled by a single host name
+const isSingleHostName = type => singleHostNameTypes.includes(type);
+
+// base path for resources
+const basePath = (type, projectKey, name) => (isSingleHostName(type)
+  ? `/resource/${projectKey}/${name}`
+  : '/');
 
 export {
   DASK,
@@ -19,4 +28,6 @@ export {
   RSHINY,
   RSTUDIO,
   ZEPPELIN,
+  isSingleHostName,
+  basePath,
 };

--- a/code/workspaces/common/src/stackTypes.spec.js
+++ b/code/workspaces/common/src/stackTypes.spec.js
@@ -1,0 +1,15 @@
+import { JUPYTER, basePath } from './stackTypes';
+
+describe('stackTypes', () => {
+  describe('basePath', () => {
+    const projectKey = 'project-key';
+    const name = 'name';
+    it('gives custom base path if type is for single hostname', () => {
+      expect(basePath(JUPYTER, projectKey, name)).toEqual('/resource/project-key/name');
+    });
+
+    it('gives root base path if type is for multiple hostname', () => {
+      expect(basePath('assumed-to-be-multiple', projectKey, name)).toEqual('/');
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/package.json
+++ b/code/workspaces/infrastructure-api/package.json
@@ -22,8 +22,8 @@
     "lodash": "4.17.19",
     "mongoose": "5.7.5",
     "mustache": "3.0.1",
-    "uuid": "3.3.2",
     "service-chassis": "^0.1.0",
+    "uuid": "3.3.2",
     "winston": "3.2.1"
   },
   "devDependencies": {

--- a/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
@@ -46,9 +46,10 @@ spec:
           name: {{ name }}
           command: ["start.sh",
             "jupyter", "{{ startCmd }}",
-            "--NotebookApp.token='$(JUPYTER_TOKEN)'",
-            "--NotebookApp.allow_origin='{{ domain }}'",
-            "--NotebookApp.notebook_dir='/data/notebooks/{{ name }}'"]
+            "--NotebookApp.token=$(JUPYTER_TOKEN)",
+            "--NotebookApp.allow_origin={{ domain }}",
+            "--NotebookApp.notebook_dir=/data/notebooks/{{ name }}",
+            "--NotebookApp.base_url={{{ basePath }}}"]
           ports:
             - containerPort: 8888
               protocol: TCP
@@ -77,7 +78,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: /
+              path: {{{ basePath }}}
               port: 8888
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/code/workspaces/infrastructure-api/src/config/config.js
+++ b/code/workspaces/infrastructure-api/src/config/config.js
@@ -7,6 +7,12 @@ const config = convict({
     default: 'info',
     env: 'LOG_LEVEL',
   },
+  datalabName: {
+    doc: 'The name of the datalab',
+    format: 'String',
+    default: 'testlab',
+    env: 'DATALAB_NAME',
+  },
   datalabDomain: {
     doc: 'The domain the datalabs instance is running on',
     format: 'String',

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -274,9 +274,10 @@ spec:
           name: deployment-name
           command: [\\"start.sh\\",
             \\"jupyter\\", \\"lab\\",
-            \\"--NotebookApp.token='$(JUPYTER_TOKEN)'\\",
-            \\"--NotebookApp.allow_origin='project-key-notebook-name.datalabs.localhost'\\",
-            \\"--NotebookApp.notebook_dir='/data/notebooks/deployment-name'\\"]
+            \\"--NotebookApp.token=$(JUPYTER_TOKEN)\\",
+            \\"--NotebookApp.allow_origin=project-key-notebook-name.datalabs.localhost\\",
+            \\"--NotebookApp.notebook_dir=/data/notebooks/deployment-name\\",
+            \\"--NotebookApp.base_url=/resource/project-key/notebook-name\\"]
           ports:
             - containerPort: 8888
               protocol: TCP
@@ -305,7 +306,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: /
+              path: /resource/project-key/notebook-name
               port: 8888
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/ingressGenerator.spec.js.snap
@@ -191,3 +191,28 @@ spec:
           servicePort: 80
 "
 `;
+
+exports[`Ingress generator should use datalab hostname and custom path for single hostname type 1`] = `
+"---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: name-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 50g
+spec:
+  tls:
+  - hosts:
+    - testlab.datalabs.localhost
+  rules:
+  - host: testlab.datalabs.localhost
+    http:
+      paths:
+      - path: /resource/project/name
+        backend:
+          serviceName: name-service
+          servicePort: 80
+"
+`;

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -1,8 +1,11 @@
 import { imageConfig, image, defaultImage } from 'common/src/config/images';
+import { stackTypes } from 'common';
 import { DeploymentTemplates, ServiceTemplates, generateManifest, ConfigMapTemplates, NetworkPolicyTemplates, AutoScalerTemplates } from './manifestGenerator';
 import nameGenerator from '../common/nameGenerators';
 import config from '../config/config';
 import logger from '../config/logger';
+
+const { basePath } = stackTypes;
 
 const containerInfo = imageConfig();
 
@@ -15,13 +18,14 @@ function getImage(type, version) {
   }
 }
 
-function createJupyterDeployment({ projectKey, deploymentName, notebookName, type, volumeMount, version }) {
+function createJupyterDeployment({ projectKey, deploymentName, name, type, volumeMount, version }) {
   const startCmd = type === 'jupyterlab' ? 'lab' : 'notebook';
   const img = getImage(type, version);
   const context = {
     name: deploymentName,
     grantSudo: 'yes',
-    domain: `${projectKey}-${notebookName}.${config.get('datalabDomain')}`,
+    domain: `${projectKey}-${name}.${config.get('datalabDomain')}`,
+    basePath: basePath(type, projectKey, name),
     jupyter: {
       image: img.image,
     },

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -93,7 +93,7 @@ describe('deploymentGenerator', () => {
     const params = {
       projectKey: 'project-key',
       deploymentName: 'deployment-name',
-      notebookName: 'notebook-name',
+      name: 'notebook-name',
       type: 'jupyterlab',
       volumeMount: 'volume-mount',
     };

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
@@ -1,3 +1,4 @@
+import { JUPYTER } from 'common/src/stackTypes';
 import ingressGenerator from './ingressGenerator';
 import config from '../config/config';
 
@@ -99,6 +100,20 @@ describe('Ingress generator', () => {
       serviceName: 'name-service',
       port: 80,
       proxyRequestBuffering: 'off',
+    };
+    const template = ingressGenerator.createIngress(options);
+
+    return expect(template).resolves.toMatchSnapshot();
+  });
+
+  it('should use datalab hostname and custom path for single hostname type', () => {
+    const options = {
+      name: 'name',
+      projectKey: 'project',
+      ingressName: 'name-ingress',
+      serviceName: 'name-service',
+      port: 80,
+      type: JUPYTER,
     };
     const template = ingressGenerator.createIngress(options);
 

--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/stackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/stackManager.spec.js.snap
@@ -30,7 +30,7 @@ Array [
       "projectKey": "project",
       "status": "requested",
       "type": "jupyter",
-      "url": "https://project-expectedName.datalabs.localhost",
+      "url": "https://testlab.datalabs.localhost/resource/project/expectedName",
     },
   ],
 ]

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { stackTypes } from 'common';
 import logger from '../config/logger';
 import deploymentApi from '../kubernetes/deploymentApi';
 import serviceApi from '../kubernetes/serviceApi';
@@ -9,6 +10,8 @@ import networkPolicyApi from '../kubernetes/networkPolicyApi';
 import autoScalerApi from '../kubernetes/autoScalerApi';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';
 import nameGenerator from '../common/nameGenerators';
+
+const { basePath } = stackTypes;
 
 export const createDeployment = (params, generator) => () => {
   const { name, projectKey, type } = params;
@@ -89,8 +92,9 @@ export const createIngressRule = (params, generator) => (service) => {
   const ingressName = nameGenerator.deploymentName(name, type);
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];
+  const base = basePath(type, projectKey, name);
 
-  return generator({ ...params, ingressName, serviceName, port })
+  return generator({ ...params, ingressName, serviceName, port, basePath: base })
     .then((manifest) => {
       logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with manifest:`);
       logger.debug(manifest.toString());

--- a/code/workspaces/infrastructure-api/src/stacks/stackManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackManager.spec.js
@@ -1,4 +1,5 @@
 import * as catalogueConfig from 'common/src/config/catalogue';
+import { JUPYTER } from 'common/src/stackTypes';
 import Stacks from './Stacks';
 import * as stackRepository from '../dataaccess/stacksRepository';
 import stackManager from './stackManager';
@@ -247,6 +248,19 @@ describe('Stack Controller', () => {
         expect(mock).toHaveBeenCalledTimes(1);
         expect(mock.mock.calls[0]).toMatchSnapshot();
       }
+    });
+  });
+
+  describe('url', () => {
+    const projectKey = 'project-key';
+    const name = 'name';
+
+    it('gives correct url when single hostname', () => {
+      expect(stackManager.url(projectKey, name, JUPYTER)).toEqual('https://testlab.datalabs.localhost/resource/project-key/name');
+    });
+
+    it('gives correct url when multiple hostname', () => {
+      expect(stackManager.url(projectKey, name, 'assumed-multiple-hostname')).toEqual('https://project-key-name.datalabs.localhost');
     });
   });
 });

--- a/code/workspaces/web-app/src/components/assetRepo/AddRepoMetadataDetails.spec.js
+++ b/code/workspaces/web-app/src/components/assetRepo/AddRepoMetadataDetails.spec.js
@@ -6,7 +6,7 @@ import * as assetRepoHooks from '../../hooks/assetRepoHooks';
 
 jest.mock('../../hooks/reduxFormHooks');
 jest.mock('../../hooks/assetRepoHooks');
-reduxFormHooks.useReduxFormValue = jest.fn().mockResolvedValue('value');
+reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue('value');
 assetRepoHooks.useAssetRepo = jest.fn().mockReturnValue({ fetching: false, value: { createdAssetId: null } });
 
 describe('AddRepoMetadataDetails', () => {

--- a/code/workspaces/web-app/src/components/assetRepo/EditRepoMetadataForm.spec.js
+++ b/code/workspaces/web-app/src/components/assetRepo/EditRepoMetadataForm.spec.js
@@ -4,7 +4,7 @@ import { PureEditRepoMetadataForm } from './EditRepoMetadataForm';
 import * as reduxFormHooks from '../../hooks/reduxFormHooks';
 
 jest.mock('../../hooks/reduxFormHooks');
-reduxFormHooks.useReduxFormValue = jest.fn().mockResolvedValue('value');
+reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue('value');
 
 describe('EditRepoMetadataForm', () => {
   const shallowRender = () => shallow(

--- a/code/workspaces/web-app/src/components/notebooks/CreateNotebookForm.js
+++ b/code/workspaces/web-app/src/components/notebooks/CreateNotebookForm.js
@@ -6,6 +6,7 @@ import { formatAndParseMultiSelect, CreateFormControls, renderAdornedTextField, 
 import { getAsyncValidate, syncValidate } from './createNotebookFormValidator';
 import getUrlNameStartEndText from '../../core/urlHelper';
 import AssetMultiSelect from '../common/form/AssetMultiSelect';
+import { useReduxFormValue } from '../../hooks/reduxFormHooks';
 
 export const FORM_NAME = 'createNotebook';
 const NAME_FIELD_NAME = 'name';
@@ -20,7 +21,8 @@ const commonProps = {
 const CreateNotebookForm = ({
   handleSubmit, cancel, submitting, dataStorageOptions, projectKey, typeOptions, versionOptions,
 }) => {
-  const { startText, endText } = getUrlNameStartEndText(projectKey, window.location);
+  const typeValue = useReduxFormValue(FORM_NAME, TYPE_FIELD_NAME);
+  const { startText, endText } = getUrlNameStartEndText(projectKey, window.location, typeValue);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/code/workspaces/web-app/src/components/notebooks/CreateNotebookForm.spec.js
+++ b/code/workspaces/web-app/src/components/notebooks/CreateNotebookForm.spec.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { JUPYTER } from 'common/src/stackTypes';
 import { PureCreateNotebookForm } from './CreateNotebookForm';
+import * as reduxFormHooks from '../../hooks/reduxFormHooks';
+
+jest.mock('../../hooks/reduxFormHooks');
+reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue('value');
 
 describe('CreateNotebookForm', () => {
   function shallowRender(props) {
@@ -44,6 +49,18 @@ describe('CreateNotebookForm', () => {
   it('creates correct snapshot for create Notebook Form when there are not version options', () => {
     // Arrange
     const props = generateProps();
+
+    // Act
+    const output = shallowRender(props);
+
+    // Assert
+    expect(output).toMatchSnapshot();
+  });
+
+  it('creates correct snapshot for create Notebook Form when the type supports single hostname', () => {
+    // Arrange
+    const props = generateProps();
+    reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue(JUPYTER);
 
     // Act
     const output = shallowRender(props);

--- a/code/workspaces/web-app/src/components/notebooks/__snapshots__/CreateNotebookForm.spec.js.snap
+++ b/code/workspaces/web-app/src/components/notebooks/__snapshots__/CreateNotebookForm.spec.js.snap
@@ -1,5 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CreateNotebookForm creates correct snapshot for create Notebook Form when the type supports single hostname 1`] = `
+<form>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      label="Display Name"
+      name="displayName"
+      placeholder="Display Name"
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      label="Type"
+      name="type"
+      options={
+        Array [
+          Object {
+            "text": "JupyterLab",
+            "value": "JUPYTER_LAB",
+          },
+          Object {
+            "text": "Jupyter",
+            "value": "JUPYTER",
+          },
+          Object {
+            "text": "RStudio",
+            "value": "RSTUDIO",
+          },
+          Object {
+            "text": "Zeppelin",
+            "value": "ZEPPELIN",
+          },
+        ]
+      }
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      endText=""
+      label="URL Name"
+      name="name"
+      placeholder="Notebook Name for URL"
+      startText="http://localhost/resource/testproj/"
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      label="Data Store to Mount"
+      name="volumeMount"
+      options={
+        Array [
+          Object {
+            "text": "First Data Store",
+            "value": "alpha",
+          },
+          Object {
+            "text": "Second Data Store",
+            "value": "beta",
+          },
+        ]
+      }
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      label="Description"
+      name="description"
+      placeholder="Description"
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      label="Sharing Status"
+      name="shared"
+      options={
+        Array [
+          Object {
+            "text": <SelectRichComponent
+              title="Private"
+              type="notebook"
+            />,
+            "value": "private",
+          },
+          Object {
+            "text": <SelectRichComponent
+              title="Project"
+              type="notebook"
+            />,
+            "value": "project",
+          },
+        ]
+      }
+    />
+  </div>
+  <div>
+    <Field
+      InputLabelProps={
+        Object {
+          "shrink": true,
+        }
+      }
+      component={[Function]}
+      format={[Function]}
+      label="Assets"
+      name="assets"
+      parse={[Function]}
+      projectKey="testproj"
+    />
+  </div>
+  <CreateFormControls
+    onCancel={[MockFunction]}
+  />
+</form>
+`;
+
 exports[`CreateNotebookForm creates correct snapshot for create Notebook Form when there are not version options 1`] = `
 <form>
   <div>

--- a/code/workspaces/web-app/src/core/urlHelper.js
+++ b/code/workspaces/web-app/src/core/urlHelper.js
@@ -1,4 +1,20 @@
-export default function getUrlNameStartEndText(projectKey, windowLocation) {
+import { stackTypes } from 'common';
+import { join } from 'path';
+
+const { isSingleHostName, basePath } = stackTypes;
+
+export default function getUrlNameStartEndText(projectKey, windowLocation, type) {
+  return isSingleHostName(type) ? singleHostName(projectKey, windowLocation, type) : multiHostName(projectKey, windowLocation);
+}
+
+function singleHostName(projectKey, windowLocation, type) {
+  const hostAndPath = join(windowLocation.hostname, basePath(type, projectKey, ''));
+  const startText = `${windowLocation.protocol}//${hostAndPath}`;
+  const endText = '';
+  return { startText, endText };
+}
+
+function multiHostName(projectKey, windowLocation) {
   const separator = '.';
   const restHostname = windowLocation.hostname.split(separator).slice(1);
   const startText = `${windowLocation.protocol}//${projectKey}-`;

--- a/code/workspaces/web-app/src/core/urlHelper.spec.js
+++ b/code/workspaces/web-app/src/core/urlHelper.spec.js
@@ -1,3 +1,4 @@
+import { JUPYTER } from 'common/src/stackTypes';
 import getUrlNameStartEndText from './urlHelper';
 
 const projectKey = 'testproj';
@@ -8,7 +9,8 @@ describe('getUrlNameStartEndText', () => {
       protocol: 'https:',
       hostname: 'localhost',
     };
-    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation);
+    const type = 'assumed-multiple-host';
+    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation, type);
 
     expect(startText).toEqual('https://testproj-');
     expect(endText).toEqual('.datalabs.localhost');
@@ -19,7 +21,8 @@ describe('getUrlNameStartEndText', () => {
       protocol: 'https:',
       hostname: 'testlab.datalabs.localhost',
     };
-    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation);
+    const type = 'assumed-multiple-host';
+    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation, type);
 
     expect(startText).toEqual('https://testproj-');
     expect(endText).toEqual('.datalabs.localhost');
@@ -30,9 +33,21 @@ describe('getUrlNameStartEndText', () => {
       protocol: 'https:',
       hostname: 'datalab.datalabs.nerc.ac.uk',
     };
-    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation);
+    const type = 'assumed-multiple-host';
+    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation, type);
 
     expect(startText).toEqual('https://testproj-');
     expect(endText).toEqual('.datalabs.nerc.ac.uk');
+  });
+
+  it('returns correct values when single hostname on datalab.datalabs.nerc.ac.uk', () => {
+    const windowLocation = {
+      protocol: 'https:',
+      hostname: 'datalab.datalabs.nerc.ac.uk',
+    };
+    const { startText, endText } = getUrlNameStartEndText(projectKey, windowLocation, JUPYTER);
+
+    expect(startText).toEqual('https://datalab.datalabs.nerc.ac.uk/resource/testproj/');
+    expect(endText).toEqual('');
   });
 });


### PR DESCRIPTION
The key changes are in:

code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml 
```
"--NotebookApp.base_url={{{ basePath }}}"]
```
This runs the internal service at a url of e.g.  http://jupyterlab-labname-7c4ff5697c-l9ch2:8888/resource/andyl/labname/lab?token=...

We can then use Symmetric Path proxying to the external URL https://testlab.datalabs.internal/resource/andyl/labname/lab?token=...

This is done in code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.js
```
  const paths = [];
  const base = basePath(type, projectKey, name);
  paths.push({
    path: base,
```

The other changes all follow on from there.