### PR TITLE
NERCDL-1052 single host for rstudio

### DIFF
--- a/code/development-env/config/local/image_config.json
+++ b/code/development-env/config/local/image_config.json
@@ -96,12 +96,12 @@
           "default": true,
           "displayName": "4.0.1",
           "image": "nerc/rstudio:4.0.1",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         },
         {
           "displayName": "3.5.3",
           "image": "nerc/rstudio:3.5.3",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     },
@@ -122,7 +122,7 @@
         {
           "displayName": "0.7.2.7",
           "image": "nerc/zeppelin:0.7.2.7",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     }

--- a/code/workspaces/common/src/config/__snapshots__/images.spec.js.snap
+++ b/code/workspaces/common/src/config/__snapshots__/images.spec.js.snap
@@ -7,13 +7,13 @@ Object {
   "userSelectableVersion": true,
   "versions": Array [
     Object {
-      "connectImage": "nerc/zeppelin-connect:1.1.1",
+      "connectImage": "nerc/zeppelin-connect:1.2.0",
       "default": true,
       "displayName": "4.0.1",
       "image": "nerc/rstudio:4.0.1",
     },
     Object {
-      "connectImage": "nerc/zeppelin-connect:1.1.1",
+      "connectImage": "nerc/zeppelin-connect:1.2.0",
       "displayName": "3.5.3",
       "image": "nerc/rstudio:3.5.3",
     },
@@ -28,13 +28,13 @@ Object {
   "userSelectableVersion": true,
   "versions": Array [
     Object {
-      "connectImage": "nerc/zeppelin-connect:1.1.1",
+      "connectImage": "nerc/zeppelin-connect:1.2.0",
       "default": true,
       "displayName": "4.0.1",
       "image": "nerc/rstudio:4.0.1",
     },
     Object {
-      "connectImage": "nerc/zeppelin-connect:1.1.1",
+      "connectImage": "nerc/zeppelin-connect:1.2.0",
       "displayName": "3.5.3",
       "image": "nerc/rstudio:3.5.3",
     },

--- a/code/workspaces/common/src/config/image_config.json
+++ b/code/workspaces/common/src/config/image_config.json
@@ -97,12 +97,12 @@
           "default": true,
           "displayName": "4.0.1",
           "image": "nerc/rstudio:4.0.1",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         },
         {
           "displayName": "3.5.3",
           "image": "nerc/rstudio:3.5.3",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     },
@@ -123,7 +123,7 @@
         {
           "displayName": "0.7.2.7",
           "image": "nerc/zeppelin:0.7.2.7",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     }

--- a/code/workspaces/common/src/stackTypes.js
+++ b/code/workspaces/common/src/stackTypes.js
@@ -9,7 +9,7 @@ const PROJECT = 'project';
 const RSHINY = 'rshiny';
 const RSTUDIO = 'rstudio';
 const ZEPPELIN = 'zeppelin';
-const singleHostNameTypes = [JUPYTER, JUPYTERLAB];
+const singleHostNameTypes = [JUPYTER, JUPYTERLAB, RSTUDIO];
 
 // returns true if this stack type can be handled by a single host name
 const isSingleHostName = type => singleHostNameTypes.includes(type);

--- a/code/workspaces/infrastructure-api/resources/rstudio.configmap.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.configmap.template.yml
@@ -5,4 +5,4 @@ metadata:
   name: {{ configMapName }}
 data:
   config: |
-    www-root-path=/
+    www-root-path={{{ basePath }}}

--- a/code/workspaces/infrastructure-api/resources/rstudio.configmap.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.configmap.template.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ configMapName }}
+data:
+  config: |
+    www-root-path=/

--- a/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
@@ -90,16 +90,27 @@ spec:
               port: 8787
             initialDelaySeconds: 5
             periodSeconds: 10
-{{#volumeMount}}
           volumeMounts:
+{{#volumeMount}}
             - name: persistentfsvol
               mountPath: /data
             - name: homedir
               mountPath: /home
+{{/volumeMount}}
+            - name: rstudio-notebook-config
+              mountPath: /etc/rstudio/rserver.conf
+              subPath: rserver.conf
       volumes:
+{{#volumeMount}}
         - name: persistentfsvol
           persistentVolumeClaim:
             claimName: {{ volumeMount }}-claim
         - name: homedir
           emptyDir: {}
 {{/volumeMount}}
+        - name: rstudio-notebook-config
+          configMap:
+            name: {{ rstudioConfigMapName }}
+            items:
+            - key: config
+              path: rserver.conf

--- a/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
@@ -57,7 +57,7 @@ spec:
               value: RSTUDIO
           livenessProbe:
             httpGet:
-              path: /status
+              path: {{{ basePath }}}/status
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -86,7 +86,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: /
+              path: {{{ basePath }}}
               port: 8787
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
@@ -57,7 +57,7 @@ spec:
               value: RSTUDIO
           livenessProbe:
             httpGet:
-              path: {{{ basePath }}}/status
+              path: /status
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -86,7 +86,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: {{{ basePath }}}
+              path: /
               port: 8787
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -97,7 +97,7 @@ spec:
             - name: homedir
               mountPath: /home
 {{/volumeMount}}
-            - name: rstudio-notebook-config
+            - name: rstudio-rserver-config
               mountPath: /etc/rstudio/rserver.conf
               subPath: rserver.conf
       volumes:
@@ -108,7 +108,7 @@ spec:
         - name: homedir
           emptyDir: {}
 {{/volumeMount}}
-        - name: rstudio-notebook-config
+        - name: rstudio-rserver-config
           configMap:
             name: {{ rstudioConfigMapName }}
             items:

--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.js
@@ -22,7 +22,7 @@ const computeSubmissionClusterRole = () => 'compute-submission-role';
 const pySparkConfigMap = deploymentName => `${deploymentName}-pyspark-config`;
 const daskConfigMap = deploymentName => `${deploymentName}-dask-config`;
 const jupyterConfigMap = deploymentName => `${deploymentName}-jupyter-config`;
-const rStudioConfigMap = deploymentName => `${deploymentName}-rstudio-config`;
+const rStudioConfigMap = deploymentName => `${deploymentName}-rserver-config`;
 const sparkDriverHeadlessService = deploymentServiceName => `${deploymentServiceName}-spark-driver-headless-service`;
 const sparkJob = deploymentName => `${deploymentName}-spark-job`;
 

--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.js
@@ -22,6 +22,7 @@ const computeSubmissionClusterRole = () => 'compute-submission-role';
 const pySparkConfigMap = deploymentName => `${deploymentName}-pyspark-config`;
 const daskConfigMap = deploymentName => `${deploymentName}-dask-config`;
 const jupyterConfigMap = deploymentName => `${deploymentName}-jupyter-config`;
+const rStudioConfigMap = deploymentName => `${deploymentName}-rstudio-config`;
 const sparkDriverHeadlessService = deploymentServiceName => `${deploymentServiceName}-spark-driver-headless-service`;
 const sparkJob = deploymentName => `${deploymentName}-spark-job`;
 
@@ -41,6 +42,7 @@ export default {
   pySparkConfigMap,
   daskConfigMap,
   jupyterConfigMap,
+  rStudioConfigMap,
   sparkDriverHeadlessService,
   sparkJob,
   stackCredentialSecret,

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -152,6 +152,18 @@ spec:
 "
 `;
 
+exports[`deploymentGenerator createRStudioConfigMap produces expected configmap 1`] = `
+"---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-name
+data:
+  config: |
+    www-root-path=/base/path
+"
+`;
+
 exports[`deploymentGenerator generates createAutoScaler manifest 1`] = `
 "apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -164,6 +164,122 @@ data:
 "
 `;
 
+exports[`deploymentGenerator createRStudioDeployment creates expected manifest 1`] = `
+"---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: rstudio-name
+  name: rstudio-name
+spec:
+  selector:
+    matchLabels:
+      name: rstudio-name
+  template:
+    metadata:
+      labels:
+        name: rstudio-name
+        user-pod: rstudio
+    spec:
+      initContainers:
+        # This container will generate the RStudio notebooks directory. RStudio starts with /home/datalabs as its initial
+        # start-up/default directory and has not environmental variable to change it. This is fixed by mounting an empty
+        # directory as /home and created a symlink datalabs pointing to /data/notebooks/rstudio
+        - name: create-notebook-folders
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: [\\"sh\\"]
+          args: [\\"-c\\", \\"mkdir -p /data/notebooks/rstudio-name\\"]
+          volumeMounts:
+            - mountPath: /data
+              name: persistentfsvol
+        # This container sets the folder permissions for the generated notebook directory to be usable by
+        # datalabs:users.
+        - name: set-directory-permissions
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: [\\"sh\\"]
+          args: [\\"-c\\", \\"chmod 777 /data/notebooks && chmod 777 /data/notebooks/rstudio-name\\"]
+          volumeMounts:
+            - mountPath: /data
+              name: persistentfsvol
+        # This container will create the /home/datalabs to /data/notebooks/rstudio symlink
+        - name: create-datalab-symlink
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: [\\"sh\\", \\"-c\\", \\"ln -s /data/notebooks/rstudio-name/ /home/datalab\\"]
+          volumeMounts:
+            - mountPath: /home
+              name: homedir
+      containers:
+        - name: rstudio-name-connect
+          image: nerc/zeppelin-connect:1.2.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: CONNECT_TYPE
+              value: RSTUDIO
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+        - name: rstudio-name
+          image: nerc/rstudio:4.0.1
+          imagePullPolicy : IfNotPresent
+          ports:
+            - containerPort: 8787
+              protocol: TCP
+          env:
+            - name: USER
+              value: datalab
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rstudio-name
+                  key: password
+            - name: ROOT
+              value: 'TRUE'
+          resources:
+            requests:
+              cpu: 200m
+              memory: 128Mi
+            limits:
+              cpu: 2
+              memory: 8Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8787
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: persistentfsvol
+              mountPath: /data
+            - name: homedir
+              mountPath: /home
+            - name: rstudio-rserver-config
+              mountPath: /etc/rstudio/rserver.conf
+              subPath: rserver.conf
+      volumes:
+        - name: persistentfsvol
+          persistentVolumeClaim:
+            claimName: volumeMount-claim
+        - name: homedir
+          emptyDir: {}
+        - name: rstudio-rserver-config
+          configMap:
+            name: rstudio-name-rserver-config
+            items:
+            - key: config
+              path: rserver.conf
+"
+`;
+
 exports[`deploymentGenerator generates createAutoScaler manifest 1`] = `
 "apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -89,7 +89,7 @@ function createZeppelinDeployment({ deploymentName, volumeMount, type, version }
   return generateManifest(context, DeploymentTemplates.ZEPPELIN_DEPLOYMENT);
 }
 
-function createRStudioDeployment({ deploymentName, volumeMount, type, version }) {
+function createRStudioDeployment({ deploymentName, volumeMount, type, version, projectKey, name }) {
   const img = getImage(type, version);
   const context = {
     name: deploymentName,
@@ -97,6 +97,7 @@ function createRStudioDeployment({ deploymentName, volumeMount, type, version })
       image: img.image,
       connectImage: img.connectImage,
     },
+    rstudioConfigMapName: nameGenerator.rStudioConfigMap(deploymentName),
     type,
     volumeMount,
   };

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -231,8 +231,8 @@ function createJupyterConfigMap(configMapName) {
   return generateManifest(context, ConfigMapTemplates.JUPYTER_CONFIGMAP);
 }
 
-function createRStudioConfigMap(configMapName) {
-  const context = { configMapName };
+function createRStudioConfigMap(configMapName, base) {
+  const context = { configMapName, basePath: base };
   return generateManifest(context, ConfigMapTemplates.RSTUDIO_CONFIGMAP);
 }
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -227,6 +227,11 @@ function createJupyterConfigMap(configMapName) {
   return generateManifest(context, ConfigMapTemplates.JUPYTER_CONFIGMAP);
 }
 
+function createRStudioConfigMap(configMapName) {
+  const context = { configMapName };
+  return generateManifest(context, ConfigMapTemplates.RSTUDIO_CONFIGMAP);
+}
+
 function createDatalabDaskSchedulerNetworkPolicy({ networkPolicyName, schedulerPodLabel, projectKey }) {
   const context = { name: networkPolicyName, schedulerPodLabel, projectKey };
   return generateManifest(context, NetworkPolicyTemplates.DATALAB_DASK_SCHEDULER_NETWORK_POLICY);
@@ -261,6 +266,7 @@ export default {
   createPySparkConfigMap,
   createDaskConfigMap,
   createJupyterConfigMap,
+  createRStudioConfigMap,
   createDatalabDaskSchedulerDeployment,
   createDatalabDaskWorkerDeployment,
   createDatalabDaskSchedulerService,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -89,7 +89,7 @@ function createZeppelinDeployment({ deploymentName, volumeMount, type, version }
   return generateManifest(context, DeploymentTemplates.ZEPPELIN_DEPLOYMENT);
 }
 
-function createRStudioDeployment({ deploymentName, volumeMount, type, version, projectKey, name }) {
+function createRStudioDeployment({ deploymentName, volumeMount, type, version }) {
   const img = getImage(type, version);
   const context = {
     name: deploymentName,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -1,3 +1,4 @@
+import { stackTypes } from 'common';
 import deploymentGenerator from './deploymentGenerator';
 import config from '../config/config';
 
@@ -104,6 +105,19 @@ describe('deploymentGenerator', () => {
   describe('createRStudioConfigMap', () => {
     it('produces expected configmap', async () => {
       const manifest = await deploymentGenerator.createRStudioConfigMap('configmap-name', '/base/path');
+      expect(manifest).toMatchSnapshot();
+    });
+  });
+
+  describe('createRStudioDeployment', () => {
+    it('creates expected manifest', async () => {
+      const deploymentName = 'rstudio-name';
+      const volumeMount = 'volumeMount';
+      const type = stackTypes.RSTUDIO;
+      const version = '4.0.1';
+      const projectKey = 'projectKey';
+      const name = 'name';
+      const manifest = await deploymentGenerator.createRStudioDeployment({ deploymentName, volumeMount, type, version, projectKey, name });
       expect(manifest).toMatchSnapshot();
     });
   });

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -100,4 +100,11 @@ describe('deploymentGenerator', () => {
     const manifest = await deploymentGenerator.createJupyterDeployment(params);
     expect(manifest).toMatchSnapshot();
   });
+
+  describe('createRStudioConfigMap', () => {
+    it('produces expected configmap', async () => {
+      const manifest = await deploymentGenerator.createRStudioConfigMap('configmap-name', '/base/path');
+      expect(manifest).toMatchSnapshot();
+    });
+  });
 });

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.js
@@ -1,12 +1,11 @@
-import { isSingleHostName, basePath } from 'common/src/stackTypes';
-import { join } from 'path';
+import { isSingleHostName } from 'common/src/stackTypes';
 import config from '../config/config';
 import { IngressTemplates, generateManifest } from './manifestGenerator';
 
 function createIngress({ name, projectKey, ingressName, serviceName, port,
-  connectPort, rewriteTarget, proxyTimeout, visible, proxyRequestBuffering, type }) {
+  connectPort, path, connectPath, rewriteTarget, proxyTimeout, visible, proxyRequestBuffering, type }) {
   const host = createSniInfo(name, projectKey, type);
-  const paths = createPathInfo(serviceName, port, connectPort, type, projectKey, name);
+  const paths = createPathInfo(serviceName, port, connectPort, path, connectPath);
   const privateEndpoint = visible !== 'public';
   const authServiceUrlRoot = config.get('authorisationServiceForIngress') || config.get('authorisationService');
   const context = {
@@ -32,18 +31,17 @@ function createSniInfo(name, projectKey, type) {
     : `${projectKey}-${name}.${domain}`;
 }
 
-function createPathInfo(serviceName, port, connectPort, type, projectKey, name) {
+function createPathInfo(serviceName, port, connectPort, path, connectPath) {
   const paths = [];
-  const base = basePath(type, projectKey, name);
   paths.push({
-    path: base,
+    path,
     serviceName,
     servicePort: port,
   });
 
   if (connectPort) {
     paths.push({
-      path: join(base, 'connect'),
+      path: connectPath,
       serviceName,
       servicePort: connectPort,
     });

--- a/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/ingressGenerator.spec.js
@@ -14,6 +14,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
+      path: '/',
     };
     const template = ingressGenerator.createIngress(options);
 
@@ -28,6 +29,8 @@ describe('Ingress generator', () => {
       serviceName: 'name-service',
       port: 80,
       connectPort: 8000,
+      path: '/',
+      connectPath: '/connect',
     };
     const template = ingressGenerator.createIngress(options);
 
@@ -42,6 +45,8 @@ describe('Ingress generator', () => {
       serviceName: 'name-service',
       port: 80,
       connectPort: 8000,
+      path: '/',
+      connectPath: '/connect',
       rewriteTarget: '/here',
     };
     const template = ingressGenerator.createIngress(options);
@@ -57,6 +62,8 @@ describe('Ingress generator', () => {
       serviceName: 'name-service',
       port: 80,
       connectPort: 8000,
+      path: '/',
+      connectPath: '/connect',
       proxyTimeout: '1800',
     };
     const template = ingressGenerator.createIngress(options);
@@ -71,6 +78,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
+      path: '/',
       visible: 'private',
     };
     const template = ingressGenerator.createIngress(options);
@@ -85,6 +93,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
+      path: '/',
       visible: 'public',
     };
     const template = ingressGenerator.createIngress(options);
@@ -99,6 +108,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
+      path: '/',
       proxyRequestBuffering: 'off',
     };
     const template = ingressGenerator.createIngress(options);
@@ -113,6 +123,7 @@ describe('Ingress generator', () => {
       ingressName: 'name-ingress',
       serviceName: 'name-service',
       port: 80,
+      path: '/resource/project/name',
       type: JUPYTER,
     };
     const template = ingressGenerator.createIngress(options);

--- a/code/workspaces/infrastructure-api/src/kubernetes/manifestGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/manifestGenerator.js
@@ -41,6 +41,7 @@ const ConfigMapTemplates = Object.freeze({
   PYSPARK_CONFIGMAP: 'pyspark.configmap.template.yml',
   DASK_CONFIGMAP: 'dask.configmap.template.yml',
   JUPYTER_CONFIGMAP: 'jupyter.configmap.template.yml',
+  RSTUDIO_CONFIGMAP: 'rstudio.configmap.template.yml',
 });
 
 const NetworkPolicyTemplates = Object.freeze({

--- a/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
@@ -4,28 +4,37 @@ import deploymentApi from '../kubernetes/deploymentApi';
 import serviceApi from '../kubernetes/serviceApi';
 import ingressGenerator from '../kubernetes/ingressGenerator';
 import ingressApi from '../kubernetes/ingressApi';
-import { createDeployment, createService, createIngressRuleWithConnect, createRStudioConfigMap } from './stackBuilders';
+import { createDeployment, createService, createIngressRule, createConnectIngressRule, createRStudioConfigMap } from './stackBuilders';
 import nameGenerators from '../common/nameGenerators';
+import configMapApi from '../kubernetes/configMapApi';
 
 function createRStudioStack(params) {
   const { projectKey, name, type } = params;
   const credentials = secretManager.createNewUserCredentials();
   const proxyTimeout = '1800';
+  const rewriteTarget = '/$2';
+  const pathPattern = '(/|$)(.*)';
 
   return secretManager.createStackCredentialSecret(name, type, projectKey, credentials)
     .then(createRStudioConfigMap(params))
     .then(createDeployment(params, deploymentGenerator.createRStudioDeployment))
     .then(createService(params, deploymentGenerator.createRStudioService))
-    .then(createIngressRuleWithConnect({ ...params, proxyTimeout }, ingressGenerator.createIngress));
+    .then(createIngressRule({ ...params, proxyTimeout, rewriteTarget, pathPattern }, ingressGenerator.createIngress))
+    // Note - the pathPattern is required, even though there's no rewriteTarget
+    // in order to ensure the connect path is long enough to be matched before the main service
+    .then(createConnectIngressRule({ ...params, proxyTimeout, pathPattern }, ingressGenerator.createIngress));
 }
 
 function deleteRStudioStack(params) {
   const { projectKey, name, type } = params;
   const k8sName = nameGenerators.deploymentName(name, type);
+  const connectK8sName = `${k8sName}-connect`;
 
-  return ingressApi.deleteIngress(k8sName, projectKey)
+  return ingressApi.deleteIngress(connectK8sName, projectKey)
+    .then(() => ingressApi.deleteIngress(k8sName, projectKey))
     .then(() => serviceApi.deleteService(k8sName, projectKey))
     .then(() => deploymentApi.deleteDeployment(k8sName, projectKey))
+    .then(() => configMapApi.deleteNamespacedConfigMap(nameGenerators.rStudioConfigMap(k8sName), projectKey))
     .then(() => secretManager.deleteStackCredentialSecret(name, type, projectKey));
 }
 

--- a/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rstudioStack.js
@@ -4,7 +4,7 @@ import deploymentApi from '../kubernetes/deploymentApi';
 import serviceApi from '../kubernetes/serviceApi';
 import ingressGenerator from '../kubernetes/ingressGenerator';
 import ingressApi from '../kubernetes/ingressApi';
-import { createDeployment, createService, createIngressRuleWithConnect } from './stackBuilders';
+import { createDeployment, createService, createIngressRuleWithConnect, createRStudioConfigMap } from './stackBuilders';
 import nameGenerators from '../common/nameGenerators';
 
 function createRStudioStack(params) {
@@ -13,6 +13,7 @@ function createRStudioStack(params) {
   const proxyTimeout = '1800';
 
   return secretManager.createStackCredentialSecret(name, type, projectKey, credentials)
+    .then(createRStudioConfigMap(params))
     .then(createDeployment(params, deploymentGenerator.createRStudioDeployment))
     .then(createService(params, deploymentGenerator.createRStudioService))
     .then(createIngressRuleWithConnect({ ...params, proxyTimeout }, ingressGenerator.createIngress));

--- a/code/workspaces/infrastructure-api/src/stacks/rstudioStack.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rstudioStack.spec.js
@@ -81,7 +81,7 @@ describe('rstudioStack', () => {
       expect(ingressApi.deleteIngress).toHaveBeenNthCalledWith(2, 'rstudio-nb-name', projectKey);
       expect(serviceApi.deleteService).toBeCalledWith('rstudio-nb-name', projectKey);
       expect(deploymentApi.deleteDeployment).toBeCalledWith('rstudio-nb-name', projectKey);
-      expect(configMapApi.deleteNamespacedConfigMap).toBeCalledWith('rstudio-nb-name-rstudio-config', projectKey);
+      expect(configMapApi.deleteNamespacedConfigMap).toBeCalledWith('rstudio-nb-name-rserver-config', projectKey);
       expect(secretManager.deleteStackCredentialSecret).toBeCalledWith(name, type, projectKey);
     });
   });

--- a/code/workspaces/infrastructure-api/src/stacks/rstudioStack.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/rstudioStack.spec.js
@@ -1,0 +1,88 @@
+import rstudioStack from './rstudioStack';
+import deploymentGenerator from '../kubernetes/deploymentGenerator';
+import ingressGenerator from '../kubernetes/ingressGenerator';
+import secretManager from '../credentials/secretManager';
+import * as stackBuilders from './stackBuilders';
+import ingressApi from '../kubernetes/ingressApi';
+import serviceApi from '../kubernetes/serviceApi';
+import deploymentApi from '../kubernetes/deploymentApi';
+import configMapApi from '../kubernetes/configMapApi';
+
+jest.mock('../credentials/secretManager');
+const credentials = { token: 'a-token' };
+secretManager.createNewUserCredentials = jest.fn().mockReturnValue(credentials);
+secretManager.createStackCredentialSecret = jest.fn().mockResolvedValue();
+secretManager.deleteStackCredentialSecret = jest.fn().mockResolvedValue();
+
+jest.mock('./stackBuilders');
+stackBuilders.createPySparkConfigMap = jest.fn().mockReturnValue(() => {});
+stackBuilders.createDaskConfigMap = jest.fn().mockReturnValue(() => {});
+stackBuilders.createRStudioConfigMap = jest.fn().mockReturnValue(() => {});
+stackBuilders.createDeployment = jest.fn().mockReturnValue(() => {});
+stackBuilders.createSparkDriverHeadlessService = jest.fn().mockReturnValue(() => {});
+stackBuilders.createService = jest.fn().mockReturnValue(() => {});
+stackBuilders.createIngressRule = jest.fn().mockReturnValue(() => {});
+
+jest.mock('../kubernetes/ingressApi');
+ingressApi.deleteIngress = jest.fn().mockResolvedValue();
+
+jest.mock('../kubernetes/serviceApi');
+serviceApi.deleteService = jest.fn().mockResolvedValue();
+
+jest.mock('../kubernetes/deploymentApi');
+deploymentApi.deleteDeployment = jest.fn().mockResolvedValue();
+
+jest.mock('../kubernetes/configMapApi');
+configMapApi.deleteNamespacedConfigMap = jest.fn().mockResolvedValue();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('rstudioStack', () => {
+  describe('createRStudioStack', () => {
+    it('creates expected resources', async () => {
+      // Arrange
+      const name = 'name';
+      const type = 'rstudio-nb';
+      const projectKey = 'projectKey';
+      const params = { name, type, projectKey };
+      const proxyTimeout = '1800';
+      const rewriteTarget = '/$2';
+      const pathPattern = '(/|$)(.*)';
+
+      // Act
+      await rstudioStack.createRStudioStack(params);
+
+      // Assert
+      expect(secretManager.createNewUserCredentials).toBeCalledWith();
+      expect(secretManager.createStackCredentialSecret).toBeCalledWith(name, type, projectKey, credentials);
+      expect(stackBuilders.createRStudioConfigMap).toBeCalledWith(params);
+      expect(stackBuilders.createDeployment).toBeCalledWith(params, deploymentGenerator.createRStudioDeployment);
+      expect(stackBuilders.createService).toBeCalledWith(params, deploymentGenerator.createRStudioService);
+      expect(stackBuilders.createIngressRule).toBeCalledWith({ ...params, proxyTimeout, rewriteTarget, pathPattern }, ingressGenerator.createIngress);
+      expect(stackBuilders.createConnectIngressRule).toBeCalledWith({ ...params, proxyTimeout, pathPattern }, ingressGenerator.createIngress);
+    });
+  });
+
+  describe('deleteRStudioStack', () => {
+    it('deletes expected resources', async () => {
+      // Arrange
+      const name = 'name';
+      const type = 'rstudio-nb';
+      const projectKey = 'projectKey';
+      const params = { name, type, projectKey };
+
+      // Act
+      await rstudioStack.deleteRStudioStack(params);
+
+      // Assert
+      expect(ingressApi.deleteIngress).toHaveBeenNthCalledWith(1, 'rstudio-nb-name-connect', projectKey);
+      expect(ingressApi.deleteIngress).toHaveBeenNthCalledWith(2, 'rstudio-nb-name', projectKey);
+      expect(serviceApi.deleteService).toBeCalledWith('rstudio-nb-name', projectKey);
+      expect(deploymentApi.deleteDeployment).toBeCalledWith('rstudio-nb-name', projectKey);
+      expect(configMapApi.deleteNamespacedConfigMap).toBeCalledWith('rstudio-nb-name-rstudio-config', projectKey);
+      expect(secretManager.deleteStackCredentialSecret).toBeCalledWith(name, type, projectKey);
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -84,6 +84,19 @@ export const createJupyterConfigMap = params => async () => {
   return configMapApi.createOrReplaceNamespacedConfigMap(configMapName, projectKey, manifest);
 };
 
+export const createRStudioConfigMap = params => async () => {
+  const { name, projectKey, type } = params;
+
+  const serviceName = nameGenerator.deploymentName(name, type);
+  const configMapName = nameGenerator.rStudioConfigMap(serviceName);
+  const manifest = await deploymentGenerator.createRStudioConfigMap(configMapName);
+
+  logger.info(`Creating configMap ${chalk.blue(configMapName)} with manifest:`);
+  logger.debug(manifest.toString());
+
+  return configMapApi.createOrReplaceNamespacedConfigMap(configMapName, projectKey, manifest);
+};
+
 export const createIngressRule = (params, generator) => (service) => {
   const { name, projectKey, type } = params;
   const ingressName = nameGenerator.deploymentName(name, type);

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { stackTypes } from 'common';
+import { join } from 'path';
 import logger from '../config/logger';
 import deploymentApi from '../kubernetes/deploymentApi';
 import serviceApi from '../kubernetes/serviceApi';
@@ -89,10 +90,11 @@ export const createJupyterConfigMap = params => async () => {
 
 export const createRStudioConfigMap = params => async () => {
   const { name, projectKey, type } = params;
+  const base = basePath(type, projectKey, name);
 
   const serviceName = nameGenerator.deploymentName(name, type);
   const configMapName = nameGenerator.rStudioConfigMap(serviceName);
-  const manifest = await deploymentGenerator.createRStudioConfigMap(configMapName);
+  const manifest = await deploymentGenerator.createRStudioConfigMap(configMapName, base);
 
   logger.info(`Creating configMap ${chalk.blue(configMapName)} with manifest:`);
   logger.debug(manifest.toString());
@@ -100,33 +102,66 @@ export const createRStudioConfigMap = params => async () => {
   return configMapApi.createOrReplaceNamespacedConfigMap(configMapName, projectKey, manifest);
 };
 
+export const ingressPath = (type, projectKey, name, pathPattern) => {
+  const base = basePath(type, projectKey, name);
+  return pathPattern ? `${base}${pathPattern}` : base;
+};
+
+export const ingressConnectPath = (type, projectKey, name, pathPattern) => {
+  const base = basePath(type, projectKey, name);
+  const connectBase = join(base, 'connect');
+  return pathPattern ? `${connectBase}${pathPattern}` : connectBase;
+};
+
 export const createIngressRule = (params, generator) => (service) => {
-  const { name, projectKey, type } = params;
+  const { name, projectKey, type, pathPattern = null } = params;
   const ingressName = nameGenerator.deploymentName(name, type);
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];
-  const base = basePath(type, projectKey, name);
+  const path = ingressPath(type, projectKey, name, pathPattern);
 
-  return generator({ ...params, ingressName, serviceName, port, basePath: base })
+  return generator({ ...params, ingressName, serviceName, port, path })
     .then((manifest) => {
       logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with manifest:`);
       logger.debug(manifest.toString());
-      return ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
+      ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
+      return service; // so can be used in additional ingresses
+    });
+};
+
+// use if the connect rule needs to be in a separate ingress,
+// e.g. because one ingress uses rewriteTarget
+export const createConnectIngressRule = (params, generator) => (service) => {
+  const { name, projectKey, type, pathPattern = null } = params;
+  const ingressName = `${nameGenerator.deploymentName(name, type)}-connect`;
+  const serviceName = service.metadata.name;
+  const connectPort = service.spec.ports[1].port;
+  const connectPath = ingressConnectPath(type, projectKey, name, pathPattern);
+
+  return generator({ ...params, ingressName, serviceName, port: connectPort, path: connectPath })
+    .then((manifest) => {
+      logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with manifest:`);
+      logger.debug(manifest.toString());
+      ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
+      return service; // so can be used in additional ingresses
     });
 };
 
 export const createIngressRuleWithConnect = (params, generator) => (service) => {
-  const { name, projectKey, type } = params;
+  const { name, projectKey, type, pathPattern = null } = params;
   const ingressName = nameGenerator.deploymentName(name, type);
   const serviceName = service.metadata.name;
   const { port } = service.spec.ports[0];
   const connectPort = service.spec.ports[1].port;
+  const path = ingressPath(type, projectKey, name, pathPattern);
+  const connectPath = ingressConnectPath(type, projectKey, name, pathPattern);
 
-  return generator({ ...params, ingressName, serviceName, port, connectPort })
+  return generator({ ...params, ingressName, serviceName, port, connectPort, path, connectPath })
     .then((manifest) => {
       logger.info(`Creating ingress rule ${chalk.blue(ingressName)} with connect port from manifest:`);
       logger.debug(manifest.toString());
-      return ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
+      ingressApi.createOrUpdateIngress(ingressName, projectKey, manifest);
+      return service; // so can be used in additional ingresses
     });
 };
 

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
@@ -1,0 +1,152 @@
+import { stackTypes } from 'common';
+import { createRStudioConfigMap, ingressPath, ingressConnectPath, createIngressRule, createConnectIngressRule, createIngressRuleWithConnect } from './stackBuilders';
+import ingressGenerator from '../kubernetes/ingressGenerator';
+import configMapApi from '../kubernetes/configMapApi';
+import ingressApi from '../kubernetes/ingressApi';
+
+jest.mock('../kubernetes/configMapApi');
+configMapApi.createOrReplaceNamespacedConfigMap = jest.fn().mockReturnValue('configmap return');
+
+jest.mock('../kubernetes/ingressApi');
+ingressApi.createOrUpdateIngress = jest.fn().mockReturnValue();
+
+const name = 'name';
+const projectKey = 'projectKey';
+const rewriteTarget = '/$2';
+const pathPattern = '(/|$)(.*)';
+const service = {
+  metadata: { name: 'service-name' },
+  spec: { ports: [
+    { port: 80 },
+    { port: 8000 },
+  ] },
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('stackBuilders', () => {
+  describe('createRStudioConfigMap', () => {
+    it('makes expected call to api', async () => {
+      const val = await createRStudioConfigMap({ name, projectKey, type: stackTypes.RSTUDIO })();
+      expect(val).toEqual('configmap return');
+      expect(configMapApi.createOrReplaceNamespacedConfigMap).toBeCalledWith('rstudio-name-rstudio-config', 'projectKey', `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rstudio-name-rstudio-config
+data:
+  config: |
+    www-root-path=/resource/projectKey/name
+`);
+    });
+  });
+
+  describe('ingressPath', () => {
+    it('gives expected ingress paths', () => {
+      expect(ingressPath('assumed-not-single-host', projectKey, name)).toEqual('/');
+      expect(ingressPath(stackTypes.JUPYTER, projectKey, name)).toEqual('/resource/projectKey/name');
+      expect(ingressPath(stackTypes.JUPYTER, projectKey, name, pathPattern)).toEqual('/resource/projectKey/name(/|$)(.*)');
+    });
+  });
+
+  describe('ingressConnectPath', () => {
+    it('gives expected ingress paths', () => {
+      expect(ingressConnectPath('assumed-not-single-host', projectKey, name)).toEqual('/connect');
+      expect(ingressConnectPath(stackTypes.JUPYTER, projectKey, name)).toEqual('/resource/projectKey/name/connect');
+      expect(ingressConnectPath(stackTypes.JUPYTER, projectKey, name, pathPattern)).toEqual('/resource/projectKey/name/connect(/|$)(.*)');
+    });
+  });
+
+  describe('createIngressRule', () => {
+    it('makes expected call to api', async () => {
+      const val = await createIngressRule({ name, projectKey, type: stackTypes.RSTUDIO, rewriteTarget, pathPattern }, ingressGenerator.createIngress)(service);
+      expect(val).toEqual(service);
+      expect(ingressApi.createOrUpdateIngress).toBeCalledWith('rstudio-name', 'projectKey', `---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: rstudio-name
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 50g
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  tls:
+  - hosts:
+    - testlab.datalabs.internal
+  rules:
+  - host: testlab.datalabs.internal
+    http:
+      paths:
+      - path: /resource/projectKey/name(/|$)(.*)
+        backend:
+          serviceName: service-name
+          servicePort: 80
+`);
+    });
+  });
+
+  describe('createConnectIngressRule', () => {
+    it('makes expected call to api', async () => {
+      const val = await createConnectIngressRule({ name, projectKey, type: stackTypes.RSTUDIO, pathPattern }, ingressGenerator.createIngress)(service);
+      expect(val).toEqual(service);
+      expect(ingressApi.createOrUpdateIngress).toBeCalledWith('rstudio-name-connect', 'projectKey', `---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: rstudio-name-connect
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 50g
+spec:
+  tls:
+  - hosts:
+    - testlab.datalabs.internal
+  rules:
+  - host: testlab.datalabs.internal
+    http:
+      paths:
+      - path: /resource/projectKey/name/connect(/|$)(.*)
+        backend:
+          serviceName: service-name
+          servicePort: 8000
+`);
+    });
+  });
+
+  describe('createIngressRuleWithConnect', () => {
+    it('makes expected call to api', async () => {
+      const val = await createIngressRuleWithConnect({ name, projectKey, type: 'minio', rewriteTarget: '/' }, ingressGenerator.createIngress)(service);
+      expect(val).toEqual(service);
+      expect(ingressApi.createOrUpdateIngress).toBeCalledWith('minio-name', 'projectKey', `---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: minio-name
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
+    nginx.ingress.kubernetes.io/proxy-body-size: 50g
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  tls:
+  - hosts:
+    - projectKey-name.datalabs.internal
+  rules:
+  - host: projectKey-name.datalabs.internal
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: service-name
+          servicePort: 80
+      - path: /connect
+        backend:
+          serviceName: service-name
+          servicePort: 8000
+`);
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
@@ -3,6 +3,11 @@ import { createRStudioConfigMap, ingressPath, ingressConnectPath, createIngressR
 import ingressGenerator from '../kubernetes/ingressGenerator';
 import configMapApi from '../kubernetes/configMapApi';
 import ingressApi from '../kubernetes/ingressApi';
+import config from '../config/config';
+
+jest.mock('../config/config');
+const origConfig = jest.requireActual('../config/config');
+config.get = jest.fn().mockImplementation(s => origConfig.default.default(s));
 
 jest.mock('../kubernetes/configMapApi');
 configMapApi.createOrReplaceNamespacedConfigMap = jest.fn().mockReturnValue('configmap return');
@@ -67,16 +72,16 @@ kind: Ingress
 metadata:
   name: rstudio-name
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
     nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
     nginx.ingress.kubernetes.io/proxy-body-size: 50g
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
   - hosts:
-    - testlab.datalabs.internal
+    - testlab.datalabs.localhost
   rules:
-  - host: testlab.datalabs.internal
+  - host: testlab.datalabs.localhost
     http:
       paths:
       - path: /resource/projectKey/name(/|$)(.*)
@@ -97,15 +102,15 @@ kind: Ingress
 metadata:
   name: rstudio-name-connect
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
     nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
     nginx.ingress.kubernetes.io/proxy-body-size: 50g
 spec:
   tls:
   - hosts:
-    - testlab.datalabs.internal
+    - testlab.datalabs.localhost
   rules:
-  - host: testlab.datalabs.internal
+  - host: testlab.datalabs.localhost
     http:
       paths:
       - path: /resource/projectKey/name/connect(/|$)(.*)
@@ -126,16 +131,16 @@ kind: Ingress
 metadata:
   name: minio-name
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: http://10.0.2.2:9000/auth
+    nginx.ingress.kubernetes.io/auth-url: http://localhost:9000/auth
     nginx.ingress.kubernetes.io/auth-signin: https://testlab.test-datalabs.nerc.ac.uk
     nginx.ingress.kubernetes.io/proxy-body-size: 50g
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   tls:
   - hosts:
-    - projectKey-name.datalabs.internal
+    - projectKey-name.datalabs.localhost
   rules:
-  - host: projectKey-name.datalabs.internal
+  - host: projectKey-name.datalabs.localhost
     http:
       paths:
       - path: /

--- a/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/stackBuilders.spec.js
@@ -34,11 +34,11 @@ describe('stackBuilders', () => {
     it('makes expected call to api', async () => {
       const val = await createRStudioConfigMap({ name, projectKey, type: stackTypes.RSTUDIO })();
       expect(val).toEqual('configmap return');
-      expect(configMapApi.createOrReplaceNamespacedConfigMap).toBeCalledWith('rstudio-name-rstudio-config', 'projectKey', `---
+      expect(configMapApi.createOrReplaceNamespacedConfigMap).toBeCalledWith('rstudio-name-rserver-config', 'projectKey', `---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rstudio-name-rstudio-config
+  name: rstudio-name-rserver-config
 data:
   config: |
     www-root-path=/resource/projectKey/name

--- a/code/workspaces/web-app/public/image_config.json
+++ b/code/workspaces/web-app/public/image_config.json
@@ -97,12 +97,12 @@
           "default": true,
           "displayName": "4.0.1",
           "image": "nerc/rstudio:4.0.1",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         },
         {
           "displayName": "3.5.3",
           "image": "nerc/rstudio:3.5.3",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     },
@@ -123,7 +123,7 @@
         {
           "displayName": "0.7.2.7",
           "image": "nerc/zeppelin:0.7.2.7",
-          "connectImage": "nerc/zeppelin-connect:1.1.1"
+          "connectImage": "nerc/zeppelin-connect:1.2.0"
         }
       ]
     }

--- a/code/workspaces/web-app/src/config/__snapshots__/images.spec.js.snap
+++ b/code/workspaces/web-app/src/config/__snapshots__/images.spec.js.snap
@@ -28,13 +28,13 @@ Object {
     "userSelectableVersion": true,
     "versions": Array [
       Object {
-        "connectImage": "nerc/zeppelin-connect:1.1.1",
+        "connectImage": "nerc/zeppelin-connect:1.2.0",
         "default": true,
         "displayName": "4.0.1",
         "image": "nerc/rstudio:4.0.1",
       },
       Object {
-        "connectImage": "nerc/zeppelin-connect:1.1.1",
+        "connectImage": "nerc/zeppelin-connect:1.2.0",
         "displayName": "3.5.3",
         "image": "nerc/rstudio:3.5.3",
       },
@@ -45,7 +45,7 @@ Object {
     "displayName": "Zeppelin",
     "versions": Array [
       Object {
-        "connectImage": "nerc/zeppelin-connect:1.1.1",
+        "connectImage": "nerc/zeppelin-connect:1.2.0",
         "displayName": "0.7.2.7",
         "image": "nerc/zeppelin:0.7.2.7",
       },

--- a/datalab.code-workspace
+++ b/datalab.code-workspace
@@ -82,6 +82,7 @@
 			"numericality",
 			"oidc",
 			"placeholder",
+			"rserver",
 			"rshiny",
 			"rstudio",
 			"screenshot",


### PR DESCRIPTION
This should give us single host for rstudio... unfortunately I won't know for sure until I deploy to the test instance.
This is an assymetric path proxy - the remap happens in the kubernetes ingress, and is supported by a www-root-path configuration parameter passed to rstudio.
Because we only want the remap to happen to the rstudio ingress and not the connect ingress, these ingresses are split up.