### PR TITLE
NERCDL-1052: fix liveness probe to avoid redirect

### DIFF
--- a/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/rstudio.deployment.template.yml
@@ -86,7 +86,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: /
+              path: /images/favicon.ico
               port: 8787
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -253,7 +253,7 @@ spec:
               memory: 8Gi
           livenessProbe:
             httpGet:
-              path: /
+              path: /images/favicon.ico
               port: 8787
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
A liveness probe to / causes RStudio to respond with a redirect, which because of the proxy gives a Location of http://10.42.2.105:8787/resource/andyl/rurl/unsupported_browser.htm.  Because this is local, kubernetes follows it, which then results in a 404.

Changing the liveness probe to /images/favicon.ico causes RStudio to respond with a 200, which is fine.