### PR TITLE
fix: only display topbar url if configured

### DIFF
--- a/code/development-env/config/local/image_config.json
+++ b/code/development-env/config/local/image_config.json
@@ -34,8 +34,8 @@
       "category": "ANALYSIS",
       "versions": [
         {
-          "displayName": "Dask 2.30.0 support",
-          "image": "nerc/jupyterlab:fbf2130-dask-2.30"
+          "displayName": "Dask 2021.6/Spark 3.1.1",
+          "image": "nerc/jupyterlab:8749f2aede87-spark-3.1.1"
         }
       ]
     },
@@ -44,8 +44,8 @@
       "category": "ANALYSIS",
       "versions": [
         {
-          "displayName": "Dask 2.30.0 support",
-          "image": "nerc/jupyterlab:fbf2130-dask-2.30"
+          "displayName": "Dask 2021.6/Spark 3.1.1",
+          "image": "nerc/jupyterlab:8749f2aede87-spark-3.1.1"
         }
       ]
     },

--- a/code/workspaces/web-app/src/components/app/TopBar.js
+++ b/code/workspaces/web-app/src/components/app/TopBar.js
@@ -58,6 +58,7 @@ const TopBar = ({ classes, identity }) => {
           }
           <TopBarButton to="/projects" label="Projects"/>
           {catalogue.available
+          && catalogue.url
           && <TopBarButton label="Catalogue" onClick={() => window.open(catalogue.url)} />
           }
           {datalabLinks.map(({ displayName, href }) => <TopBarButton

--- a/code/workspaces/web-app/src/components/app/TopBar.spec.js
+++ b/code/workspaces/web-app/src/components/app/TopBar.spec.js
@@ -41,7 +41,7 @@ describe('TopBar', () => {
 
   it('correctly renders correct snapshot if catalogue exists', () => {
     useCurrentUserPermissions.mockReturnValueOnce({ value: [] });
-    getCatalogue.mockReturnValueOnce({ available: true, topBarLink: true, url: 'https://catalogue-url.com/' });
+    getCatalogue.mockReturnValueOnce({ available: true, url: 'https://catalogue-url.com/' });
     expect(
       shallow(<TopBar identity={{ expected: 'identity', picture: 'expectedUrl' }} />),
     ).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/app/TopBar.spec.js
+++ b/code/workspaces/web-app/src/components/app/TopBar.spec.js
@@ -41,7 +41,7 @@ describe('TopBar', () => {
 
   it('correctly renders correct snapshot if catalogue exists', () => {
     useCurrentUserPermissions.mockReturnValueOnce({ value: [] });
-    getCatalogue.mockReturnValueOnce({ available: true, url: 'https://catalogue-url.com/' });
+    getCatalogue.mockReturnValueOnce({ available: true, topBarLink: true, url: 'https://catalogue-url.com/' });
     expect(
       shallow(<TopBar identity={{ expected: 'identity', picture: 'expectedUrl' }} />),
     ).toMatchSnapshot();


### PR DESCRIPTION
This is a minor change so that we can release the assetRepo in prod where the catalogue link isn't yet functional