### PR TITLE
Dask docker version update to 2021.6.2

### DIFF
--- a/code/development-env/config/local/image_config.json
+++ b/code/development-env/config/local/image_config.json
@@ -25,7 +25,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "daskdev/dask:2.30.0"
+          "image": "daskdev/dask:2021.6.2"
         }
       ]
     },

--- a/code/workspaces/common/src/config/image_config.json
+++ b/code/workspaces/common/src/config/image_config.json
@@ -26,7 +26,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "daskdev/dask:2.30.0"
+          "image": "daskdev/dask:2021.6.2"
         }
       ]
     },

--- a/code/workspaces/web-app/public/image_config.json
+++ b/code/workspaces/web-app/public/image_config.json
@@ -26,7 +26,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "daskdev/dask:2.30.0"
+          "image": "daskdev/dask:2021.6.2"
         }
       ]
     },


### PR DESCRIPTION
Updated the Dask docker version so it is compatible with the Dask version used in conda.
This is needed because there seems to be some breaking change between version 2.30.0 and 2021.x.y, see [here](https://github.com/dask/dask-gateway/issues/388#issuecomment-821268841) and [here](https://github.com/dask/dask-gateway/issues/316#issuecomment-702947730).