### PR TITLE
NERCDL-981: Anonymise data and convert user IDs

### DIFF
--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -15,6 +15,7 @@ import rolesService from '../dataaccess/rolesService';
 import centralAssetRepoService from '../dataaccess/centralAssetRepoService';
 import clustersService from '../dataaccess/clustersService';
 import w from './wrapper';
+import { replaceFields } from '../util/converters';
 
 const { elementPermissions: { STORAGE_EDIT } } = permissionTypes;
 const { READY } = statusTypes;
@@ -81,7 +82,7 @@ const resolvers = {
     },
     accessKey: (obj, args, { token }) => minioTokenService.requestMinioToken(obj, token),
     stacksMountingStore: ({ name, projectKey }, args, { token }) => (projectKey
-      ? stackService.getAllByVolumeMount(projectKey, name, { token }) : []),
+      ? replaceFields(stackService.getAllByVolumeMount(projectKey, name, { token }), token) : []),
     status: () => READY,
   },
 

--- a/code/workspaces/client-api/src/util/converters.js
+++ b/code/workspaces/client-api/src/util/converters.js
@@ -1,0 +1,28 @@
+import usersService from '../dataaccess/usersService';
+
+const convertIdsToNames = async (obj, token) => {
+  // Converts all IDs in a "users" array to user names.
+  if (!obj.users) {
+    return obj;
+  }
+
+  const names = await Promise.all(obj.users.map(u => usersService.getUserName(u, token)));
+
+  return {
+    ...obj,
+    users: names,
+  };
+};
+
+const replaceFields = async (fn, token) => {
+  // Replaces certain fields in the response object from "fn", namely converting user IDs to user names.
+  const response = await fn;
+
+  if (Array.isArray(response)) {
+    return Promise.all(response.map(async i => convertIdsToNames(i, token)));
+  }
+
+  return convertIdsToNames(response, token);
+};
+
+export { convertIdsToNames, replaceFields };

--- a/code/workspaces/client-api/src/util/converters.spec.js
+++ b/code/workspaces/client-api/src/util/converters.spec.js
@@ -1,0 +1,103 @@
+import { convertIdsToNames, replaceFields } from './converters';
+import usersService from '../dataaccess/usersService';
+
+jest.mock('../dataaccess/usersService');
+
+const getUserNameMock = jest.fn();
+const token = 'token';
+
+usersService.getUserName = getUserNameMock;
+
+describe('converters', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('convertIdsToNames', () => {
+    it('returns the original object if there is no users field', async () => {
+      const input = {
+        field: 'field',
+      };
+
+      const response = await convertIdsToNames(input, token);
+      expect(response).toEqual(input);
+      expect(getUserNameMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('converts all user IDs to user names', async () => {
+      getUserNameMock
+        .mockResolvedValueOnce('name1')
+        .mockResolvedValueOnce('name2');
+
+      const input = {
+        field: 'field',
+        users: ['id1', 'id2'],
+      };
+      const expected = {
+        field: 'field',
+        users: ['name1', 'name2'],
+      };
+
+      const response = await convertIdsToNames(input, token);
+      expect(response).toEqual(expected);
+      expect(getUserNameMock).toHaveBeenCalledTimes(2);
+      expect(getUserNameMock).toHaveBeenCalledWith('id1', token);
+      expect(getUserNameMock).toHaveBeenCalledWith('id2', token);
+    });
+  });
+
+  describe('replaceFields', () => {
+    it('converts an array of responses', async () => {
+      getUserNameMock
+        .mockResolvedValueOnce('name1')
+        .mockResolvedValueOnce('name1')
+        .mockResolvedValueOnce('name2');
+
+      const fnResponse = [
+        {
+          field: 'field',
+          users: ['id1'],
+        },
+        {
+          field: 'field',
+          users: ['id1', 'id2'],
+        },
+      ];
+      const fn = Promise.resolve(fnResponse);
+
+      const expected = [
+        {
+          field: 'field',
+          users: ['name1'],
+        },
+        {
+          field: 'field',
+          users: ['name1', 'name2'],
+        },
+      ];
+
+      const replaced = await replaceFields(fn, token);
+      expect(replaced).toEqual(expected);
+      expect(getUserNameMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('converts a single response', async () => {
+      getUserNameMock
+        .mockResolvedValueOnce('name1')
+        .mockResolvedValueOnce('name2');
+
+      const fnResponse = {
+        field: 'field',
+        users: ['id1', 'id2'],
+      };
+      const fn = Promise.resolve(fnResponse);
+
+      const expected = {
+        field: 'field',
+        users: ['name1', 'name2'],
+      };
+
+      const replaced = await replaceFields(fn, token);
+      expect(replaced).toEqual(expected);
+      expect(getUserNameMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/controllers/stacksController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stacksController.js
@@ -48,7 +48,7 @@ function listByMountExec(request, response) {
   const { user } = request;
   const params = matchedData(request);
 
-  return stackRepository.getAllByVolumeMount(params.projectKey, user, params.mount)
+  return stackRepository.getAllByVolumeMountAnonymised(params.projectKey, user, params.mount)
     .then(stack => response.send(stack))
     .catch(controllerHelper.handleError(response, 'matching mount for', TYPE, undefined));
 }

--- a/code/workspaces/infrastructure-api/src/controllers/stacksController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stacksController.spec.js
@@ -10,12 +10,14 @@ const getAllByUserMock = jest.fn();
 const getAllByProjectMock = jest.fn().mockReturnValue(Promise.resolve([]));
 const getAllByCategoryMock = jest.fn().mockReturnValue(Promise.resolve([]));
 const getAllByVolumeMountMock = jest.fn().mockReturnValue(Promise.resolve([]));
+const getAllByVolumeMountAnonymisedMock = jest.fn().mockReturnValue(Promise.resolve([]));
 
 stackRepository.default = {
   getAllByUser: getAllByUserMock,
   getAllByProject: getAllByProjectMock,
   getAllByCategory: getAllByCategoryMock,
   getAllByVolumeMount: getAllByVolumeMountMock,
+  getAllByVolumeMountAnonymised: getAllByVolumeMountAnonymisedMock,
 };
 
 let request;
@@ -140,7 +142,7 @@ describe('Stacks controller', () => {
     });
 
     it('should return 500 for failed request', () => {
-      getAllByVolumeMountMock.mockReturnValue(Promise.reject({ message: 'error' }));
+      getAllByVolumeMountAnonymisedMock.mockReturnValue(Promise.reject({ message: 'error' }));
 
       const response = httpMocks.createResponse();
 

--- a/code/workspaces/infrastructure-api/src/dataaccess/__snapshots__/stacksRepository.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/dataaccess/__snapshots__/stacksRepository.spec.js.snap
@@ -66,6 +66,20 @@ Array [
 ]
 `;
 
+exports[`stacksRepository getAllByVolumeMountAnonymised returns expected snapshot 1`] = `
+Array [
+  Object {
+    "name": "Stack 1",
+    "users": Array [
+      "username",
+    ],
+  },
+  Object {
+    "name": "Stack 2",
+  },
+]
+`;
+
 exports[`stacksRepository getAllStacks returns expected snapshot 1`] = `
 Array [
   Object {

--- a/code/workspaces/infrastructure-api/src/dataaccess/testUtil/databaseMock.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/testUtil/databaseMock.js
@@ -6,6 +6,7 @@ class InvocationState {
     this.projectKey = undefined;
     this.params = undefined;
     this.user = undefined;
+    this.lean = false;
   }
 
   addQuery(query) {
@@ -72,6 +73,10 @@ function createDatabaseMock(items, state) {
       invocations.addQuery(query);
       return createDatabaseMock(items, invocations)();
     },
+    lean: (l) => {
+      invocations.lean = l;
+      return createDatabaseMock(items, invocations)();
+    },
     exec: () => Promise.resolve(items),
     invocation: () => invocations,
     query: () => invocations.lastQuery,
@@ -81,6 +86,7 @@ function createDatabaseMock(items, state) {
     project: () => invocations.projectKey,
     category: () => invocations.category,
     user: () => invocations.user,
+    isLean: () => invocations.lean,
     clear: () => { invocations = new InvocationState(); },
   });
 }


### PR DESCRIPTION
Added "anonymisation" to data in infrastructure-api where the displayName and other fields are returned as "private" if the calling user does not have permissions on the given data (i.e. if it is marked as private and they are not the "owner").
Also added a function in the client-api to convert from userIds to user names so they can be displayed more meaningfully in the webapp