### PR TITLE
NERCDL-1095: Spark cluster creation

### DIFF
--- a/code/development-env/config/local/image_config.json
+++ b/code/development-env/config/local/image_config.json
@@ -110,6 +110,10 @@
       "versions": [
         {
           "image": "nerc/spark-k8s:0.1.0"
+        },
+        {
+          "displayName": "Per Project",
+          "image": "bitnami/spark:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",

--- a/code/workspaces/common/src/config/image_config.json
+++ b/code/workspaces/common/src/config/image_config.json
@@ -111,6 +111,10 @@
       "versions": [
         {
           "image": "nerc/spark-k8s:0.1.0"
+        },
+        {
+          "displayName": "Per Project",
+          "image": "bitnami/spark:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",

--- a/code/workspaces/infrastructure-api/resources/datalab-dask-scheduler.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/datalab-dask-scheduler.deployment.template.yml
@@ -16,7 +16,7 @@ spec:
         - image: {{{daskImage}}}
           command: ["bash"]
           args: ["-c", "{{{schedulerPath}}}"]
-          name: dask-scheduler-cont
+          name: {{schedulerContainerName}}
           ports:
             - containerPort: 8786
             - containerPort: 8787

--- a/code/workspaces/infrastructure-api/resources/datalab-dask-worker.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/datalab-dask-worker.deployment.template.yml
@@ -16,7 +16,7 @@ spec:
         - image: {{{daskImage}}}
           command: ["bash"]
           args: ["-c", "{{{workerPath}}} --nthreads {{nThreads}} --no-dashboard --memory-limit {{workerMemory}} --death-timeout {{deathTimeoutSec}} tcp://{{schedulerServiceName}}:8786"]
-          name: dask-worker-cont
+          name: {{workerContainerName}}
           resources:
             requests:
               memory: {{workerMemory}}

--- a/code/workspaces/infrastructure-api/resources/datalab-spark-scheduler.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/datalab-spark-scheduler.deployment.template.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - image: {{{sparkImage}}}
-          name: spark-scheduler-cont
+          name: {{schedulerContainerName}}
           env:
             - name: SPARK_MODE
               value: "master"

--- a/code/workspaces/infrastructure-api/resources/datalab-spark-worker.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/datalab-spark-worker.deployment.template.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - image: {{{sparkImage}}}
-          name: spark-worker-cont
+          name: {{workerContainerName}}
           env:
             - name: SPARK_MODE
               value: "worker"

--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.js
@@ -8,6 +8,8 @@ const isAssetVolume = volumeName => volumeName.match(/^asset-/);
 const networkPolicyName = (name, type) => `${type}-${name}-netpol`;
 const autoScalerName = (name, type) => `${type}-${name}-hpa`;
 const podLabel = (name, type) => `${type}-${name}-po`;
+const schedulerContainerName = type => `${type}-scheduler-cont`;
+const workerContainerName = type => `${type}-worker-cont`;
 
 // project namespaces
 const projectNamespace = projectKey => projectKey;
@@ -36,6 +38,8 @@ export default {
   networkPolicyName,
   autoScalerName,
   podLabel,
+  schedulerContainerName,
+  workerContainerName,
   projectNamespace,
   projectComputeNamespace,
   pvcName,

--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.spec.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.spec.js
@@ -7,6 +7,8 @@ describe('nameGenerators', () => {
     expect(nameGenerators.networkPolicyName('aName', 'aType')).toEqual('aType-aName-netpol');
     expect(nameGenerators.autoScalerName('aName', 'aType')).toEqual('aType-aName-hpa');
     expect(nameGenerators.podLabel('aName', 'aType')).toEqual('aType-aName-po');
+    expect(nameGenerators.schedulerContainerName('aType')).toEqual('aType-scheduler-cont');
+    expect(nameGenerators.workerContainerName('aType')).toEqual('aType-worker-cont');
     expect(nameGenerators.assetVolume('anAsset')).toEqual('asset-anAsset');
     expect(nameGenerators.jupyterConfigMap('deploymentName')).toEqual('deploymentName-jupyter-config');
   });

--- a/code/workspaces/infrastructure-api/src/controllers/clustersController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/clustersController.js
@@ -1,6 +1,6 @@
 import { matchedData } from 'express-validator';
 import clustersRepository from '../dataaccess/clustersRepository';
-import { getSchedulerServiceName, createClusterStack, deleteClusterStack } from '../stacks/clusterManager';
+import { getSchedulerServiceName, getSchedulerAddress, createClusterStack, deleteClusterStack } from '../stacks/clusterManager';
 
 function requestCluster(request) {
   const params = matchedData(request);
@@ -26,7 +26,7 @@ async function createCluster(request, response, next) {
 
   try {
     const schedulerServiceName = getSchedulerServiceName(cluster.name, cluster.type);
-    const schedulerAddress = `tcp://${schedulerServiceName}:8786`;
+    const schedulerAddress = getSchedulerAddress(schedulerServiceName, cluster.type);
     const createdCluster = await clustersRepository.createCluster({ ...cluster, schedulerAddress });
     await createClusterStack(cluster);
     return response.status(201).send(createdCluster);

--- a/code/workspaces/infrastructure-api/src/controllers/clustersController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/clustersController.spec.js
@@ -7,6 +7,7 @@ jest.mock('../stacks/clusterManager');
 clusterManager.createClusterStack = jest.fn().mockResolvedValue();
 clusterManager.deleteClusterStack = jest.fn().mockResolvedValue();
 clusterManager.getSchedulerServiceName = jest.fn().mockReturnValue('dask-scheduler-cluster');
+clusterManager.getSchedulerAddress = jest.fn().mockReturnValue('tcp://dask-scheduler-cluster:8786');
 
 jest.mock('../dataaccess/clustersRepository');
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -152,6 +152,81 @@ spec:
 "
 `;
 
+exports[`deploymentGenerator createDatalabSparkSchedulerDeployment uses spark image 1`] = `
+"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-name
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      spark-infra: scheduler-pod-label
+  template:
+    metadata:
+      labels:
+        spark-infra: scheduler-pod-label
+    spec:
+      containers:
+        - image: spark-image
+          name: spark-scheduler-cont
+          env:
+            - name: SPARK_MODE
+              value: \\"master\\"
+          ports:
+            - containerPort: 8080
+            - containerPort: 7077
+          resources:
+            requests:
+              memory: scheduler-memory
+              cpu: scheduler-cpu
+            limits:
+              memory: scheduler-memory
+              cpu: scheduler-cpu
+          volumeMounts:
+      hostname: spark-scheduler-host
+      restartPolicy: Always
+      volumes:
+"
+`;
+
+exports[`deploymentGenerator createDatalabSparkWorkerDeployment uses spark image 1`] = `
+"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-name
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      spark-infra: worker-pod-label
+  template:
+    metadata:
+      labels:
+        spark-infra: worker-pod-label
+    spec:
+      containers:
+        - image: spark-image
+          name: spark-worker-cont
+          env:
+            - name: SPARK_MODE
+              value: \\"worker\\"
+            - name: SPARK_MASTER_URL
+              value: \\"spark://spark-scheduler-host:7077\\"
+          resources:
+            requests:
+              memory: worker-memory
+              cpu: worker-cpu
+            limits:
+              memory: worker-memory
+              cpu: worker-cpu
+          volumeMounts:
+      hostname: spark-worker-host
+      restartPolicy: Always
+      volumes:
+"
+`;
+
 exports[`deploymentGenerator createRStudioConfigMap produces expected configmap 1`] = `
 "---
 apiVersion: v1
@@ -340,6 +415,48 @@ spec:
       targetPort: 8787
   selector:
     dask-infra: scheduler-pod-label
+"
+`;
+
+exports[`deploymentGenerator generates createDatalabSparkSchedulerNetworkPolicy manifest 1`] = `
+"apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: policy-name
+spec:
+  podSelector:
+    matchLabels:
+      spark-infra: scheduler-pod-label
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: project-key
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 7077
+"
+`;
+
+exports[`deploymentGenerator generates createDatalabSparkSchedulerService manifest 1`] = `
+"apiVersion: v1
+kind: Service
+metadata:
+  name: service-name
+spec:
+  ports:
+    - name: \\"client\\"
+      port: 8080
+      targetPort: 8080
+    - name: \\"driver\\"
+      port: 7077
+      targetPort: 7077
+  selector:
+    spark-infra: scheduler-pod-label
 "
 `;
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -41,10 +41,10 @@ function createJupyterDeployment({ projectKey, deploymentName, name, type, volum
   return generateManifest(context, DeploymentTemplates.JUPYTER_DEPLOYMENT);
 }
 
-function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, pureDaskImage, jupyterLabImage, schedulerPodLabel, schedulerMemory, schedulerCpu, volumeMount }) {
+function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, schedulerPodLabel, schedulerMemory, schedulerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
-    daskImage: (volumeMount && condaPath) ? jupyterLabImage : pureDaskImage,
+    daskImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     schedulerPath: (volumeMount && condaPath) ? `${condaPath}/bin/dask-scheduler` : 'dask-scheduler',
     schedulerPodLabel,
     schedulerMemory,
@@ -54,11 +54,11 @@ function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, pureD
   return generateManifest(context, DeploymentTemplates.DATALAB_DASK_SCHEDULER_DEPLOYMENT);
 }
 
-function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, pureDaskImage, jupyterLabImage, workerPodLabel, workerMemory, workerCpu, volumeMount, nThreads, deathTimeoutSec,
+function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, workerPodLabel, workerMemory, workerCpu, volumeMount, nThreads, deathTimeoutSec,
   schedulerServiceName }) {
   const context = {
     name: deploymentName,
-    daskImage: (volumeMount && condaPath) ? jupyterLabImage : pureDaskImage,
+    daskImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     workerPath: (volumeMount && condaPath) ? `${condaPath}/bin/dask-worker` : 'dask-worker',
     workerPodLabel,
     workerMemory,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -41,12 +41,13 @@ function createJupyterDeployment({ projectKey, deploymentName, name, type, volum
   return generateManifest(context, DeploymentTemplates.JUPYTER_DEPLOYMENT);
 }
 
-function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, schedulerPodLabel, schedulerMemory, schedulerCpu, volumeMount }) {
+function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
     daskImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     schedulerPath: (volumeMount && condaPath) ? `${condaPath}/bin/dask-scheduler` : 'dask-scheduler',
     schedulerPodLabel,
+    schedulerContainerName,
     schedulerMemory,
     schedulerCpu,
     volumeMount,
@@ -54,13 +55,14 @@ function createDatalabDaskSchedulerDeployment({ deploymentName, condaPath, clust
   return generateManifest(context, DeploymentTemplates.DATALAB_DASK_SCHEDULER_DEPLOYMENT);
 }
 
-function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, workerPodLabel, workerMemory, workerCpu, volumeMount, nThreads, deathTimeoutSec,
-  schedulerServiceName }) {
+function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount, nThreads,
+  deathTimeoutSec, schedulerServiceName }) {
   const context = {
     name: deploymentName,
     daskImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     workerPath: (volumeMount && condaPath) ? `${condaPath}/bin/dask-worker` : 'dask-worker',
     workerPodLabel,
+    workerContainerName,
     workerMemory,
     workerCpu,
     volumeMount,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -71,6 +71,32 @@ function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterI
   return generateManifest(context, DeploymentTemplates.DATALAB_DASK_WORKER_DEPLOYMENT);
 }
 
+function createDatalabSparkSchedulerDeployment({ deploymentName, clusterImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
+  const context = {
+    name: deploymentName,
+    sparkImage: clusterImage,
+    schedulerPodLabel,
+    schedulerContainerName,
+    schedulerMemory,
+    schedulerCpu,
+    volumeMount,
+  };
+  return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_SCHEDULER_DEPLOYMENT);
+}
+
+function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
+  const context = {
+    name: deploymentName,
+    sparkImage: clusterImage,
+    workerPodLabel,
+    workerContainerName,
+    workerMemory,
+    workerCpu,
+    volumeMount,
+  };
+  return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_WORKER_DEPLOYMENT);
+}
+
 function createZeppelinDeployment({ deploymentName, volumeMount, type, version }) {
   const img = getImage(type, version);
   const context = {
@@ -165,6 +191,14 @@ function createDatalabDaskSchedulerService({ serviceName, schedulerPodLabel }) {
   return generateManifest(context, ServiceTemplates.DATALAB_DASK_SCHEDULER_SERVICE);
 }
 
+function createDatalabSparkSchedulerService({ serviceName, schedulerPodLabel }) {
+  const context = {
+    name: serviceName,
+    schedulerPodLabel,
+  };
+  return generateManifest(context, ServiceTemplates.DATALAB_SPARK_SCHEDULER_SERVICE);
+}
+
 function createZeppelinService({ serviceName }) {
   const context = { name: serviceName };
   return generateManifest(context, ServiceTemplates.ZEPPELIN_SERVICE);
@@ -241,6 +275,11 @@ function createDatalabDaskSchedulerNetworkPolicy({ networkPolicyName, schedulerP
   return generateManifest(context, NetworkPolicyTemplates.DATALAB_DASK_SCHEDULER_NETWORK_POLICY);
 }
 
+function createDatalabSparkSchedulerNetworkPolicy({ networkPolicyName, schedulerPodLabel, projectKey }) {
+  const context = { name: networkPolicyName, schedulerPodLabel, projectKey };
+  return generateManifest(context, NetworkPolicyTemplates.DATALAB_SPARK_SCHEDULER_NETWORK_POLICY);
+}
+
 function createAutoScaler({ autoScalerName, scaleDeploymentName, maxReplicas, targetCpuUtilization, targetMemoryUtilization, scaleDownWindowSec }) {
   const context = {
     name: autoScalerName,
@@ -275,5 +314,9 @@ export default {
   createDatalabDaskWorkerDeployment,
   createDatalabDaskSchedulerService,
   createDatalabDaskSchedulerNetworkPolicy,
+  createDatalabSparkSchedulerDeployment,
+  createDatalabSparkWorkerDeployment,
+  createDatalabSparkSchedulerService,
+  createDatalabSparkSchedulerNetworkPolicy,
   createAutoScaler,
 };

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -73,10 +73,10 @@ function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterI
   return generateManifest(context, DeploymentTemplates.DATALAB_DASK_WORKER_DEPLOYMENT);
 }
 
-function createDatalabSparkSchedulerDeployment({ deploymentName, clusterImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
+function createDatalabSparkSchedulerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
-    sparkImage: clusterImage,
+    sparkImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     schedulerPodLabel,
     schedulerContainerName,
     schedulerMemory,
@@ -86,10 +86,10 @@ function createDatalabSparkSchedulerDeployment({ deploymentName, clusterImage, s
   return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_SCHEDULER_DEPLOYMENT);
 }
 
-function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
+function createDatalabSparkWorkerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
-    sparkImage: clusterImage,
+    sparkImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
     workerPodLabel,
     workerContainerName,
     workerMemory,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -73,10 +73,10 @@ function createDatalabDaskWorkerDeployment({ deploymentName, condaPath, clusterI
   return generateManifest(context, DeploymentTemplates.DATALAB_DASK_WORKER_DEPLOYMENT);
 }
 
-function createDatalabSparkSchedulerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
+function createDatalabSparkSchedulerDeployment({ deploymentName, clusterImage, schedulerPodLabel, schedulerContainerName, schedulerMemory, schedulerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
-    sparkImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
+    sparkImage: clusterImage,
     schedulerPodLabel,
     schedulerContainerName,
     schedulerMemory,
@@ -86,10 +86,10 @@ function createDatalabSparkSchedulerDeployment({ deploymentName, condaPath, clus
   return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_SCHEDULER_DEPLOYMENT);
 }
 
-function createDatalabSparkWorkerDeployment({ deploymentName, condaPath, clusterImage, jupyterLabImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
+function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
   const context = {
     name: deploymentName,
-    sparkImage: (volumeMount && condaPath) ? jupyterLabImage : clusterImage,
+    sparkImage: clusterImage,
     workerPodLabel,
     workerContainerName,
     workerMemory,

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -13,6 +13,7 @@ describe('deploymentGenerator', () => {
       clusterImage: 'dask-image',
       jupyterLabImage: 'lab-image',
       schedulerPodLabel: 'scheduler-pod-label',
+      schedulerContainerName: 'dask-scheduler-cont',
       schedulerMemory: 'scheduler-memory',
       schedulerCpu: 'scheduler-cpu',
     };
@@ -37,6 +38,7 @@ describe('deploymentGenerator', () => {
       clusterImage: 'dask-image',
       jupyterLabImage: 'lab-image',
       workerPodLabel: 'worker-pod-label',
+      workerContainerName: 'dask-worker-cont',
       workerMemory: 'worker-memory',
       workerCpu: 'worker-cpu',
       nThreads: 'n-threads',

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -77,6 +77,60 @@ describe('deploymentGenerator', () => {
     expect(manifest).toMatchSnapshot();
   });
 
+  describe('createDatalabSparkSchedulerDeployment', () => {
+    const params = {
+      deploymentName: 'deployment-name',
+      clusterImage: 'spark-image',
+      jupyterLabImage: 'lab-image',
+      schedulerPodLabel: 'scheduler-pod-label',
+      schedulerContainerName: 'spark-scheduler-cont',
+      schedulerMemory: 'scheduler-memory',
+      schedulerCpu: 'scheduler-cpu',
+    };
+    it('uses spark image', async () => {
+      const manifest = await deploymentGenerator.createDatalabSparkSchedulerDeployment(params);
+      expect(manifest).toMatchSnapshot();
+    });
+  });
+
+  describe('createDatalabSparkWorkerDeployment', () => {
+    const params = {
+      deploymentName: 'deployment-name',
+      clusterImage: 'spark-image',
+      jupyterLabImage: 'lab-image',
+      workerPodLabel: 'worker-pod-label',
+      workerContainerName: 'spark-worker-cont',
+      workerMemory: 'worker-memory',
+      workerCpu: 'worker-cpu',
+      nThreads: 'n-threads',
+      deathTimeoutSec: 'death-timeout-sec',
+      schedulerServiceName: 'scheduler-service-name',
+    };
+    it('uses spark image', async () => {
+      const manifest = await deploymentGenerator.createDatalabSparkWorkerDeployment(params);
+      expect(manifest).toMatchSnapshot();
+    });
+  });
+
+  it('generates createDatalabSparkSchedulerService manifest', async () => {
+    const params = {
+      serviceName: 'service-name',
+      schedulerPodLabel: 'scheduler-pod-label',
+    };
+    const manifest = await deploymentGenerator.createDatalabSparkSchedulerService(params);
+    expect(manifest).toMatchSnapshot();
+  });
+
+  it('generates createDatalabSparkSchedulerNetworkPolicy manifest', async () => {
+    const params = {
+      networkPolicyName: 'policy-name',
+      schedulerPodLabel: 'scheduler-pod-label',
+      projectKey: 'project-key',
+    };
+    const manifest = await deploymentGenerator.createDatalabSparkSchedulerNetworkPolicy(params);
+    expect(manifest).toMatchSnapshot();
+  });
+
   it('generates createAutoScaler manifest', async () => {
     const params = {
       autoScalerName: 'auto-scaler-name',

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.spec.js
@@ -10,7 +10,7 @@ describe('deploymentGenerator', () => {
   describe('createDatalabDaskSchedulerDeployment', () => {
     const params = {
       deploymentName: 'deployment-name',
-      pureDaskImage: 'dask-image',
+      clusterImage: 'dask-image',
       jupyterLabImage: 'lab-image',
       schedulerPodLabel: 'scheduler-pod-label',
       schedulerMemory: 'scheduler-memory',
@@ -34,7 +34,7 @@ describe('deploymentGenerator', () => {
   describe('createDatalabDaskWorkerDeployment', () => {
     const params = {
       deploymentName: 'deployment-name',
-      pureDaskImage: 'dask-image',
+      clusterImage: 'dask-image',
       jupyterLabImage: 'lab-image',
       workerPodLabel: 'worker-pod-label',
       workerMemory: 'worker-memory',

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
@@ -18,8 +18,22 @@ const getWorkerName = name => `worker-${name}`;
 
 export const getSchedulerServiceName = (name, type) => nameGenerator.deploymentName(getSchedulerName(name), getLowerType(type));
 
+export const getSchedulerAddress = (schedulerServiceName, type) => {
+  const lowerType = getLowerType(type);
+  if (lowerType === 'dask') {
+    return `tcp://${schedulerServiceName}:8786`;
+  }
+
+  if (lowerType === 'spark') {
+    return `spark://${schedulerServiceName}:7077`;
+  }
+
+  return '';
+};
+
 export const getComponentCreators = (type) => {
-  if (type === 'dask') {
+  const lowerType = getLowerType(type);
+  if (lowerType === 'dask') {
     return {
       networkPolicyCreator: deploymentGenerator.createDatalabDaskSchedulerNetworkPolicy,
       schedulerDeploymentCreator: deploymentGenerator.createDatalabDaskSchedulerDeployment,
@@ -28,7 +42,7 @@ export const getComponentCreators = (type) => {
     };
   }
 
-  if (type === 'spark') {
+  if (lowerType === 'spark') {
     return {
       networkPolicyCreator: deploymentGenerator.createDatalabSparkSchedulerNetworkPolicy,
       schedulerDeploymentCreator: deploymentGenerator.createDatalabSparkSchedulerDeployment,

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
@@ -57,6 +57,8 @@ export async function createClusterStack({ type, volumeMount, condaPath, maxWork
   const schedulerServiceName = getSchedulerServiceName(name, type);
   const schedulerPodLabel = nameGenerator.podLabel(schedulerName, lowerType);
   const workerPodLabel = nameGenerator.podLabel(workerName, lowerType);
+  const schedulerContainerName = nameGenerator.schedulerContainerName(lowerType);
+  const workerContainerName = nameGenerator.workerContainerName(lowerType);
 
   const clusterParams = {
     type: lowerType,
@@ -67,10 +69,12 @@ export async function createClusterStack({ type, volumeMount, condaPath, maxWork
     jupyterLabImage: defaultImage('jupyterlab').image,
     // scheduler
     schedulerPodLabel,
+    schedulerContainerName,
     schedulerMemory: `${clustersConfig()[lowerType].scheduler.memoryMax_GB.default}Gi`,
     schedulerCpu: clustersConfig()[lowerType].scheduler.CpuMax_vCPU.default,
     // workers
     workerPodLabel,
+    workerContainerName,
     schedulerServiceName,
     nThreads: clustersConfig()[lowerType].workers.nThreads.default,
     deathTimeoutSec: clustersConfig()[lowerType].workers.deathTimeout_sec.default,
@@ -110,8 +114,8 @@ export async function createClusterStack({ type, volumeMount, condaPath, maxWork
     const schedulerDeploymentName = nameGenerator.deploymentName(schedulerName, lowerType);
     const workerDeploymentName = nameGenerator.deploymentName(workerName, lowerType);
     await Promise.all([
-      mountAssetsOnDeployment({ projectKey, deploymentName: schedulerDeploymentName, containerNameWithMounts: 'dask-scheduler-cont', assetIds }),
-      mountAssetsOnDeployment({ projectKey, deploymentName: workerDeploymentName, containerNameWithMounts: 'dask-worker-cont', assetIds }),
+      mountAssetsOnDeployment({ projectKey, deploymentName: schedulerDeploymentName, containerNameWithMounts: schedulerContainerName, assetIds }),
+      mountAssetsOnDeployment({ projectKey, deploymentName: workerDeploymentName, containerNameWithMounts: workerContainerName, assetIds }),
     ]);
   }
 }

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
@@ -1,6 +1,6 @@
 import clustersConfig from 'common/src/config/clusters';
 import { defaultImage, image } from 'common/src/config/images';
-import { createClusterStack, deleteClusterStack } from './clusterManager';
+import { createClusterStack, deleteClusterStack, getSchedulerAddress } from './clusterManager';
 import * as stackBuilders from './stackBuilders';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';
 import autoScalerApi from '../kubernetes/autoScalerApi';
@@ -34,6 +34,22 @@ jest.mock('./assets/assetManager', () => ({
 describe('clusterManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('getSchedulerAddress', () => {
+    const scheduler = 'scheduler';
+
+    it('returns the correct dask address', () => {
+      expect(getSchedulerAddress(scheduler, 'DASK')).toEqual('tcp://scheduler:8786');
+    });
+
+    it('returns the correct spark address', () => {
+      expect(getSchedulerAddress(scheduler, 'SPARK')).toEqual('spark://scheduler:7077');
+    });
+
+    it('returns an empty address for an invalid type', () => {
+      expect(getSchedulerAddress(scheduler, 'invalid')).toEqual('');
+    });
   });
 
   describe('createClusterStack', () => {

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
@@ -1,5 +1,5 @@
 import clustersConfig from 'common/src/config/clusters';
-import { defaultImage } from 'common/src/config/images';
+import { defaultImage, image } from 'common/src/config/images';
 import { createClusterStack, deleteClusterStack } from './clusterManager';
 import * as stackBuilders from './stackBuilders';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';
@@ -59,10 +59,12 @@ describe('clusterManager', () => {
         jupyterLabImage: defaultImage('jupyterlab').image,
         // scheduler
         schedulerPodLabel: 'dask-scheduler-cluster-name-po',
+        schedulerContainerName: 'dask-scheduler-cont',
         schedulerMemory: `${clustersConfig().dask.scheduler.memoryMax_GB.default}Gi`,
         schedulerCpu: clustersConfig().dask.scheduler.CpuMax_vCPU.default,
         // workers
         workerPodLabel: 'dask-worker-cluster-name-po',
+        workerContainerName: 'dask-worker-cont',
         schedulerServiceName: 'dask-scheduler-cluster-name',
         nThreads: clustersConfig().dask.workers.nThreads.default,
         deathTimeoutSec: clustersConfig().dask.workers.deathTimeout_sec.default,
@@ -102,6 +104,73 @@ describe('clusterManager', () => {
       });
     });
 
+    it('creates spark cluster correctly', async () => {
+      // Arrange
+      const cluster = {
+        type: 'SPARK',
+        volumeMount: 'volume-mount',
+        condaPath: '/conda/path',
+        maxWorkers: 8,
+        maxWorkerMemoryGb: 4,
+        maxWorkerCpu: 2,
+        projectKey: 'project-key',
+        name: 'cluster-name',
+        assetIds: ['1234', '5678'],
+      };
+      const clusterParams = {
+        type: 'spark',
+        projectKey: cluster.projectKey,
+        volumeMount: cluster.volumeMount,
+        condaPath: cluster.condaPath,
+        clusterImage: image('spark', 'Per Project').image,
+        jupyterLabImage: defaultImage('jupyterlab').image,
+        // scheduler
+        schedulerPodLabel: 'spark-scheduler-cluster-name-po',
+        schedulerContainerName: 'spark-scheduler-cont',
+        schedulerMemory: `${clustersConfig().spark.scheduler.memoryMax_GB.default}Gi`,
+        schedulerCpu: clustersConfig().spark.scheduler.CpuMax_vCPU.default,
+        // workers
+        workerPodLabel: 'spark-worker-cluster-name-po',
+        workerContainerName: 'spark-worker-cont',
+        schedulerServiceName: 'spark-scheduler-cluster-name',
+        nThreads: clustersConfig().spark.workers.nThreads.default,
+        deathTimeoutSec: clustersConfig().spark.workers.deathTimeout_sec.default,
+        workerMemory: `${cluster.maxWorkerMemoryGb}Gi`,
+        workerCpu: cluster.maxWorkerCpu,
+        // auto-scaling
+        maxReplicas: cluster.maxWorkers,
+        targetCpuUtilization: clustersConfig().spark.workers.targetCpuUtilization_percent.default,
+        targetMemoryUtilization: clustersConfig().spark.workers.targetMemoryUtilization_percent.default,
+        scaleDownWindowSec: clustersConfig().spark.workers.scaleDownWindow_sec.default,
+      };
+      const schedulerParams = { ...clusterParams, name: 'scheduler-cluster-name' };
+      const workerParams = { ...clusterParams, name: 'worker-cluster-name' };
+
+      // Act
+      await createClusterStack(cluster);
+
+      // Asset
+      expect(stackBuilders.createNetworkPolicy).toBeCalledWith(schedulerParams, deploymentGenerator.createDatalabSparkSchedulerNetworkPolicy);
+      expect(stackBuilders.createDeployment).toHaveBeenNthCalledWith(1, schedulerParams, deploymentGenerator.createDatalabSparkSchedulerDeployment);
+      expect(stackBuilders.createService).toBeCalledWith(schedulerParams, deploymentGenerator.createDatalabSparkSchedulerService);
+      expect(stackBuilders.createDeployment).toHaveBeenNthCalledWith(2, workerParams, deploymentGenerator.createDatalabSparkWorkerDeployment);
+      expect(stackBuilders.createAutoScaler).toBeCalledWith(workerParams, deploymentGenerator.createAutoScaler);
+
+      expect(mountAssetsOnDeployment).toBeCalledWith({
+        projectKey: 'project-key',
+        deploymentName: 'spark-scheduler-cluster-name',
+        containerNameWithMounts: 'spark-scheduler-cont',
+        assetIds: cluster.assetIds,
+      });
+
+      expect(mountAssetsOnDeployment).toBeCalledWith({
+        projectKey: 'project-key',
+        deploymentName: 'spark-worker-cluster-name',
+        containerNameWithMounts: 'spark-worker-cont',
+        assetIds: cluster.assetIds,
+      });
+    });
+
     it('creates expected resources without assets', async () => {
       // Arrange
       const cluster = {
@@ -120,14 +189,16 @@ describe('clusterManager', () => {
         projectKey: cluster.projectKey,
         volumeMount: cluster.volumeMount,
         condaPath: cluster.condaPath,
-        pureDaskImage: defaultImage('dask').image,
+        clusterImage: defaultImage('dask').image,
         jupyterLabImage: defaultImage('jupyterlab').image,
         // scheduler
         schedulerPodLabel: 'dask-scheduler-cluster-name-po',
+        schedulerContainerName: 'dask-scheduler-cont',
         schedulerMemory: `${clustersConfig().dask.scheduler.memoryMax_GB.default}Gi`,
         schedulerCpu: clustersConfig().dask.scheduler.CpuMax_vCPU.default,
         // workers
         workerPodLabel: 'dask-worker-cluster-name-po',
+        workerContainerName: 'dask-worker-cont',
         schedulerServiceName: 'dask-scheduler-cluster-name',
         nThreads: clustersConfig().dask.workers.nThreads.default,
         deathTimeoutSec: clustersConfig().dask.workers.deathTimeout_sec.default,

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
@@ -55,7 +55,7 @@ describe('clusterManager', () => {
         projectKey: cluster.projectKey,
         volumeMount: cluster.volumeMount,
         condaPath: cluster.condaPath,
-        pureDaskImage: defaultImage('dask').image,
+        clusterImage: defaultImage('dask').image,
         jupyterLabImage: defaultImage('jupyterlab').image,
         // scheduler
         schedulerPodLabel: 'dask-scheduler-cluster-name-po',

--- a/code/workspaces/web-app/public/image_config.json
+++ b/code/workspaces/web-app/public/image_config.json
@@ -111,6 +111,10 @@
       "versions": [
         {
           "image": "nerc/spark-k8s:0.1.0"
+        },
+        {
+          "displayName": "Per Project",
+          "image": "bitnami/spark:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",


### PR DESCRIPTION
Implemented per-project Spark cluster creation in the infrastructure API.
This currently uses the bitnami Docker image for Spark as it seemed to be closer to the way that Dask works, though we may want to use a different image (e.g. the nerc one).