### PR TITLE
NERCDL-981 Retrieve clusters using data stores

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/clustersService.js
+++ b/code/workspaces/client-api/src/dataaccess/clustersService.js
@@ -32,8 +32,17 @@ async function getClusters(projectKey, token) {
   return data;
 }
 
+async function getClustersByMount(projectKey, mount, token) {
+  const { data } = await infrastructureApi().get(
+    `/${projectKey}/mount/${mount}`,
+    requestConfig(token),
+  );
+  return data;
+}
+
 export default {
   createCluster: wrapWithAxiosErrorWrapper('Error creating cluster.', createCluster),
   deleteCluster: wrapWithAxiosErrorWrapper('Error deleting cluster.', deleteCluster),
   getClusters: wrapWithAxiosErrorWrapper('Error getting clusters.', getClusters),
+  getClustersByMount: wrapWithAxiosErrorWrapper('Error getting clusters by mount.', getClustersByMount),
 };

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -83,6 +83,8 @@ const resolvers = {
     accessKey: (obj, args, { token }) => minioTokenService.requestMinioToken(obj, token),
     stacksMountingStore: ({ name, projectKey }, args, { token }) => (projectKey
       ? replaceFields(stackService.getAllByVolumeMount(projectKey, name, { token }), token) : []),
+    clustersMountingStore: ({ name, projectKey }, args, { token }) => (projectKey
+      ? clustersService.getClustersByMount(projectKey, name, token) : []),
     status: () => READY,
   },
 

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -152,6 +152,7 @@ type DataStore {
     users: [String]
     accessKey: String
     stacksMountingStore: [Stack]
+    clustersMountingStore: [Cluster]
     status: StatusType
 }
 

--- a/code/workspaces/infrastructure-api/src/controllers/clustersController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/clustersController.js
@@ -72,8 +72,20 @@ async function listByProject(request, response, next) {
   }
 }
 
+async function listByMount(request, response, next) {
+  const { projectKey, volumeMount } = matchedData(request);
+
+  try {
+    const clusters = await clustersRepository.getByVolumeMount(projectKey, volumeMount);
+    return response.status(200).send(clusters);
+  } catch (error) {
+    return next(new Error(`Error listing clusters: ${error.message}`));
+  }
+}
+
 export default {
   createCluster,
   deleteCluster,
   listByProject,
+  listByMount,
 };

--- a/code/workspaces/infrastructure-api/src/controllers/clustersController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/clustersController.spec.js
@@ -198,4 +198,34 @@ describe('clustersController', () => {
       expect(nextMock).toHaveBeenCalledWith(new Error('Error listing clusters: Expected test error'));
     });
   });
+
+  describe('listByMount', () => {
+    const { listByMount } = clustersController;
+    it('calls to get clusters using mount and returns response configured with 200 status and array of clusters when projectKey and volumeMount provided', async () => {
+      // Arrange
+      const requestMock = { projectKey: 'test-proj', volumeMount: 'example' };
+      const clusterDocuments = [clusterDocument()];
+      clustersRepository.getByVolumeMount.mockResolvedValueOnce(clusterDocuments);
+
+      // Act
+      const returnValue = await listByMount(requestMock, responseMock, nextMock);
+
+      // Assert
+      expect(returnValue).toBe(responseMock);
+      expect(responseMock.status).toHaveBeenCalledWith(200);
+      expect(responseMock.send).toHaveBeenCalledWith(clusterDocuments);
+    });
+
+    it('calls next with an error if there is an error when listing the metadata', async () => {
+      // Arrange
+      const requestMock = {};
+      clustersRepository.getByVolumeMount.mockRejectedValueOnce(new Error('Expected test error'));
+
+      // Act
+      await listByMount(requestMock, responseMock, nextMock);
+
+      // Assert
+      expect(nextMock).toHaveBeenCalledWith(new Error('Error listing clusters: Expected test error'));
+    });
+  });
 });

--- a/code/workspaces/infrastructure-api/src/dataaccess/clustersRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/clustersRepository.js
@@ -36,10 +36,17 @@ async function getAll() {
   return ClusterModel().find().exec();
 }
 
+function getByVolumeMount(projectKey, mount) {
+  return ClusterModel()
+    .find({ projectKey, volumeMount: mount })
+    .exec();
+}
+
 export default {
   createCluster,
   deleteCluster,
   clusterExists,
   listByProject,
+  getByVolumeMount,
   getAll,
 };

--- a/code/workspaces/infrastructure-api/src/dataaccess/clustersRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/clustersRepository.spec.js
@@ -124,4 +124,20 @@ describe('clustersRepository', () => {
       expect(response).toEqual([document]);
     });
   });
+
+  describe('getAll', () => {
+    it('gets clusters by volume mount', async () => {
+      // Arrange
+      const { projectKey, volumeMount } = clusterRequest();
+      const document = clusterDocument();
+      clusterModelMock.exec.mockReturnValueOnce([document]);
+
+      // Act
+      const response = await clustersRepository.getByVolumeMount(projectKey, volumeMount);
+
+      // Assert
+      expect(clusterModelMock.find).toHaveBeenCalledWith({ projectKey, volumeMount });
+      expect(response).toEqual([document]);
+    });
+  });
 });

--- a/code/workspaces/infrastructure-api/src/routers/clustersRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/clustersRouter.js
@@ -5,9 +5,16 @@ import { permissionTypes } from 'common';
 import clustersController from '../controllers/clustersController';
 import permissionMiddleware from '../auth/permissionMiddleware';
 import { projectKeyValidator, nameValidator } from '../validators/commonValidators';
-import { clusterValidator, clusterTypeValidator } from '../validators/clusterValidators';
+import { clusterValidator, clusterTypeValidator, mountValidator } from '../validators/clusterValidators';
 
-const { projectPermissions: { PROJECT_KEY_CLUSTERS_CREATE, PROJECT_KEY_CLUSTERS_LIST, PROJECT_KEY_CLUSTERS_DELETE } } = permissionTypes;
+const {
+  projectPermissions: {
+    PROJECT_KEY_CLUSTERS_CREATE,
+    PROJECT_KEY_CLUSTERS_LIST,
+    PROJECT_KEY_CLUSTERS_DELETE,
+    PROJECT_KEY_STORAGE_LIST,
+  },
+} = permissionTypes;
 
 const { errorWrapper } = service.middleware;
 
@@ -26,6 +33,14 @@ clustersRouter.get(
   permissionMiddleware(PROJECT_KEY_CLUSTERS_LIST),
   projectKeyValidator(query),
   errorWrapper(clustersController.listByProject),
+);
+
+clustersRouter.get(
+  '/:projectKey/mount/:volumeMount',
+  permissionMiddleware(PROJECT_KEY_STORAGE_LIST, PROJECT_KEY_CLUSTERS_LIST),
+  projectKeyValidator(param),
+  mountValidator(param),
+  errorWrapper(clustersController.listByMount),
 );
 
 clustersRouter.delete(

--- a/code/workspaces/infrastructure-api/src/validators/clusterValidators.js
+++ b/code/workspaces/infrastructure-api/src/validators/clusterValidators.js
@@ -13,6 +13,11 @@ const clusterTypeValidation = checkFunction => new ValidationChainHelper(checkFu
   .getValidationChain();
 export const clusterTypeValidator = checkFunction => service.middleware.validator([clusterTypeValidation(checkFunction)], logger);
 
+const mountValidation = checkFunction => new ValidationChainHelper(checkFunction('volumeMount'))
+  .exists()
+  .getValidationChain();
+export const mountValidator = checkFunction => service.middleware.validator([mountValidation(checkFunction)], logger);
+
 export const clusterValidator = (checkFunction) => {
   const validations = [
     clusterTypeValidation(checkFunction),

--- a/code/workspaces/infrastructure-api/src/validators/clusterValidators.spec.js
+++ b/code/workspaces/infrastructure-api/src/validators/clusterValidators.spec.js
@@ -1,6 +1,6 @@
 import * as expressValidator from 'express-validator';
 import ValidationChainHelper from './ValidationChainHelper';
-import { clusterTypeValidator } from './clusterValidators';
+import { clusterTypeValidator, mountValidator } from './clusterValidators';
 
 const bodyMock = jest
   .spyOn(expressValidator, 'body');
@@ -21,6 +21,12 @@ describe('clusterValidators', () => {
       expect(bodyMock).toHaveBeenCalledWith('type');
       expect(mockHelperChain.exists).toHaveBeenCalledWith();
       expect(mockHelperChain.isIn).toHaveBeenCalledWith(['DASK']);
+    });
+
+    it('mountValidator', () => {
+      mountValidator(expressValidator.body);
+      expect(bodyMock).toHaveBeenCalledWith('volumeMount');
+      expect(mockHelperChain.exists).toHaveBeenCalledWith();
     });
   });
 });

--- a/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/dataStorageService.spec.js.snap
@@ -50,7 +50,16 @@ exports[`dataStorageService loadDataStorage should build the correct query and u
 "
     DataStorage($projectKey: String!) {
       dataStorage(projectKey: $projectKey) {
-         id, projectKey, name, displayName, description, type, stacksMountingStore { id, displayName, type, users }, status, users
+         id,
+         projectKey,
+         name,
+         displayName,
+         description,
+         type, 
+         stacksMountingStore { id, displayName, type, users },
+         clustersMountingStore { id, displayName, type },
+         status,
+         users
       }
     }"
 `;

--- a/code/workspaces/web-app/src/api/dataStorageService.js
+++ b/code/workspaces/web-app/src/api/dataStorageService.js
@@ -5,7 +5,16 @@ function loadDataStorage(projectKey) {
   const query = `
     DataStorage($projectKey: String!) {
       dataStorage(projectKey: $projectKey) {
-         id, projectKey, name, displayName, description, type, stacksMountingStore { id, displayName, type, users }, status, users
+         id,
+         projectKey,
+         name,
+         displayName,
+         description,
+         type, 
+         stacksMountingStore { id, displayName, type, users },
+         clustersMountingStore { id, displayName, type },
+         status,
+         users
       }
     }`;
 

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -22,11 +22,11 @@ import { STORAGE_TYPE_NAME, STORAGE_TYPE_NAME_PLURAL } from './storageTypeName';
 const { projectPermissions: { PROJECT_KEY_STORAGE_CREATE, PROJECT_KEY_STORAGE_DELETE, PROJECT_KEY_STORAGE_OPEN, PROJECT_KEY_STORAGE_EDIT }, projectKeyPermission } = permissionTypes;
 const FORM_NAME = 'createDataStore';
 
-const stackString = (stack) => {
-  const base = `- ${stack.displayName} (${stack.type})`;
+const resourceString = (resource) => {
+  const base = `- ${resource.displayName} (${resource.type})`;
 
-  if (stack.users && stack.users.length === 1) {
-    return `${base} (Owner: ${stack.users[0]})`;
+  if (resource.users && resource.users.length === 1) {
+    return `${base} (Owner: ${resource.users[0]})`;
   }
 
   return base;
@@ -92,13 +92,18 @@ class DataStorageContainer extends Component {
     title: `Unable to Delete ${dataStore.displayName} ${STORAGE_TYPE_NAME}`,
     body: [
       `Unable to delete, ${STORAGE_TYPE_NAME} is in use by the following resources:`,
-      ...dataStore.stacksMountingStore.map(stackString),
+      ...dataStore.stacksMountingStore.map(resourceString),
+      ...dataStore.clustersMountingStore.map(resourceString),
     ],
     onCancel: this.props.actions.closeModalDialog,
   });
 
   chooseDialogue = (dataStore) => {
-    if (dataStore.stacksMountingStore.length > 0) {
+    const resourcesMountingStore = [
+      ...(dataStore.stacksMountingStore || []),
+      ...(dataStore.clustersMountingStore || []),
+    ];
+    if (resourcesMountingStore.length > 0) {
       return this.prohibitDeletion(dataStore);
     }
 

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.spec.js
@@ -109,6 +109,19 @@ describe('DataStorageContainer', () => {
       },
     ];
 
+    const clustersMountingStore = [
+      {
+        id: 1,
+        displayName: 'Dask Cluster',
+        type: 'DASK',
+      },
+      {
+        id: 2,
+        displayName: 'Spark Cluster',
+        type: 'SPARK',
+      },
+    ];
+
     const generateProps = () => ({
       dataStorage,
       userPermissions: ['expectedPermission'],
@@ -169,7 +182,12 @@ describe('DataStorageContainer', () => {
     it('confirmDeleteDataStore calls openModalDialog with correct action for unmounted volume', () => {
       // Arrange
       const props = generateProps();
-      const stack = { displayName: 'expectedDisplayName', name: 'expectedName', stacksMountingStore: [] };
+      const stack = {
+        displayName: 'expectedDisplayName',
+        name: 'expectedName',
+        stacksMountingStore: [],
+        clustersMountingStore: [],
+      };
 
       // Act/Assert
       const output = shallowRenderPure(props);
@@ -185,7 +203,12 @@ describe('DataStorageContainer', () => {
       // Arrange
       const props = generateProps();
 
-      const stack = { displayName: 'expectedDisplayName', name: 'expectedName', stacksMountingStore };
+      const stack = {
+        displayName: 'expectedDisplayName',
+        name: 'expectedName',
+        stacksMountingStore,
+        clustersMountingStore,
+      };
 
       // Act/Assert
       const output = shallowRenderPure(props);
@@ -200,7 +223,12 @@ describe('DataStorageContainer', () => {
     it('confirmDeleteDataStore generates correct dialog for unmounted volume', () => {
       // Arrange
       const props = generateProps();
-      const stack = { displayName: 'expectedDisplayName', name: 'expectedName', stacksMountingStore: [] };
+      const stack = {
+        displayName: 'expectedDisplayName',
+        name: 'expectedName',
+        stacksMountingStore: [],
+        clustersMountingStore: [],
+      };
 
       // Act
       const output = shallowRenderPure(props);
@@ -217,7 +245,12 @@ describe('DataStorageContainer', () => {
     it('confirmDeleteDataStore generates correct dialog for mounted volume', () => {
       // Arrange
       const props = generateProps();
-      const stack = { displayName: 'expectedDisplayName', name: 'expectedName', stacksMountingStore };
+      const stack = {
+        displayName: 'expectedDisplayName',
+        name: 'expectedName',
+        stacksMountingStore,
+        clustersMountingStore,
+      };
 
       // Act
       const output = shallowRenderPure(props);
@@ -234,7 +267,12 @@ describe('DataStorageContainer', () => {
     it('confirmDeleteDataStore - onSubmit calls deleteDataStore with correct value', () => {
       // Arrange
       const props = generateProps();
-      const stack = { displayName: 'expectedDisplayName', name: 'expectedName', stacksMountingStore: [] };
+      const stack = {
+        displayName: 'expectedDisplayName',
+        name: 'expectedName',
+        stacksMountingStore: [],
+        clustersMountingStore: [],
+      };
 
       // Act
       const output = shallowRenderPure(props);

--- a/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
@@ -23,6 +23,8 @@ Object {
     "- Name (notebook)",
     "- Other Name (notebook) (Owner: user1)",
     "- Private (notebook) (Owner: user2)",
+    "- Dask Cluster (DASK)",
+    "- Spark Cluster (SPARK)",
   ],
   "title": "Unable to Delete expectedDisplayName Data Store",
 }


### PR DESCRIPTION
Updated backend to include routes to retrieve clusters by data stores.
Updated frontend to request the clusters that are using a data store so that deletion is prohibited when there are clusters using a data store, and the message displayed mentions ay clusters as well.