### PR TITLE
NERCDL-1094: Spark k8s updates

### DIFF
--- a/code/development-env/config/local/image_config.json
+++ b/code/development-env/config/local/image_config.json
@@ -109,11 +109,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "nerc/spark-k8s:0.1.0"
-        },
-        {
-          "displayName": "Per Project",
-          "image": "bitnami/spark:3.1.2"
+          "image": "nerc/spark-k8s:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",

--- a/code/workspaces/common/src/config/__snapshots__/clusters.spec.js.snap
+++ b/code/workspaces/common/src/config/__snapshots__/clusters.spec.js.snap
@@ -75,7 +75,7 @@ Object {
       },
       "memoryMax_GB": Object {
         "default": 4,
-        "lowerLimit": 0.5,
+        "lowerLimit": 2,
         "upperLimit": 8,
       },
       "nThreads": Object {

--- a/code/workspaces/common/src/config/__snapshots__/clusters.spec.js.snap
+++ b/code/workspaces/common/src/config/__snapshots__/clusters.spec.js.snap
@@ -10,6 +10,7 @@ Object {
         "upperLimit": 8,
       },
     },
+    "condaRequired": false,
     "scheduler": Object {
       "CpuMax_vCPU": Object {
         "default": 0.2,
@@ -54,6 +55,7 @@ Object {
         "upperLimit": 8,
       },
     },
+    "condaRequired": true,
     "scheduler": Object {
       "CpuMax_vCPU": Object {
         "default": 0.2,

--- a/code/workspaces/common/src/config/clusters_config.json
+++ b/code/workspaces/common/src/config/clusters_config.json
@@ -62,7 +62,7 @@
     },
     "workers": {
       "memoryMax_GB": {
-        "lowerLimit": 0.5,
+        "lowerLimit": 2,
         "default": 4,
         "upperLimit": 8
       },

--- a/code/workspaces/common/src/config/clusters_config.json
+++ b/code/workspaces/common/src/config/clusters_config.json
@@ -41,7 +41,8 @@
       "scaleDownWindow_sec": {
         "default": 300
       }
-    }
+    },
+    "condaRequired": false
   },
   "spark": {
     "cluster": {
@@ -85,6 +86,7 @@
       "scaleDownWindow_sec": {
         "default": 300
       }
-    }
+    },
+    "condaRequired": true
   }
 }

--- a/code/workspaces/common/src/config/image_config.json
+++ b/code/workspaces/common/src/config/image_config.json
@@ -110,11 +110,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "nerc/spark-k8s:0.1.0"
-        },
-        {
-          "displayName": "Per Project",
-          "image": "bitnami/spark:3.1.2"
+          "image": "nerc/spark-k8s:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",

--- a/code/workspaces/infrastructure-api/resources/datalab-spark-worker.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/datalab-spark-worker.deployment.template.yml
@@ -19,7 +19,7 @@ spec:
             - name: SPARK_MODE
               value: "worker"
             - name: SPARK_MASTER_URL
-              value: "spark://spark-scheduler-host:7077"
+              value: "spark://{{schedulerServiceName}}:7077"
           resources:
             requests:
               memory: {{workerMemory}}

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -212,7 +212,7 @@ spec:
             - name: SPARK_MODE
               value: \\"worker\\"
             - name: SPARK_MASTER_URL
-              value: \\"spark://spark-scheduler-host:7077\\"
+              value: \\"spark://scheduler-service-name:7077\\"
           resources:
             requests:
               memory: worker-memory

--- a/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/deploymentGenerator.js
@@ -86,7 +86,7 @@ function createDatalabSparkSchedulerDeployment({ deploymentName, clusterImage, s
   return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_SCHEDULER_DEPLOYMENT);
 }
 
-function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount }) {
+function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, workerPodLabel, workerContainerName, workerMemory, workerCpu, volumeMount, schedulerServiceName }) {
   const context = {
     name: deploymentName,
     sparkImage: clusterImage,
@@ -95,6 +95,7 @@ function createDatalabSparkWorkerDeployment({ deploymentName, clusterImage, work
     workerMemory,
     workerCpu,
     volumeMount,
+    schedulerServiceName,
   };
   return generateManifest(context, DeploymentTemplates.DATALAB_SPARK_WORKER_DEPLOYMENT);
 }

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.js
@@ -1,5 +1,5 @@
 import clustersConfig from 'common/src/config/clusters';
-import { defaultImage, image } from 'common/src/config/images';
+import { defaultImage } from 'common/src/config/images';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';
 import { createDeployment, createService, createNetworkPolicy, createAutoScaler } from './stackBuilders';
 import nameGenerator from '../common/nameGenerators';
@@ -54,14 +54,6 @@ export const getComponentCreators = (type) => {
   throw new Error(`Unsupported cluster type ${type}`);
 };
 
-export const getClusterImage = (type) => {
-  if (type === 'spark') {
-    return image(type, 'Per Project');
-  }
-
-  return defaultImage(type);
-};
-
 export async function createClusterStack({ type, volumeMount, condaPath, maxWorkers, maxWorkerMemoryGb, maxWorkerCpu, projectKey, name, assetIds }) {
   const lowerType = getLowerType(type);
   const schedulerName = getSchedulerName(name);
@@ -79,7 +71,7 @@ export async function createClusterStack({ type, volumeMount, condaPath, maxWork
     projectKey,
     volumeMount,
     condaPath,
-    clusterImage: getClusterImage(lowerType).image,
+    clusterImage: defaultImage(lowerType).image,
     jupyterLabImage: defaultImage('jupyterlab').image,
     // scheduler
     schedulerPodLabel,

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
@@ -1,5 +1,5 @@
 import clustersConfig from 'common/src/config/clusters';
-import { defaultImage, image } from 'common/src/config/images';
+import { defaultImage } from 'common/src/config/images';
 import { createClusterStack, deleteClusterStack, getSchedulerAddress } from './clusterManager';
 import * as stackBuilders from './stackBuilders';
 import deploymentGenerator from '../kubernetes/deploymentGenerator';

--- a/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/clusterManager.spec.js
@@ -138,7 +138,7 @@ describe('clusterManager', () => {
         projectKey: cluster.projectKey,
         volumeMount: cluster.volumeMount,
         condaPath: cluster.condaPath,
-        clusterImage: image('spark', 'Per Project').image,
+        clusterImage: defaultImage('spark').image,
         jupyterLabImage: defaultImage('jupyterlab').image,
         // scheduler
         schedulerPodLabel: 'spark-scheduler-cluster-name-po',

--- a/code/workspaces/web-app/public/clusters_config.json
+++ b/code/workspaces/web-app/public/clusters_config.json
@@ -18,7 +18,8 @@
         "default": 0.5,
         "upperLimit": 2
       }
-    }
+    },
+    "condaRequired": false
   },
   "spark": {
     "cluster": {
@@ -39,6 +40,7 @@
         "default": 0.5,
         "upperLimit": 2
       }
-    }
+    },
+    "condaRequired": true
   }
 }

--- a/code/workspaces/web-app/public/clusters_config.json
+++ b/code/workspaces/web-app/public/clusters_config.json
@@ -31,7 +31,7 @@
     },
     "workers": {
       "memoryMax_GB": {
-        "lowerLimit": 0.5,
+        "lowerLimit": 2,
         "default": 4,
         "upperLimit": 8
       },

--- a/code/workspaces/web-app/public/image_config.json
+++ b/code/workspaces/web-app/public/image_config.json
@@ -110,11 +110,7 @@
       "category": "INFRASTRUCTURE",
       "versions": [
         {
-          "image": "nerc/spark-k8s:0.1.0"
-        },
-        {
-          "displayName": "Per Project",
-          "image": "bitnami/spark:3.1.2"
+          "image": "nerc/spark-k8s:3.1.2"
         }
       ],
       "masterAddress": "spark://spark-master:7077",

--- a/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
@@ -29,6 +29,7 @@ exports[`clusterService loadClusters should build the correct query and unpack t
         name
         displayName
         schedulerAddress
+        condaPath
       }
     }
   "

--- a/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
@@ -30,6 +30,7 @@ exports[`clusterService loadClusters should build the correct query and unpack t
         displayName
         schedulerAddress
         condaPath
+        maxWorkerMemoryGb
       }
     }
   "

--- a/code/workspaces/web-app/src/api/clusterService.js
+++ b/code/workspaces/web-app/src/api/clusterService.js
@@ -43,6 +43,7 @@ function loadClusters(projectKey) {
         displayName
         schedulerAddress
         condaPath
+        maxWorkerMemoryGb
       }
     }
   `;

--- a/code/workspaces/web-app/src/api/clusterService.js
+++ b/code/workspaces/web-app/src/api/clusterService.js
@@ -42,6 +42,7 @@ function loadClusters(projectKey) {
         name
         displayName
         schedulerAddress
+        condaPath
       }
     }
   `;

--- a/code/workspaces/web-app/src/components/cluster/CreateClusterForm.spec.js
+++ b/code/workspaces/web-app/src/components/cluster/CreateClusterForm.spec.js
@@ -14,6 +14,7 @@ const getProps = () => ({
   clusterMaxWorkers: { lowerLimit: 1, default: 4, upperLimit: 8 },
   workerMaxMemory: { lowerLimit: 0.5, default: 4, upperLimit: 8 },
   workerMaxCpu: { lowerLimit: 0.5, default: 0.5, upperLimit: 2 },
+  condaRequired: false,
 });
 
 describe('CreateClusterForm', () => {
@@ -35,6 +36,16 @@ describe('CreateClusterForm', () => {
     it('with condaPath field when volumeMount field is set', () => {
       useReduxFormValue.mockReturnValueOnce('teststore');
       const props = getProps();
+      const render = shallow(<PureCreateClusterForm {...props} />);
+      expect(render).toMatchSnapshot();
+    });
+
+    it('when conda is required and volumeMount field is set', () => {
+      useReduxFormValue.mockReturnValueOnce('teststore');
+      const props = {
+        ...getProps(),
+        condaRequired: true,
+      };
       const render = shallow(<PureCreateClusterForm {...props} />);
       expect(render).toMatchSnapshot();
     });

--- a/code/workspaces/web-app/src/components/cluster/__snapshots__/CreateClusterForm.spec.js.snap
+++ b/code/workspaces/web-app/src/components/cluster/__snapshots__/CreateClusterForm.spec.js.snap
@@ -1,5 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CreateClusterForm it renders to match snapshot when conda is required and volumeMount field is set 1`] = `
+<form>
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    component={[Function]}
+    label="Display Name"
+    name="displayName"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    component={[Function]}
+    label="Internal Name"
+    name="name"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    component={[Function]}
+    label="Data Store to Mount"
+    name="volumeMount"
+    options={
+      Array [
+        Object {
+          "text": "Test Store",
+          "value": "teststore",
+        },
+      ]
+    }
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    component={[Function]}
+    helperText="The file path to the conda environment on the selected Data Store to be used by the workers."
+    label="Path to Conda environment"
+    name="condaPath"
+    placeholder="/data/conda/conda-env"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    InputProps={
+      Object {
+        "inputProps": Object {
+          "max": 8,
+          "min": 1,
+          "step": 1,
+        },
+      }
+    }
+    component={[Function]}
+    helperText="Value range: min=1 max=8 default=4"
+    label="Maximum number of workers"
+    name="maxWorkers"
+    parse={[Function]}
+    type="number"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    InputProps={
+      Object {
+        "inputProps": Object {
+          "max": 8,
+          "min": 0.5,
+          "step": 0.5,
+        },
+      }
+    }
+    component={[Function]}
+    helperText="Value range: min=0.5 max=8 default=4"
+    label="Maximum worker memory (GB)"
+    name="maxWorkerMemoryGb"
+    parse={[Function]}
+    type="number"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    InputProps={
+      Object {
+        "inputProps": Object {
+          "max": 2,
+          "min": 0.5,
+          "step": 0.5,
+        },
+      }
+    }
+    component={[Function]}
+    helperText="Value range: min=0.5 max=2 default=0.5"
+    label="Maximum worker CPU use"
+    name="maxWorkerCpu"
+    parse={[Function]}
+    type="number"
+  />
+  <Field
+    InputLabelProps={
+      Object {
+        "shrink": true,
+      }
+    }
+    component={[Function]}
+    format={[Function]}
+    label="Assets"
+    name="assets"
+    parse={[Function]}
+  />
+  <CreateFormControls
+    onCancel={[MockFunction cancel]}
+    submitting={false}
+  />
+</form>
+`;
+
 exports[`CreateClusterForm it renders to match snapshot with condaPath field when volumeMount field is set 1`] = `
 <form>
   <Field

--- a/code/workspaces/web-app/src/components/cluster/createClusterValidator.js
+++ b/code/workspaces/web-app/src/components/cluster/createClusterValidator.js
@@ -1,6 +1,6 @@
 import reduxFormValidator from '../common/form/reduxFormValidator';
 
-const constraints = {
+const getConstraints = condaRequired => ({
   displayName: {
     presence: true,
     length: { minimum: 2 },
@@ -16,6 +16,12 @@ const constraints = {
       maximum: 16,
     },
   },
+  volumeMount: {
+    presence: condaRequired,
+  },
+  condaPath: {
+    presence: condaRequired,
+  },
   maxWorkers: {
     presence: true,
     numericality: { onlyInteger: true, noStrings: true },
@@ -28,7 +34,7 @@ const constraints = {
     presence: true,
     numericality: { noStrings: true },
   },
-};
+});
 
 // eslint-disable-next-line import/prefer-default-export
-export const syncValidate = values => reduxFormValidator(values, constraints);
+export const syncValidate = condaRequired => values => reduxFormValidator(values, getConstraints(condaRequired));

--- a/code/workspaces/web-app/src/components/cluster/createClusterValidator.spec.js
+++ b/code/workspaces/web-app/src/components/cluster/createClusterValidator.spec.js
@@ -5,17 +5,18 @@ describe('syncValidate', () => {
     displayName: 'Test Cluster',
     name: 'testcluster',
     volumeMount: 'teststore',
+    condaPath: 'example/path/to/env',
     maxWorkers: 5,
     maxWorkerMemoryGb: 4.5,
     maxWorkerCpu: 0.5,
   });
 
-  const testValues = (fieldName, validValues, invalidValues) => {
+  const testValues = (fieldName, validValues, invalidValues, condaRequired = false) => {
     validValues.forEach((testValue) => {
       it(`as valid when value = ${testValue} and is typeof ${typeof testValue}`, () => {
         const valuesToValidate = getValidValues();
         valuesToValidate[fieldName] = testValue;
-        const validationResult = syncValidate(valuesToValidate);
+        const validationResult = syncValidate(condaRequired)(valuesToValidate);
         expect(validationResult).toBeUndefined(); // no return value when all valid
       });
     });
@@ -24,7 +25,7 @@ describe('syncValidate', () => {
       it(`as invalid when value = ${testValue} and is typeof ${typeof testValue}`, () => {
         const valuesToValidate = getValidValues();
         valuesToValidate[fieldName] = testValue;
-        const validationResult = syncValidate(valuesToValidate);
+        const validationResult = syncValidate(condaRequired)(valuesToValidate);
         expect(validationResult).toBeDefined();
         expect(validationResult[fieldName]).toBeDefined(); // return of { fieldName: error } when invalid
       });
@@ -67,12 +68,28 @@ describe('syncValidate', () => {
   });
 
   describe('validates volumeMount', () => {
-    const validValues = [
-      'teststore',
-      undefined,
-    ];
-    const invalidValues = [];
-    testValues('volumeMount', validValues, invalidValues);
+    describe('when conda is not required', () => {
+      const validValues = [
+        'teststore',
+        undefined,
+      ];
+      const invalidValues = [];
+      testValues('volumeMount', validValues, invalidValues);
+    });
+
+    describe('when conda is required', () => {
+      const validValues = ['teststore'];
+      const invalidValues = [undefined];
+      testValues('volumeMount', validValues, invalidValues, true);
+    });
+  });
+
+  describe('validates condaPath', () => {
+    describe('when conda is required', () => {
+      const validValues = ['example/path/to/env'];
+      const invalidValues = [undefined];
+      testValues('condaPath', validValues, invalidValues, true);
+    });
   });
 
   describe('validates maxWorkers', () => {

--- a/code/workspaces/web-app/src/components/modal/CreateClusterDialog.js
+++ b/code/workspaces/web-app/src/components/modal/CreateClusterDialog.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const CreateClusterDialog = ({ title, formName, onSubmit, onCancel, dataStorageOptions, clusterMaxWorkers, workerMaxMemory, workerMaxCpu, projectKey }) => {
+const CreateClusterDialog = ({ title, formName, onSubmit, onCancel, dataStorageOptions, clusterMaxWorkers, workerMaxMemory, workerMaxCpu, projectKey, condaRequired }) => {
   const classes = useStyles();
   return (
     <Dialog open={true} maxWidth="md">
@@ -33,6 +33,7 @@ const CreateClusterDialog = ({ title, formName, onSubmit, onCancel, dataStorageO
               maxWorkerCpu: workerMaxCpu.default,
             }}
             projectKey={projectKey}
+            condaRequired={condaRequired}
           />
         </DialogContent>
       </div>
@@ -56,6 +57,7 @@ CreateClusterDialog.propTypes = {
   workerMaxMemory: inputConstraintPropTypes.isRequired,
   workerMaxCpu: inputConstraintPropTypes.isRequired,
   projectKey: PropTypes.string.isRequired,
+  condaRequired: PropTypes.bool.isRequired,
 };
 
 export default CreateClusterDialog;

--- a/code/workspaces/web-app/src/config/clusters.js
+++ b/code/workspaces/web-app/src/config/clusters.js
@@ -13,3 +13,4 @@ export async function initialiseClusters() {
 export const getClusterMaxWorkers = type => cachedData[type.toLowerCase()].cluster.workersMax;
 export const getWorkerMemoryMax = type => cachedData[type.toLowerCase()].workers.memoryMax_GB;
 export const getWorkerCpuMax = type => cachedData[type.toLowerCase()].workers.CpuMax_vCPU;
+export const getCondaRequired = type => cachedData[type.toLowerCase()].condaRequired;

--- a/code/workspaces/web-app/src/config/clusters.spec.js
+++ b/code/workspaces/web-app/src/config/clusters.spec.js
@@ -1,7 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import data from 'common/src/config/clusters_config.json';
-import { initialiseClusters, getClusterMaxWorkers, getWorkerCpuMax, getWorkerMemoryMax } from './clusters';
+import { initialiseClusters, getClusterMaxWorkers, getWorkerCpuMax, getWorkerMemoryMax, getCondaRequired } from './clusters';
 
 const httpMock = new MockAdapter(axios);
 httpMock.onGet('/clusters_config.json').reply(() => [200, data]);
@@ -29,6 +29,14 @@ describe('getWorkerCpuMax', () => {
     await initialiseClusters();
     const maxCpu = getWorkerCpuMax(CLUSTER_TYPE);
     expect(maxCpu).toMatchSnapshot();
+  });
+});
+
+describe('getCondaRequired', () => {
+  it('returns correct value', async () => {
+    await initialiseClusters();
+    const condaRequired = getCondaRequired(CLUSTER_TYPE);
+    expect(condaRequired).toBeFalsy();
   });
 });
 

--- a/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.js
+++ b/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.js
@@ -9,7 +9,7 @@ import { useClustersByType } from '../../hooks/clustersHooks';
 import clusterActions from '../../actions/clusterActions';
 import { useCurrentUserId } from '../../hooks/authHooks';
 import modalDialogActions from '../../actions/modalDialogActions';
-import { getClusterMaxWorkers, getWorkerCpuMax, getWorkerMemoryMax } from '../../config/clusters';
+import { getClusterMaxWorkers, getWorkerCpuMax, getWorkerMemoryMax, getCondaRequired } from '../../config/clusters';
 import { MODAL_TYPE_CREATE_CLUSTER, MODAL_TYPE_CONFIRMATION } from '../../constants/modaltypes';
 import { useDataStorageForUserInProject } from '../../hooks/dataStorageHooks';
 import dataStorageActions from '../../actions/dataStorageActions';
@@ -122,6 +122,7 @@ export const getDialogProps = (dispatch, projectKey, clusterType, dataStores) =>
   clusterMaxWorkers: getClusterMaxWorkers(clusterType),
   workerMaxMemory: getWorkerMemoryMax(clusterType),
   workerMaxCpu: getWorkerCpuMax(clusterType),
+  condaRequired: getCondaRequired(clusterType),
   dataStorageOptions: dataStores.map(store => ({ text: store.displayName, value: store.name })),
   projectKey,
 });

--- a/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.spec.js
@@ -55,6 +55,7 @@ const setMocks = () => {
   mockCluster.getClusterMaxWorkers.mockReturnValue({ lowerLimit: 1, default: 4, upperLimit: 8 });
   mockCluster.getWorkerMemoryMax.mockReturnValue({ lowerLimit: 0.5, default: 4, upperLimit: 8 });
   mockCluster.getWorkerCpuMax.mockReturnValue({ lowerLimit: 0.5, default: 0.5, upperLimit: 2 });
+  mockCluster.getCondaRequired.mockReturnValue(true);
   mockClusterActions.loadClusters = mockLoadClustersAction;
   mockClusterActions.createCluster = mockCreateClusterAction;
   mockModalDialogActions.closeModalDialog = mockCloseModalDialogAction;

--- a/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
@@ -99,6 +99,7 @@ Object {
     "lowerLimit": 1,
     "upperLimit": 8,
   },
+  "condaRequired": true,
   "dataStorageOptions": Array [],
   "formName": "createCluster",
   "onCancel": [Function],

--- a/code/workspaces/web-app/src/pages/SparkPage.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.js
@@ -17,8 +17,7 @@ const useStyles = makeStyles(theme => ({
 export const getPythonMessage = (condaPath, schedulerAddress) => {
   const pythonVersionString = `${condaPath}/bin/python`;
 
-  return `
-import os
+  return `import os
 import pyspark
 
 conf = pyspark.SparkConf()

--- a/code/workspaces/web-app/src/pages/SparkPage.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.js
@@ -14,13 +14,28 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const copySnippet = ({ schedulerAddress }) => {
-  const message = `# Paste this into your notebook cell
+export const getPythonMessage = (condaPath, schedulerAddress) => {
+  const pythonVersionString = `${condaPath}/bin/python`;
+
+  return `
+import os
 import pyspark
 
-sc = pyspark.SparkContext(master="${schedulerAddress}")
+conf = pyspark.SparkConf()
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+conf.set('spark.executor.memory', '3g')
+
+os.environ["PYSPARK_PYTHON"] = "${pythonVersionString}"
+os.environ["PYSPARK_DRIVER_PYTHON"] = "${pythonVersionString}"
+
+sc = pyspark.SparkContext(master="${schedulerAddress}", conf=conf)
 sc
 `;
+};
+
+const copySnippet = ({ condaPath, schedulerAddress }) => {
+  const message = getPythonMessage(condaPath, schedulerAddress);
   try {
     copy(message);
     notify.success('Clipboard contains snippet for notebook cell');

--- a/code/workspaces/web-app/src/pages/SparkPage.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.js
@@ -14,8 +14,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export const getPythonMessage = (condaPath, schedulerAddress) => {
+export const getPythonMessage = (condaPath, schedulerAddress, maxWorkerMemoryGb) => {
   const pythonVersionString = `${condaPath}/bin/python`;
+
+  // 1GB is reserved, and Spark expects integer values for the executor memory.
+  const mem = Math.floor(maxWorkerMemoryGb) - 1;
 
   return `import os
 import pyspark
@@ -23,7 +26,7 @@ import pyspark
 conf = pyspark.SparkConf()
 # The below option can be altered depending on your memory requirement.
 # The maximum value is the amount of memory assigned to each worker, minus 1GB.
-conf.set('spark.executor.memory', '3g')
+conf.set('spark.executor.memory', '${mem}g')
 
 os.environ["PYSPARK_PYTHON"] = "${pythonVersionString}"
 os.environ["PYSPARK_DRIVER_PYTHON"] = "${pythonVersionString}"
@@ -33,8 +36,8 @@ sc
 `;
 };
 
-const copySnippet = ({ condaPath, schedulerAddress }) => {
-  const message = getPythonMessage(condaPath, schedulerAddress);
+const copySnippet = ({ condaPath, schedulerAddress, maxWorkerMemoryGb }) => {
+  const message = getPythonMessage(condaPath, schedulerAddress, maxWorkerMemoryGb);
   try {
     copy(message);
     notify.success('Clipboard contains snippet for notebook cell');

--- a/code/workspaces/web-app/src/pages/SparkPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow } from '@material-ui/core/test-utils';
-import SparkPage from './SparkPage';
+import SparkPage, { getPythonMessage } from './SparkPage';
 
 describe('SparkPage', () => {
   let shallow;
@@ -11,5 +11,14 @@ describe('SparkPage', () => {
 
   it('renders correct snapshot', () => {
     expect(shallow(<SparkPage />)).toMatchSnapshot();
+  });
+});
+
+describe('getMessage', () => {
+  it('returns the correct message', () => {
+    const condaPath = '/data/conda/myenv';
+    const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
+
+    expect(getPythonMessage(condaPath, schedulerAddress)).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/pages/SparkPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.spec.js
@@ -22,4 +22,12 @@ describe('getMessage', () => {
 
     expect(getPythonMessage(condaPath, schedulerAddress, maxMemory)).toMatchSnapshot();
   });
+
+  it('returns the correct message if memory is not an integer', () => {
+    const condaPath = '/data/conda/myenv';
+    const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
+    const maxMemory = 5.5;
+
+    expect(getPythonMessage(condaPath, schedulerAddress, maxMemory)).toMatchSnapshot();
+  });
 });

--- a/code/workspaces/web-app/src/pages/SparkPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.spec.js
@@ -18,7 +18,8 @@ describe('getMessage', () => {
   it('returns the correct message', () => {
     const condaPath = '/data/conda/myenv';
     const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
+    const maxMemory = 4;
 
-    expect(getPythonMessage(condaPath, schedulerAddress)).toMatchSnapshot();
+    expect(getPythonMessage(condaPath, schedulerAddress, maxMemory)).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
@@ -27,3 +27,21 @@ exports[`SparkPage renders correct snapshot 1`] = `
   </div>
 </WithStyles(Page)>
 `;
+
+exports[`getMessage returns the correct message 1`] = `
+"
+import os
+import pyspark
+
+conf = pyspark.SparkConf()
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+conf.set('spark.executor.memory', '3g')
+
+os.environ[\\"PYSPARK_PYTHON\\"] = \\"/data/conda/myenv/bin/python\\"
+os.environ[\\"PYSPARK_DRIVER_PYTHON\\"] = \\"/data/conda/myenv/bin/python\\"
+
+sc = pyspark.SparkContext(master=\\"spark://spark-scheduler-mycluster:7077\\", conf=conf)
+sc
+"
+`;

--- a/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
@@ -29,8 +29,7 @@ exports[`SparkPage renders correct snapshot 1`] = `
 `;
 
 exports[`getMessage returns the correct message 1`] = `
-"
-import os
+"import os
 import pyspark
 
 conf = pyspark.SparkConf()

--- a/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
@@ -44,3 +44,20 @@ sc = pyspark.SparkContext(master=\\"spark://spark-scheduler-mycluster:7077\\", c
 sc
 "
 `;
+
+exports[`getMessage returns the correct message if memory is not an integer 1`] = `
+"import os
+import pyspark
+
+conf = pyspark.SparkConf()
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+conf.set('spark.executor.memory', '4g')
+
+os.environ[\\"PYSPARK_PYTHON\\"] = \\"/data/conda/myenv/bin/python\\"
+os.environ[\\"PYSPARK_DRIVER_PYTHON\\"] = \\"/data/conda/myenv/bin/python\\"
+
+sc = pyspark.SparkContext(master=\\"spark://spark-scheduler-mycluster:7077\\", conf=conf)
+sc
+"
+`;


### PR DESCRIPTION
Updated the per-project Spark template to have the correct master URL.
Also updated the Spark image in the config to just use the nerc k8s one, which is now based on bitnami.