### PR TITLE
NERCDL-1128: Spark R snippets

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -90,7 +90,7 @@ function styles(theme) {
 }
 
 const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartStack, typeName,
-  userPermissions, openPermission, deletePermission, editPermission, getLogs, shareStack, copySnippet }) => {
+  userPermissions, openPermission, deletePermission, editPermission, getLogs, shareStack, copySnippets }) => {
   const users = useUsers();
   const storeDisplayValue = (typeName === STORAGE_TYPE_NAME && stack.type) ? storageDisplayValue(stack.type) : '';
   const description = getDescription(stack, typeName);
@@ -130,7 +130,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
           editStack={editStack}
           restartStack={restartStack}
           getLogs={getLogs}
-          copySnippet={copySnippet}
+          copySnippets={copySnippets}
           userPermissions={userPermissions}
           openPermission={openPermission}
           deletePermission={deletePermission}
@@ -165,6 +165,7 @@ StackCard.propTypes = {
   openPermission: PropTypes.string,
   deletePermission: PropTypes.string,
   editPermission: PropTypes.string,
+  copySnippets: PropTypes.objectOf(PropTypes.func),
 };
 
 function getDisplayName(stack) {

--- a/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
@@ -34,7 +34,9 @@ describe('StackCard', () => {
     deleteStack: jest.fn().mockName('deleteStack'),
     shareStack: jest.fn().mockName('shareStack'),
     restartStack: jest.fn().mockName('restartStack'),
-    copySnippet: jest.fn().mockName('copySnippet'),
+    copySnippets: {
+      Python: jest.fn().mockName('copyPythonSnippet'),
+    },
     typeName: 'notebook',
     ...permissionProps,
   });

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
@@ -40,7 +40,7 @@ const StackCardActions = (props) => {
   />;
 };
 
-export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack, restartStack, copySnippet, userActions,
+export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack, restartStack, copySnippets, userActions,
   userPermissions, openPermission, deletePermission, editPermission, currentUserId, classes, getLogs, shareStack }) => {
   // Treat user as owner if 'users' not a defined field on stack.
   // This is the case for projects which also use this component. This will mean that
@@ -63,7 +63,7 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
   const shouldRenderShare = userActions.share && shareStack !== undefined;
   const shouldRenderRestart = userActions.restart && restartStack !== undefined;
   const shouldRenderDelete = userActions.delete && deleteStack !== undefined;
-  const shouldRenderCopySnippet = userActions.copySnippet && copySnippet !== undefined;
+  const shouldRenderCopySnippet = userActions.copySnippets && copySnippets !== undefined;
   const shouldRenderMenuItems = shouldRenderLogs
     || shouldRenderEdit
     || shouldRenderShare
@@ -141,14 +141,15 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
         >
           Restart
         </StackMoreMenuItem>
-        <StackMoreMenuItem
+        {copySnippets !== undefined && Object.keys(copySnippets).map(k => <StackMoreMenuItem
           shouldRender={shouldRenderCopySnippet}
-          onClick={() => { handleMoreMenuClose(); copySnippet(stack); }}
+          onClick={() => { handleMoreMenuClose(); copySnippets[k](stack); }}
           userPermissions={userPermissions}
           requiredPermission={openPermission}
+          key={k}
         >
-          Copy snippet
-        </StackMoreMenuItem>
+          {`Copy ${k} snippet`}
+        </StackMoreMenuItem>)}
         <StackMoreMenuItem
           shouldRender={shouldRenderDelete}
           onClick={() => deleteStack(stack)}
@@ -176,7 +177,7 @@ const sharedPropTypes = {
   restartStack: PropTypes.func,
   getLogs: PropTypes.func,
   shareStack: PropTypes.func,
-  copySnippet: PropTypes.func,
+  copySnippets: PropTypes.objectOf(PropTypes.func),
   userPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
   openPermission: PropTypes.string,
   deletePermission: PropTypes.string,
@@ -193,7 +194,7 @@ PureStackCardActions.propTypes = {
     restart: PropTypes.bool,
     delete: PropTypes.bool,
     logs: PropTypes.bool,
-    copySnippet: PropTypes.bool,
+    copySnippets: PropTypes.bool,
   }).isRequired,
 };
 

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
@@ -13,7 +13,9 @@ const deleteStackMock = jest.fn().mockName('deleteStack');
 const editStackMock = jest.fn().mockName('editStack');
 const shareStackMock = jest.fn().mockName('shareStack');
 const restartStackMock = jest.fn().mockName('restartStack');
-const copySnippetMock = jest.fn().mockName('copySnippet');
+const copySnippetsMock = {
+  Python: jest.fn().mockName('copyPythonSnippet'),
+};
 
 const generateProps = () => ({
   stack: {
@@ -30,7 +32,7 @@ const generateProps = () => ({
   editStack: editStackMock,
   shareStack: shareStackMock,
   restartStack: restartStackMock,
-  copySnippet: copySnippetMock,
+  copySnippets: copySnippetsMock,
   userPermissions: ['open', 'delete', 'edit'],
   openPermission: 'open',
   deletePermission: 'delete',
@@ -82,6 +84,23 @@ describe('PureStackCardActions', () => {
   it('creates correct snapshot', () => {
     // Arrange
     const props = generateProps();
+
+    // Act
+    const output = shallowRender(props);
+
+    // Assert
+    expect(output).toMatchSnapshot();
+  });
+
+  it('creates correct snapshot if there are multiple copy snippets', () => {
+    // Arrange
+    const props = {
+      ...generateProps(),
+      copySnippets: {
+        Python: jest.fn().mockName('copyPythonSnippet'),
+        R: jest.fn().mockName('copyRSnippet'),
+      },
+    };
 
     // Act
     const output = shallowRender(props);

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/__snapshots__/StackCardActions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/__snapshots__/StackCardActions.spec.js.snap
@@ -131,6 +131,7 @@ exports[`PureStackCardActions Should not render edit/delete buttons if functions
         Restart
       </ForwardRef>
       <ForwardRef
+        key="Python"
         onClick={[Function]}
         requiredPermission="open"
         userPermissions={
@@ -141,7 +142,7 @@ exports[`PureStackCardActions Should not render edit/delete buttons if functions
           ]
         }
       >
-        Copy snippet
+        Copy Python snippet
       </ForwardRef>
       <ForwardRef
         onClick={[Function]}
@@ -327,6 +328,7 @@ exports[`PureStackCardActions Should render Open as disabled if stack is not rea
         Restart
       </ForwardRef>
       <ForwardRef
+        key="Python"
         onClick={[Function]}
         requiredPermission="open"
         userPermissions={
@@ -337,7 +339,7 @@ exports[`PureStackCardActions Should render Open as disabled if stack is not rea
           ]
         }
       >
-        Copy snippet
+        Copy Python snippet
       </ForwardRef>
       <ForwardRef
         onClick={[Function]}
@@ -489,6 +491,7 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
         Restart
       </ForwardRef>
       <ForwardRef
+        key="Python"
         onClick={[Function]}
         requiredPermission="open"
         userPermissions={
@@ -499,7 +502,184 @@ exports[`PureStackCardActions creates correct snapshot 1`] = `
           ]
         }
       >
-        Copy snippet
+        Copy Python snippet
+      </ForwardRef>
+      <ForwardRef
+        onClick={[Function]}
+        requiredPermission="delete"
+        shouldRender={true}
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Delete
+      </ForwardRef>
+    </WithStyles(ForwardRef(Menu))>
+  </ComponentWrapper>
+</div>
+`;
+
+exports[`PureStackCardActions creates correct snapshot if there are multiple copy snippets 1`] = `
+<div
+  className="cardActions"
+>
+  <ComponentWrapper
+    className="buttonWrapper"
+    permission="open"
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "edit",
+      ]
+    }
+  >
+    <WithStyles(ForwardRef(Tooltip))
+      disableHoverListener={true}
+      placement="bottom-start"
+      title="Cannot be opened until resource is ready"
+    >
+      <div>
+        <ForwardRef
+          disabled={false}
+          fullWidth={true}
+          onClick={[Function]}
+        >
+          Open
+        </ForwardRef>
+      </div>
+    </WithStyles(ForwardRef(Tooltip))>
+  </ComponentWrapper>
+  <ComponentWrapper
+    className="buttonWrapper"
+    permission="delete"
+    userPermissions={
+      Array [
+        "open",
+        "delete",
+        "edit",
+      ]
+    }
+  >
+    <SecondaryActionButton
+      aria-controls="more-menu"
+      aria-haspopup="true"
+      fullWidth={true}
+      onClick={[Function]}
+    >
+      <WithStyles(ForwardRef(Icon))
+        style={
+          Object {
+            "color": "inherit",
+          }
+        }
+      >
+        more_vert
+      </WithStyles(ForwardRef(Icon))>
+    </SecondaryActionButton>
+    <WithStyles(ForwardRef(Menu))
+      anchorEl={null}
+      id="more-menu"
+      keepMounted={true}
+      onClose={[Function]}
+      open={false}
+      transformOrigin={
+        Object {
+          "horizontal": "right",
+          "vertical": "top",
+        }
+      }
+    >
+      <ForwardRef
+        onClick={[Function]}
+        requiredPermission="delete"
+        shouldRender={false}
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Logs
+      </ForwardRef>
+      <ForwardRef
+        onClick={[Function]}
+        requiredPermission="edit"
+        shouldRender={true}
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Edit
+      </ForwardRef>
+      <ForwardRef
+        disableTooltip={true}
+        disabled={false}
+        onClick={[Function]}
+        requiredPermission="delete"
+        shouldRender={true}
+        tooltipText="Resource is already shared within the project"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Share
+      </ForwardRef>
+      <ForwardRef
+        onClick={[Function]}
+        requiredPermission="edit"
+        shouldRender={true}
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Restart
+      </ForwardRef>
+      <ForwardRef
+        key="Python"
+        onClick={[Function]}
+        requiredPermission="open"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Copy Python snippet
+      </ForwardRef>
+      <ForwardRef
+        key="R"
+        onClick={[Function]}
+        requiredPermission="open"
+        userPermissions={
+          Array [
+            "open",
+            "delete",
+            "edit",
+          ]
+        }
+      >
+        Copy R snippet
       </ForwardRef>
       <ForwardRef
         onClick={[Function]}
@@ -651,6 +831,7 @@ exports[`PureStackCardActions should not render button if userAction for that bu
         Restart
       </ForwardRef>
       <ForwardRef
+        key="Python"
         onClick={[Function]}
         requiredPermission="open"
         userPermissions={
@@ -661,7 +842,7 @@ exports[`PureStackCardActions should not render button if userAction for that bu
           ]
         }
       >
-        Copy snippet
+        Copy Python snippet
       </ForwardRef>
       <ForwardRef
         onClick={[Function]}
@@ -690,7 +871,11 @@ exports[`StackCardActions passes props down to child component as well as curren
       "cardActions": "StackCardActions-cardActions-1",
     }
   }
-  copySnippet={[MockFunction copySnippet]}
+  copySnippets={
+    Object {
+      "Python": [MockFunction copyPythonSnippet],
+    }
+  }
   currentUserId="owner-id"
   deletePermission="delete"
   deleteStack={[MockFunction deleteStack]}

--- a/code/workspaces/web-app/src/components/stacks/StackCards.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles(theme => ({
 
 const StackCards = (
   { stacks, typeName, typeNamePlural, openStack, deleteStack, editStack, restartStack, openCreationForm, showCreateButton,
-    userPermissions, createPermission, openPermission, deletePermission, editPermission, getLogs, shareStack, copySnippet = undefined },
+    userPermissions, createPermission, openPermission, deletePermission, editPermission, getLogs, shareStack, copySnippets = undefined },
 ) => {
   const classes = useStyles();
   const sortedStacks = stacks.fetching ? [] : sortBy(stacks.value, stack => stack.displayName.toLowerCase());
@@ -47,7 +47,7 @@ const StackCards = (
         deletePermission={deletePermission}
         editPermission={editPermission}
         getLogs={getLogs}
-        copySnippet={copySnippet}
+        copySnippets={copySnippets}
       />))
     : [<div className={classes.placeholderCard} key={'placeholder-card'}>
         <Typography variant="body1">{`No ${typeNamePlural || 'items'} to display.`}</Typography>
@@ -89,5 +89,5 @@ StackCards.propTypes = {
   openPermission: PropTypes.string,
   deletePermission: PropTypes.string,
   editPermission: PropTypes.string,
-  copySnippet: PropTypes.func,
+  copySnippets: PropTypes.objectOf(PropTypes.func),
 };

--- a/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCards.spec.js
@@ -22,7 +22,9 @@ describe('StackCards', () => {
     openCreationForm: jest.fn().mockName('openCreationForm'),
     editStack: jest.fn().mockName('editStack'),
     restartStack: jest.fn().mockName('restartStack'),
-    copySnippet: jest.fn().mockName('copySnippet'),
+    copySnippets: {
+      Python: jest.fn().mockName('copyPythonSnippet'),
+    },
     userPermissions: () => ['open', 'delete', 'create', 'edit'],
     openPermission: 'open',
     deletePermission: 'delete',

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -44,7 +44,11 @@ exports[`StackCard creates correct snapshot for Jupyter stack type 1`] = `
     className="StackCard-actionsDiv-6"
   >
     <WithStyles(StackCardActions)
-      copySnippet={[MockFunction copySnippet]}
+      copySnippets={
+        Object {
+          "Python": [MockFunction copyPythonSnippet],
+        }
+      }
       deletePermission="delete"
       deleteStack={[MockFunction deleteStack]}
       editPermission="edit"
@@ -117,7 +121,11 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
     className="StackCard-actionsDiv-6"
   >
     <WithStyles(StackCardActions)
-      copySnippet={[MockFunction copySnippet]}
+      copySnippets={
+        Object {
+          "Python": [MockFunction copyPythonSnippet],
+        }
+      }
       deletePermission="delete"
       deleteStack={[MockFunction deleteStack]}
       editPermission="edit"
@@ -190,7 +198,11 @@ exports[`StackCard creates correct snapshot for glusterfs stack type 1`] = `
     className="StackCard-actionsDiv-6"
   >
     <WithStyles(StackCardActions)
-      copySnippet={[MockFunction copySnippet]}
+      copySnippets={
+        Object {
+          "Python": [MockFunction copyPythonSnippet],
+        }
+      }
       deletePermission="delete"
       deleteStack={[MockFunction deleteStack]}
       editPermission="edit"
@@ -270,7 +282,11 @@ exports[`StackCard should show status ad buttons when status is ready 1`] = `
       />
     </div>
     <WithStyles(StackCardActions)
-      copySnippet={[MockFunction copySnippet]}
+      copySnippets={
+        Object {
+          "Python": [MockFunction copyPythonSnippet],
+        }
+      }
       deletePermission="delete"
       deleteStack={[MockFunction deleteStack]}
       editPermission="edit"

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCards.spec.js.snap
@@ -33,7 +33,11 @@ exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
       items={
         Array [
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"
@@ -59,7 +63,11 @@ exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
             }
           />,
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"
@@ -85,7 +93,11 @@ exports[`StackCards creates correct snapshot for an array of stacks 1`] = `
             }
           />,
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"
@@ -228,7 +240,11 @@ exports[`StackCards creates correct snapshot when no create button 1`] = `
       items={
         Array [
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"
@@ -254,7 +270,11 @@ exports[`StackCards creates correct snapshot when no create button 1`] = `
             }
           />,
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"
@@ -280,7 +300,11 @@ exports[`StackCards creates correct snapshot when no create button 1`] = `
             }
           />,
           <ForwardRef(WithStyles)
-            copySnippet={[MockFunction copySnippet]}
+            copySnippets={
+              Object {
+                "Python": [MockFunction copyPythonSnippet],
+              }
+            }
             deletePermission="delete"
             deleteStack={[MockFunction deleteStack]}
             editPermission="edit"

--- a/code/workspaces/web-app/src/config/__snapshots__/images.spec.js.snap
+++ b/code/workspaces/web-app/src/config/__snapshots__/images.spec.js.snap
@@ -90,7 +90,7 @@ Object {
 
 exports[`getUserActionsForType returns all as true if cannot find type 1`] = `
 Object {
-  "copySnippet": true,
+  "copySnippets": true,
   "delete": true,
   "edit": true,
   "logs": true,
@@ -101,7 +101,7 @@ Object {
 
 exports[`getUserActionsForType returns to match snapshot for site type with logs userActionOverrides 1`] = `
 Object {
-  "copySnippet": true,
+  "copySnippets": true,
   "delete": true,
   "edit": true,
   "logs": true,
@@ -112,7 +112,7 @@ Object {
 
 exports[`getUserActionsForType returns to match snapshot for site type with no logs userActionOverrides 1`] = `
 Object {
-  "copySnippet": true,
+  "copySnippets": true,
   "delete": true,
   "edit": true,
   "logs": false,

--- a/code/workspaces/web-app/src/config/images.js
+++ b/code/workspaces/web-app/src/config/images.js
@@ -57,7 +57,7 @@ function calculateUserActionsForType(type) {
 }
 
 function getActionDefaults() {
-  const possibleActions = ['share', 'edit', 'restart', 'delete', 'logs', 'copySnippet'];
+  const possibleActions = ['share', 'edit', 'restart', 'delete', 'logs', 'copySnippets'];
   const defaultValue = true;
   return possibleActions.reduce(
     (returnValue, actionName) => {

--- a/code/workspaces/web-app/src/containers/clusters/ClustersContainer.js
+++ b/code/workspaces/web-app/src/containers/clusters/ClustersContainer.js
@@ -3,16 +3,16 @@ import { useCurrentProjectKey } from '../../hooks/currentProjectHooks';
 import { useCurrentUserPermissions } from '../../hooks/authHooks';
 import ProjectClustersContainer from './ProjectClustersContainer';
 
-const ClustersContainer = ({ clusterType, copySnippet }) => {
+const ClustersContainer = ({ clusterType, copySnippets }) => {
   const { value: projectKey } = useCurrentProjectKey();
   const { value: userPermissions } = useCurrentUserPermissions();
   const modifyData = true;
-  return ProjectClustersContainer({ clusterType, projectKey, userPermissions, modifyData, copySnippet });
+  return ProjectClustersContainer({ clusterType, projectKey, userPermissions, modifyData, copySnippets });
 };
 
 export default ClustersContainer;
 
 ClustersContainer.propTypes = {
   clusterType: PropTypes.string.isRequired,
-  copySnippet: PropTypes.func,
+  copySnippets: PropTypes.objectOf(PropTypes.func),
 };

--- a/code/workspaces/web-app/src/containers/clusters/ClustersContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/clusters/ClustersContainer.spec.js
@@ -39,10 +39,12 @@ mockCluster.getClusterMaxWorkers.mockReturnValue({ lowerLimit: 1, default: 4, up
 mockCluster.getWorkerMemoryMax.mockReturnValue({ lowerLimit: 0.5, default: 4, upperLimit: 8 });
 mockCluster.getWorkerCpuMax.mockReturnValue({ lowerLimit: 0.5, default: 0.5, upperLimit: 2 });
 
-const copyMock = () => {};
+const copyMock = {
+  Python: () => {},
+};
 
 describe('ClustersContainer', () => {
-  const getShallowRender = () => shallow(<ClustersContainer clusterType="DASK" copySnippet={copyMock}/>);
+  const getShallowRender = () => shallow(<ClustersContainer clusterType="DASK" copySnippets={copyMock}/>);
 
   it('renders correct snapshot', () => {
     expect(getShallowRender()).toMatchSnapshot();

--- a/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.js
+++ b/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.js
@@ -50,7 +50,7 @@ const getOpenCreationForm = (dispatch, projectKey, clusterType, dataStores) => {
   return undefined;
 };
 
-const ProjectClustersContainer = ({ clusterType, projectKey, userPermissions, modifyData, copySnippet }) => {
+const ProjectClustersContainer = ({ clusterType, projectKey, userPermissions, modifyData, copySnippets }) => {
   const dispatch = useDispatch();
   const currentUserId = useCurrentUserId();
   const { value: dataStores } = useDataStorageForUserInProject(currentUserId, projectKey);
@@ -76,7 +76,7 @@ const ProjectClustersContainer = ({ clusterType, projectKey, userPermissions, mo
         createPermission={projectKeyPermission(PROJECT_KEY_CLUSTERS_CREATE, projectKey)}
         showCreateButton={modifyData}
         deleteStack={modifyData ? confirmDeleteCluster(dispatch) : undefined}
-        copySnippet={copySnippet}
+        copySnippets={copySnippets}
         deletePermission={projectKeyPermission(PROJECT_KEY_CLUSTERS_DELETE, projectKey)}
         editPermission={projectKeyPermission(PROJECT_KEY_CLUSTERS_EDIT, projectKey)}
         openPermission={projectKeyPermission(PROJECT_KEY_CLUSTERS_OPEN, projectKey)}
@@ -131,5 +131,5 @@ export default ProjectClustersContainer;
 
 ProjectClustersContainer.propTypes = {
   clusterType: PropTypes.string,
-  copySnippet: PropTypes.func,
+  copySnippets: PropTypes.objectOf(PropTypes.func),
 };

--- a/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/clusters/ProjectClustersContainer.spec.js
@@ -61,7 +61,9 @@ const setMocks = () => {
   mockModalDialogActions.closeModalDialog = mockCloseModalDialogAction;
 };
 
-const copyMock = () => {};
+const copyMock = {
+  Python: () => {},
+};
 
 describe('ProjectClustersContainer', () => {
   beforeEach(() => {
@@ -70,12 +72,12 @@ describe('ProjectClustersContainer', () => {
   });
 
   it('renders correct snapshot for all clusters', () => {
-    const getShallowRender = () => shallow(<ProjectClustersContainer projectKey="project-key" userPermissions={[]} modifyData copySnippet={copyMock}/>);
+    const getShallowRender = () => shallow(<ProjectClustersContainer projectKey="project-key" userPermissions={[]} modifyData copySnippets={copyMock}/>);
     expect(getShallowRender()).toMatchSnapshot();
   });
 
   it('renders correct snapshot for Dask clusters', () => {
-    const getShallowRender = () => shallow(<ProjectClustersContainer clusterType="DASK" projectKey="project-key" userPermissions={[]} modifyData copySnippet={copyMock}/>);
+    const getShallowRender = () => shallow(<ProjectClustersContainer clusterType="DASK" projectKey="project-key" userPermissions={[]} modifyData copySnippets={copyMock}/>);
     expect(getShallowRender()).toMatchSnapshot();
   });
 
@@ -93,7 +95,7 @@ describe('ProjectClustersContainer', () => {
       ],
     }));
 
-    const getShallowRender = () => shallow(<ProjectClustersContainer clusterType="SPARK" projectKey="project-key" userPermissions={[]} modifyData copySnippet={copyMock}/>);
+    const getShallowRender = () => shallow(<ProjectClustersContainer clusterType="SPARK" projectKey="project-key" userPermissions={[]} modifyData copySnippets={copyMock}/>);
     expect(getShallowRender()).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/containers/clusters/__snapshots__/ClustersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/clusters/__snapshots__/ClustersContainer.spec.js.snap
@@ -2,7 +2,11 @@
 
 exports[`ClustersContainer renders correct snapshot 1`] = `
 <StackCards
-  copySnippet={[Function]}
+  copySnippets={
+    Object {
+      "Python": [Function],
+    }
+  }
   createPermission="projects:current-project:clusters:create"
   deletePermission="projects:current-project:clusters:delete"
   deleteStack={[Function]}

--- a/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
@@ -2,7 +2,11 @@
 
 exports[`ProjectClustersContainer renders correct snapshot for Dask clusters 1`] = `
 <StackCards
-  copySnippet={[Function]}
+  copySnippets={
+    Object {
+      "Python": [Function],
+    }
+  }
   createPermission="projects:project-key:clusters:create"
   deletePermission="projects:project-key:clusters:delete"
   deleteStack={[Function]}
@@ -33,7 +37,11 @@ exports[`ProjectClustersContainer renders correct snapshot for Dask clusters 1`]
 
 exports[`ProjectClustersContainer renders correct snapshot for Spark clusters 1`] = `
 <StackCards
-  copySnippet={[Function]}
+  copySnippets={
+    Object {
+      "Python": [Function],
+    }
+  }
   createPermission="projects:project-key:clusters:create"
   deletePermission="projects:project-key:clusters:delete"
   deleteStack={[Function]}
@@ -64,7 +72,11 @@ exports[`ProjectClustersContainer renders correct snapshot for Spark clusters 1`
 
 exports[`ProjectClustersContainer renders correct snapshot for all clusters 1`] = `
 <StackCards
-  copySnippet={[Function]}
+  copySnippets={
+    Object {
+      "Python": [Function],
+    }
+  }
   createPermission="projects:project-key:clusters:create"
   deletePermission="projects:project-key:clusters:delete"
   deleteStack={[Function]}

--- a/code/workspaces/web-app/src/pages/DaskPage.js
+++ b/code/workspaces/web-app/src/pages/DaskPage.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const copySnippet = ({ schedulerAddress }) => {
+const copyPythonSnippet = ({ schedulerAddress }) => {
   const proxyAddress = schedulerAddress.replace('tcp://', 'proxy/').replace('8786', '8787');
   const message = `# Paste this into your notebook cell
 # Note that the Dask scheduler can be accessed from the Dask JupyterLab extension with address
@@ -34,6 +34,10 @@ c
 const DaskPage = () => {
   const classes = useStyles();
 
+  const copySnippets = {
+    Python: copyPythonSnippet,
+  };
+
   return (
     <Page className={''} title="Dask">
       <Typography variant="body1">
@@ -43,7 +47,7 @@ const DaskPage = () => {
         Dask can only be used with Python.
       </Typography>
       <div className={classes.clusterList}>
-        <ClustersContainer clusterType={DASK_CLUSTER_TYPE} copySnippet={copySnippet} />
+        <ClustersContainer clusterType={DASK_CLUSTER_TYPE} copySnippets={copySnippets} />
       </div>
     </Page>
   );

--- a/code/workspaces/web-app/src/pages/SparkPage.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.js
@@ -70,6 +70,11 @@ const copyRSnippet = ({ schedulerAddress, maxWorkerMemoryGb }) => {
 const SparkPage = () => {
   const classes = useStyles();
 
+  const copySnippets = {
+    Python: copyPythonSnippet,
+    R: copyRSnippet,
+  };
+
   return (
     <Page className={''} title="Spark">
       <Typography variant="body1">
@@ -78,7 +83,7 @@ const SparkPage = () => {
         to be deployed across the cluster.
       </Typography>
       <div className={classes.clusterList}>
-        <ClustersContainer clusterType={SPARK_CLUSTER_TYPE} copySnippet={copySnippet} />
+        <ClustersContainer clusterType={SPARK_CLUSTER_TYPE} copySnippets={copySnippets} />
       </div>
     </Page>
   );

--- a/code/workspaces/web-app/src/pages/SparkPage.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.js
@@ -36,8 +36,29 @@ sc
 `;
 };
 
-const copySnippet = ({ condaPath, schedulerAddress, maxWorkerMemoryGb }) => {
+const copyPythonSnippet = ({ condaPath, schedulerAddress, maxWorkerMemoryGb }) => {
   const message = getPythonMessage(condaPath, schedulerAddress, maxWorkerMemoryGb);
+  try {
+    copy(message);
+    notify.success('Clipboard contains snippet for notebook cell');
+  } catch (error) {
+    notify.error('Unable to access clipboard.');
+  }
+};
+
+export const getRMessage = (schedulerAddress, maxWorkerMemoryGb) => {
+  // 1GB is reserved, and Spark expects integer values for the executor memory.
+  const mem = Math.floor(maxWorkerMemoryGb) - 1;
+
+  return `library(SparkR)
+
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+sparkR.session(master="${schedulerAddress}", sparkConfig=list(spark.executor.memory="${mem}g"))`;
+};
+
+const copyRSnippet = ({ schedulerAddress, maxWorkerMemoryGb }) => {
+  const message = getRMessage(schedulerAddress, maxWorkerMemoryGb);
   try {
     copy(message);
     notify.success('Clipboard contains snippet for notebook cell');

--- a/code/workspaces/web-app/src/pages/SparkPage.spec.js
+++ b/code/workspaces/web-app/src/pages/SparkPage.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow } from '@material-ui/core/test-utils';
-import SparkPage, { getPythonMessage } from './SparkPage';
+import SparkPage, { getPythonMessage, getRMessage } from './SparkPage';
 
 describe('SparkPage', () => {
   let shallow;
@@ -14,7 +14,7 @@ describe('SparkPage', () => {
   });
 });
 
-describe('getMessage', () => {
+describe('getPythonMessage', () => {
   it('returns the correct message', () => {
     const condaPath = '/data/conda/myenv';
     const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
@@ -29,5 +29,21 @@ describe('getMessage', () => {
     const maxMemory = 5.5;
 
     expect(getPythonMessage(condaPath, schedulerAddress, maxMemory)).toMatchSnapshot();
+  });
+});
+
+describe('getRMessage', () => {
+  it('returns the correct message', () => {
+    const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
+    const maxMemory = 4;
+
+    expect(getRMessage(schedulerAddress, maxMemory)).toMatchSnapshot();
+  });
+
+  it('returns the correct message if memory is not an integer', () => {
+    const schedulerAddress = 'spark://spark-scheduler-mycluster:7077';
+    const maxMemory = 5.5;
+
+    expect(getRMessage(schedulerAddress, maxMemory)).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/pages/__snapshots__/DaskPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/DaskPage.spec.js.snap
@@ -26,7 +26,11 @@ exports[`DaskPage renders correct snapshot 1`] = `
   >
     <ClustersContainer
       clusterType="DASK"
-      copySnippet={[Function]}
+      copySnippets={
+        Object {
+          "Python": [Function],
+        }
+      }
     />
   </div>
 </WithStyles(Page)>

--- a/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
@@ -22,7 +22,12 @@ exports[`SparkPage renders correct snapshot 1`] = `
   >
     <ClustersContainer
       clusterType="SPARK"
-      copySnippet={[Function]}
+      copySnippets={
+        Object {
+          "Python": [Function],
+          "R": [Function],
+        }
+      }
     />
   </div>
 </WithStyles(Page)>

--- a/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
+++ b/code/workspaces/web-app/src/pages/__snapshots__/SparkPage.spec.js.snap
@@ -28,7 +28,7 @@ exports[`SparkPage renders correct snapshot 1`] = `
 </WithStyles(Page)>
 `;
 
-exports[`getMessage returns the correct message 1`] = `
+exports[`getPythonMessage returns the correct message 1`] = `
 "import os
 import pyspark
 
@@ -45,7 +45,7 @@ sc
 "
 `;
 
-exports[`getMessage returns the correct message if memory is not an integer 1`] = `
+exports[`getPythonMessage returns the correct message if memory is not an integer 1`] = `
 "import os
 import pyspark
 
@@ -60,4 +60,20 @@ os.environ[\\"PYSPARK_DRIVER_PYTHON\\"] = \\"/data/conda/myenv/bin/python\\"
 sc = pyspark.SparkContext(master=\\"spark://spark-scheduler-mycluster:7077\\", conf=conf)
 sc
 "
+`;
+
+exports[`getRMessage returns the correct message 1`] = `
+"library(SparkR)
+
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+sparkR.session(master=\\"spark://spark-scheduler-mycluster:7077\\", sparkConfig=list(spark.executor.memory=\\"3g\\"))"
+`;
+
+exports[`getRMessage returns the correct message if memory is not an integer 1`] = `
+"library(SparkR)
+
+# The below option can be altered depending on your memory requirement.
+# The maximum value is the amount of memory assigned to each worker, minus 1GB.
+sparkR.session(master=\\"spark://spark-scheduler-mycluster:7077\\", sparkConfig=list(spark.executor.memory=\\"4g\\"))"
 `;


### PR DESCRIPTION
Added R snippet to connect to Spark.
This updates the "copySnippets" from being a single function to an object where the keys are language names and values are the copy functions.
Copying Python and R snippets are available for Spark clusters, but only Python snippets are available for Dask clusters.