### PR TITLE
NERCDL-1121: Messages in webapp

### DIFF
--- a/code/workspaces/web-app/src/actions/messagesActions.js
+++ b/code/workspaces/web-app/src/actions/messagesActions.js
@@ -1,0 +1,34 @@
+import messagesService from '../api/messagesService';
+
+export const CREATE_MESSAGE_ACTION = 'CREATE_MESSAGE_ACTION';
+export const DELETE_MESSAGE_ACTION = 'DELETE_MESSAGE_ACTION';
+export const GET_MESSAGES_ACTION = 'GET_MESSAGES_ACTION';
+export const GET_ALL_MESSAGES_ACTION = 'GET_ALL_MESSAGES_ACTION';
+export const DISMISS_MESSAGE_ACTION = 'DISMISS_MESSAGE_ACTION';
+
+const createMessage = message => ({
+  type: CREATE_MESSAGE_ACTION,
+  payload: messagesService.createMessage(message),
+});
+
+const deleteMessage = messageId => ({
+  type: DELETE_MESSAGE_ACTION,
+  payload: messagesService.deleteMessage(messageId),
+});
+
+const getMessages = () => ({
+  type: GET_MESSAGES_ACTION,
+  payload: messagesService.getMessages(),
+});
+
+const getAllMessages = () => ({
+  type: GET_ALL_MESSAGES_ACTION,
+  payload: messagesService.getAllMessages(),
+});
+
+const dismissMessage = messageId => ({
+  type: DISMISS_MESSAGE_ACTION,
+  payload: messageId,
+});
+
+export default { createMessage, deleteMessage, getMessages, getAllMessages, dismissMessage };

--- a/code/workspaces/web-app/src/actions/messagesActions.spec.js
+++ b/code/workspaces/web-app/src/actions/messagesActions.spec.js
@@ -1,0 +1,88 @@
+import messagesActions, {
+  CREATE_MESSAGE_ACTION,
+  DELETE_MESSAGE_ACTION,
+  GET_MESSAGES_ACTION,
+  GET_ALL_MESSAGES_ACTION,
+  DISMISS_MESSAGE_ACTION,
+} from './messagesActions';
+import messagesService from '../api/messagesService';
+
+jest.mock('../api/messagesService');
+
+const { createMessage, deleteMessage, getMessages, getAllMessages } = messagesService;
+
+const messageId = 'msgId';
+const message1 = { id: 'id1' };
+const message2 = { id: 'id2' };
+const messages = [message1, message2];
+
+describe('messagesActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    createMessage.mockReturnValue(message1);
+    deleteMessage.mockReturnValue(message1);
+    getMessages.mockReturnValue(messages);
+    getAllMessages.mockReturnValue(messages);
+  });
+
+  describe('createMessage', () => {
+    it('makes correct api call', () => {
+      const output = messagesActions.createMessage(message1);
+
+      expect(createMessage).toHaveBeenCalledTimes(1);
+      expect(output).toEqual({
+        type: CREATE_MESSAGE_ACTION,
+        payload: message1,
+      });
+    });
+  });
+
+  describe('deleteMessage', () => {
+    it('makes correct api call', () => {
+      const output = messagesActions.deleteMessage(message1);
+
+      expect(deleteMessage).toHaveBeenCalledTimes(1);
+      expect(output).toEqual({
+        type: DELETE_MESSAGE_ACTION,
+        payload: message1,
+      });
+    });
+  });
+
+  describe('getMessages', () => {
+    it('makes correct api call', () => {
+      const output = messagesActions.getMessages();
+
+      expect(getMessages).toHaveBeenCalledTimes(1);
+      expect(output).toEqual({
+        type: GET_MESSAGES_ACTION,
+        payload: messages,
+      });
+    });
+  });
+
+  describe('getAllMessages', () => {
+    it('makes correct api call', () => {
+      const output = messagesActions.getAllMessages();
+
+      expect(getAllMessages).toHaveBeenCalledTimes(1);
+      expect(output).toEqual({
+        type: GET_ALL_MESSAGES_ACTION,
+        payload: messages,
+      });
+    });
+  });
+
+  describe('dismissMessage', () => {
+    it('creates correct action', () => {
+      const output = messagesActions.dismissMessage(messageId);
+
+      expect(output).toEqual({
+        type: DISMISS_MESSAGE_ACTION,
+        payload: messageId,
+      });
+    });
+  });
+});
+

--- a/code/workspaces/web-app/src/api/__snapshots__/messagesService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/messagesService.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`messagesService createMessage should build the correct mutation and unpack the results 1`] = `
+"
+    CreateMessage($cluster: ClusterCreationRequest!) {
+      createMessage(cluster: $cluster) {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  "
+`;
+
+exports[`messagesService deleteMessage should build the correct mutation and unpack the results 1`] = `
+"
+    DeleteMessage($messageId: ID!) {
+      deleteMessage(messageId: $messageId) {
+        id
+      }
+    }"
+`;
+
+exports[`messagesService getAllMessages should build the correct query and unpack the results 1`] = `
+"
+    GetAllMessages {
+      allMessages {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  "
+`;
+
+exports[`messagesService getMessages should build the correct query and unpack the results 1`] = `
+"
+    GetMessages {
+      messages {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  "
+`;

--- a/code/workspaces/web-app/src/api/messagesService.js
+++ b/code/workspaces/web-app/src/api/messagesService.js
@@ -1,7 +1,7 @@
 import { gqlMutation, gqlQuery } from './graphqlClient';
 import errorHandler from './graphqlErrorHandler';
 
-function createMessage(message) {
+async function createMessage(message) {
   const mutation = `
     CreateMessage($cluster: ClusterCreationRequest!) {
       createMessage(cluster: $cluster) {
@@ -13,11 +13,11 @@ function createMessage(message) {
     }
   `;
 
-  return gqlMutation(mutation, { message })
-    .then(errorHandler('data.createMessage'));
+  const response = await gqlMutation(mutation, { message });
+  return errorHandler('data.createMessage')(response);
 }
 
-function deleteMessage(messageId) {
+async function deleteMessage(messageId) {
   const mutation = `
     DeleteMessage($messageId: ID!) {
       deleteMessage(messageId: $messageId) {
@@ -25,11 +25,11 @@ function deleteMessage(messageId) {
       }
     }`;
 
-  return gqlMutation(mutation, { messageId })
-    .then(errorHandler('data'));
+  const response = await gqlMutation(mutation, { messageId });
+  return errorHandler('data')(response);
 }
 
-function getMessages() {
+async function getMessages() {
   const query = `
     GetMessages {
       messages {
@@ -41,11 +41,11 @@ function getMessages() {
     }
   `;
 
-  return gqlQuery(query)
-    .then(errorHandler('data'));
+  const response = await gqlQuery(query);
+  return errorHandler('data')(response);
 }
 
-function getAllMessages() {
+async function getAllMessages() {
   const query = `
     GetAllMessages {
       allMessages {
@@ -57,8 +57,8 @@ function getAllMessages() {
     }
   `;
 
-  return gqlQuery(query)
-    .then(errorHandler('data'));
+  const response = await gqlQuery(query);
+  return errorHandler('data')(response);
 }
 
 export default { createMessage, deleteMessage, getMessages, getAllMessages };

--- a/code/workspaces/web-app/src/api/messagesService.js
+++ b/code/workspaces/web-app/src/api/messagesService.js
@@ -1,0 +1,64 @@
+import { gqlMutation, gqlQuery } from './graphqlClient';
+import errorHandler from './graphqlErrorHandler';
+
+function createMessage(message) {
+  const mutation = `
+    CreateMessage($cluster: ClusterCreationRequest!) {
+      createMessage(cluster: $cluster) {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  `;
+
+  return gqlMutation(mutation, { message })
+    .then(errorHandler('data.createMessage'));
+}
+
+function deleteMessage(messageId) {
+  const mutation = `
+    DeleteMessage($messageId: ID!) {
+      deleteMessage(messageId: $messageId) {
+        id
+      }
+    }`;
+
+  return gqlMutation(mutation, { messageId })
+    .then(errorHandler('data'));
+}
+
+function getMessages() {
+  const query = `
+    GetMessages {
+      messages {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  `;
+
+  return gqlQuery(query)
+    .then(errorHandler('data'));
+}
+
+function getAllMessages() {
+  const query = `
+    GetAllMessages {
+      allMessages {
+        id
+        message
+        expiry
+        created
+      }
+    }
+  `;
+
+  return gqlQuery(query)
+    .then(errorHandler('data'));
+}
+
+export default { createMessage, deleteMessage, getMessages, getAllMessages };

--- a/code/workspaces/web-app/src/api/messagesService.spec.js
+++ b/code/workspaces/web-app/src/api/messagesService.spec.js
@@ -1,0 +1,89 @@
+import mockClient from './graphqlClient';
+import messagesService from './messagesService';
+
+jest.mock('./graphqlClient');
+
+const id = 'id1';
+const message = {
+  id,
+  message: 'Test message',
+  expiry: '2021-12-25',
+  created: '2021-10-31',
+};
+
+describe('messagesService', () => {
+  beforeEach(() => mockClient.clearResult());
+
+  describe('createMessage', () => {
+    it('should build the correct mutation and unpack the results', async () => {
+      const creationResponseData = { id };
+      mockClient.prepareSuccess(creationResponseData);
+
+      await messagesService.createMessage(message);
+
+      expect(mockClient.lastQuery()).toMatchSnapshot();
+      expect(mockClient.lastOptions()).toEqual({ message });
+    });
+
+    it('should throw an error if the mutation fails', async () => {
+      mockClient.prepareFailure('expected error');
+
+      await expect(messagesService.createMessage(message)).rejects.toEqual({ error: 'expected error' });
+    });
+  });
+
+  describe('deleteMessage', () => {
+    it('should build the correct mutation and unpack the results', async () => {
+      const deletionResponseData = { id };
+      mockClient.prepareSuccess(deletionResponseData);
+
+      await messagesService.deleteMessage(id);
+
+      expect(mockClient.lastQuery()).toMatchSnapshot();
+      expect(mockClient.lastOptions()).toEqual({ messageId: id });
+    });
+
+    it('should throw an error if the mutation fails', async () => {
+      mockClient.prepareFailure('expected error');
+
+      await expect(messagesService.deleteMessage(id)).rejects.toEqual({ error: 'expected error' });
+    });
+  });
+
+  describe('getMessages', () => {
+    it('should build the correct query and unpack the results', async () => {
+      mockClient.prepareSuccess([message]);
+
+      const messagesResponse = await messagesService.getMessages();
+
+      expect(mockClient.lastQuery()).toMatchSnapshot();
+      expect(mockClient.lastOptions()).toEqual({});
+      expect(messagesResponse).toEqual([message]);
+    });
+
+    it('should throw an error if the query fails', async () => {
+      mockClient.prepareFailure('expected error');
+
+      await expect(messagesService.getMessages()).rejects.toEqual({ error: 'expected error' });
+    });
+  });
+
+  describe('getAllMessages', () => {
+    it('should build the correct query and unpack the results', async () => {
+      mockClient.prepareSuccess([message]);
+
+      const messagesResponse = await messagesService.getAllMessages();
+
+      expect(mockClient.lastQuery()).toMatchSnapshot();
+      expect(mockClient.lastOptions()).toEqual({});
+      expect(messagesResponse).toEqual([message]);
+    });
+
+    it('should throw an error if the query fails', async () => {
+      mockClient.prepareFailure('expected error');
+
+      await expect(messagesService.getAllMessages()).rejects.toEqual({ error: 'expected error' });
+    });
+  });
+});
+

--- a/code/workspaces/web-app/src/components/app/Message.js
+++ b/code/workspaces/web-app/src/components/app/Message.js
@@ -13,7 +13,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.messageBackground,
     color: theme.palette.message,
     alignItems: 'center',
-    borderRadius: '10px',
+    borderRadius: theme.shape.borderRadius,
   },
   text: {
     flexGrow: 1,

--- a/code/workspaces/web-app/src/components/app/Message.js
+++ b/code/workspaces/web-app/src/components/app/Message.js
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
+import PropTypes from 'prop-types';
 import messagesActions from '../../actions/messagesActions';
 
 const styles = theme => ({
@@ -35,6 +36,16 @@ const Message = ({ classes, message }) => {
     <Button onClick={() => dispatch(messagesActions.dismissMessage(message.id))} color={'secondary'}>Dismiss</Button>
   </div>
   );
+};
+
+Message.propTypes = {
+  classes: PropTypes.object.isRequired,
+  message: PropTypes.shape({
+    id: PropTypes.string,
+    message: PropTypes.string.isRequired,
+    expiry: PropTypes.string,
+    created: PropTypes.string,
+  }).isRequired,
 };
 
 export default withStyles(styles)(Message);

--- a/code/workspaces/web-app/src/components/app/Message.js
+++ b/code/workspaces/web-app/src/components/app/Message.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { withStyles } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
+import messagesActions from '../../actions/messagesActions';
+
+const styles = theme => ({
+  message: {
+    display: 'flex',
+    padding: '5px',
+    margin: '5px',
+    backgroundColor: theme.palette.messageBackground,
+    color: theme.palette.message,
+    alignItems: 'center',
+    borderRadius: '10px',
+  },
+  text: {
+    flexGrow: 1,
+  },
+  icon: {
+    padding: '5px',
+  },
+});
+
+const Message = ({ classes, message }) => {
+  const dispatch = useDispatch();
+
+  return (
+  <div className={classes.message}>
+    <ErrorOutline className={classes.icon}/>
+    <div className={classes.text}>
+      {message.message}
+    </div>
+    <Button onClick={() => dispatch(messagesActions.dismissMessage(message.id))} color={'secondary'}>Dismiss</Button>
+  </div>
+  );
+};
+
+export default withStyles(styles)(Message);

--- a/code/workspaces/web-app/src/components/app/Message.js
+++ b/code/workspaces/web-app/src/components/app/Message.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
@@ -26,6 +26,9 @@ const styles = theme => ({
 
 const Message = ({ classes, message }) => {
   const dispatch = useDispatch();
+  const handleClick = useCallback(() => {
+    dispatch(messagesActions.dismissMessage(message.id));
+  }, [dispatch, message]);
 
   return (
   <div className={classes.message}>
@@ -33,7 +36,7 @@ const Message = ({ classes, message }) => {
     <div className={classes.text}>
       {message.message}
     </div>
-    <Button onClick={() => dispatch(messagesActions.dismissMessage(message.id))} color={'secondary'}>Dismiss</Button>
+    <Button onClick={handleClick} color={'secondary'}>Dismiss</Button>
   </div>
   );
 };

--- a/code/workspaces/web-app/src/components/app/Message.spec.js
+++ b/code/workspaces/web-app/src/components/app/Message.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { createShallow } from '@material-ui/core/test-utils';
+import Message from './Message';
+
+jest.mock('react-redux');
+useDispatch.mockReturnValue(jest.fn().mockName('dispatch'));
+
+describe('Message', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  it('renders correct snapshot', () => {
+    const message = {
+      id: 'id1',
+      message: 'Test message',
+      expiry: '2021-12-25',
+      created: '2021-10-31',
+    };
+    expect(shallow(<Message message={message}/>)).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/components/app/MessageBanner.js
+++ b/code/workspaces/web-app/src/components/app/MessageBanner.js
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import messagesActions from '../../actions/messagesActions';
+import Message from './Message';
+
+const MessageBanner = () => {
+  const dispatch = useDispatch();
+  const messages = useSelector(s => s.messages.value);
+
+  useEffect(() => {
+    dispatch(messagesActions.getMessages());
+  }, [dispatch]);
+
+  return (
+  <div >
+    {messages.map(m => <Message message={m} key={m.id}/>)}
+  </div>
+  );
+};
+
+export default MessageBanner;

--- a/code/workspaces/web-app/src/components/app/MessageBanner.spec.js
+++ b/code/workspaces/web-app/src/components/app/MessageBanner.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { createShallow } from '@material-ui/core/test-utils';
+import MessageBanner from './MessageBanner';
+
+jest.mock('react-redux');
+useDispatch.mockReturnValue(jest.fn().mockName('dispatch'));
+
+const message1 = {
+  id: 'id1',
+  message: 'Test message',
+  expiry: '2021-12-25',
+  created: '2021-10-31',
+};
+const message2 = {
+  id: 'id2',
+  message: 'Other message',
+  expiry: '2021-12-26',
+  created: '2021-11-31',
+};
+const messages = [message1, message2];
+useSelector.mockReturnValue(messages);
+
+describe('MessageBanner', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow();
+  });
+
+  it('renders correct snapshot', () => {
+    expect(shallow(<MessageBanner/>)).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/web-app/src/components/app/Navigation.js
+++ b/code/workspaces/web-app/src/components/app/Navigation.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { withStyles, useTheme } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import TopBar from './TopBar';
 import MessageBanner from './MessageBanner';
 
@@ -9,6 +8,7 @@ const styles = theme => ({
   container: {
     backgroundColor: theme.palette.backgroundColor,
     width: '100%',
+    height: `calc(100vh - ${theme.shape.topBarHeight}px)`,
     paddingTop: theme.shape.topBarHeight,
   },
   appFrame: {
@@ -22,28 +22,22 @@ const styles = theme => ({
     overflow: 'auto',
     flexDirection: 'column',
     width: '100%',
+    height: '100%',
     display: 'flex',
   },
 });
 
-const Navigation = ({ classes, children, identity, userPermissions }) => {
-  const messageCount = useSelector(s => s.messages.value).length;
-  const theme = useTheme();
-  const messagesHeight = messageCount * theme.shape.messageHeight;
-  const heightDiff = theme.shape.topBarHeight + messagesHeight;
-
-  return (
-    <div className={classes.container} style={{ height: `calc(100vh - ${heightDiff}px)` }}>
+const Navigation = ({ classes, children, identity, userPermissions }) => (
+    <div className={classes.container}>
       <div className={classes.appFrame}>
         <TopBar identity={identity} userPermissions={userPermissions} />
-        <main className={classes.pageContainer} style={{ height: `calc(100% + ${messagesHeight}px)` }}>
+        <main className={classes.pageContainer}>
           <MessageBanner/>
           {children}
         </main>
       </div>
     </div>
-  );
-};
+);
 
 Navigation.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/code/workspaces/web-app/src/components/app/Navigation.js
+++ b/code/workspaces/web-app/src/components/app/Navigation.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 import TopBar from './TopBar';
+import MessageBanner from './MessageBanner';
 
 const styles = theme => ({
   container: {
     backgroundColor: theme.palette.backgroundColor,
     width: '100%',
-    height: `calc(100vh - ${theme.shape.topBarHeight}px)`,
     paddingTop: theme.shape.topBarHeight,
   },
   appFrame: {
@@ -17,23 +18,32 @@ const styles = theme => ({
     zIndex: 1,
   },
   pageContainer: {
+    backgroundColor: theme.palette.backgroundColor,
     overflow: 'auto',
+    flexDirection: 'column',
     width: '100%',
-    height: '100%',
     display: 'flex',
   },
 });
 
-const Navigation = ({ classes, children, identity, userPermissions }) => (
-  <div className={classes.container}>
-    <div className={classes.appFrame}>
-      <TopBar identity={identity} userPermissions={userPermissions} />
-      <main className={classes.pageContainer}>
-        {children}
-      </main>
+const Navigation = ({ classes, children, identity, userPermissions }) => {
+  const messageCount = useSelector(s => s.messages.value).length;
+  const theme = useTheme();
+  const messagesHeight = messageCount * theme.shape.messageHeight;
+  const heightDiff = theme.shape.topBarHeight + messagesHeight;
+
+  return (
+    <div className={classes.container} style={{ height: `calc(100vh - ${heightDiff}px)` }}>
+      <div className={classes.appFrame}>
+        <TopBar identity={identity} userPermissions={userPermissions} />
+        <main className={classes.pageContainer} style={{ height: `calc(100% + ${messagesHeight}px)` }}>
+          <MessageBanner/>
+          {children}
+        </main>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Navigation.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/code/workspaces/web-app/src/components/app/SideBarNavigation.js
+++ b/code/workspaces/web-app/src/components/app/SideBarNavigation.js
@@ -4,8 +4,8 @@ import { withStyles } from '@material-ui/core';
 const style = () => ({
   projectNavigation: {
     display: 'flex',
-    height: '100%',
     width: '100%',
+    flexGrow: '1',
   },
   contentArea: {
     display: 'flex',

--- a/code/workspaces/web-app/src/components/app/__snapshots__/Message.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/Message.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Message renders correct snapshot 1`] = `
+<div
+  className="Message-message-1"
+>
+  <ErrorOutlineIcon
+    className="Message-icon-3"
+  />
+  <div
+    className="Message-text-2"
+  >
+    Test message
+  </div>
+  <WithStyles(ForwardRef(Button))
+    color="secondary"
+    onClick={[Function]}
+  >
+    Dismiss
+  </WithStyles(ForwardRef(Button))>
+</div>
+`;

--- a/code/workspaces/web-app/src/components/app/__snapshots__/MessageBanner.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/MessageBanner.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MessageBanner renders correct snapshot 1`] = `
+<div>
+  <WithStyles(Message)
+    key="id1"
+    message={
+      Object {
+        "created": "2021-10-31",
+        "expiry": "2021-12-25",
+        "id": "id1",
+        "message": "Test message",
+      }
+    }
+  />
+  <WithStyles(Message)
+    key="id2"
+    message={
+      Object {
+        "created": "2021-11-31",
+        "expiry": "2021-12-26",
+        "id": "id2",
+        "message": "Other message",
+      }
+    }
+  />
+</div>
+`;

--- a/code/workspaces/web-app/src/components/app/__snapshots__/Navigation.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/Navigation.spec.js.snap
@@ -22,6 +22,7 @@ exports[`DescribeDatalabs renders correct snapshot 1`] = `
     <main
       className="Navigation-pageContainer-3"
     >
+      <MessageBanner />
       <span>
         Content
       </span>

--- a/code/workspaces/web-app/src/reducers/index.js
+++ b/code/workspaces/web-app/src/reducers/index.js
@@ -5,6 +5,7 @@ import authentication from './authReducer';
 import dataStorage from './dataStorageReducer';
 import projects from './projectsReducer';
 import stacks from './stacksReducer';
+import messages from './messagesReducer';
 import modal from './modelDialogReducer';
 import users from './usersReducer';
 import roles from './rolesReducer';
@@ -18,6 +19,7 @@ const rootReducer = history => combineReducers({
   dataStorage,
   projects,
   stacks,
+  messages,
   modal,
   users,
   roles,

--- a/code/workspaces/web-app/src/reducers/messageStorage.js
+++ b/code/workspaces/web-app/src/reducers/messageStorage.js
@@ -23,11 +23,12 @@ export const getDismissedMessages = () => {
 };
 
 export const getMessagesToDisplay = (messages) => {
-  // Only display messages that have not been dismissed.
-  const dismissed = getDismissedMessages();
   if (!messages) {
     return [];
   }
+
+  // Only display messages that have not been dismissed.
+  const dismissed = getDismissedMessages();
 
   return messages.filter(m => !dismissed.includes(m.id));
 };

--- a/code/workspaces/web-app/src/reducers/messageStorage.js
+++ b/code/workspaces/web-app/src/reducers/messageStorage.js
@@ -22,13 +22,25 @@ export const getDismissedMessages = () => {
   return JSON.parse(messages);
 };
 
+export const filterExpiredMessages = (messages) => {
+  // The messages returned from the backend are all "active" (i.e. not expired).
+  // So, if there are messages in the cache that aren't in this response, we can clear them from the cache as they have expired.
+  const dismissed = getDismissedMessages();
+  const activeMessageIds = messages.map(m => m.id);
+
+  const activeDismissed = dismissed.filter(d => activeMessageIds.includes(d));
+  localStorage.setItem(messageField, JSON.stringify(activeDismissed));
+
+  return activeDismissed;
+};
+
 export const getMessagesToDisplay = (messages) => {
   if (!messages) {
     return [];
   }
 
   // Only display messages that have not been dismissed.
-  const dismissed = getDismissedMessages();
+  const dismissed = filterExpiredMessages(messages);
 
   return messages.filter(m => !dismissed.includes(m.id));
 };

--- a/code/workspaces/web-app/src/reducers/messageStorage.js
+++ b/code/workspaces/web-app/src/reducers/messageStorage.js
@@ -1,0 +1,40 @@
+const messageField = 'dismissedMessages';
+
+export const setDismissedMessage = (id) => {
+  // If a message has been dismissed, store its ID in local storage.
+  const alreadyDismissed = getDismissedMessages();
+
+  if (!alreadyDismissed.includes(id)) {
+    const updatedDismissed = [
+      ...alreadyDismissed,
+      id,
+    ];
+    localStorage.setItem(messageField, JSON.stringify(updatedDismissed));
+  }
+};
+
+export const getDismissedMessages = () => {
+  const messages = localStorage.getItem(messageField);
+  if (!messages) {
+    return [];
+  }
+
+  return JSON.parse(messages);
+};
+
+export const getMessagesToDisplay = (messages) => {
+  // Only display messages that have not been dismissed.
+  const dismissed = getDismissedMessages();
+  if (!messages) {
+    return [];
+  }
+
+  return messages.filter(m => !dismissed.includes(m.id));
+};
+
+export const getUpdatedMessages = (messages, messageId) => {
+  // When a message is dismissed, remove it from the list of messages.
+  setDismissedMessage(messageId);
+
+  return messages.filter(m => m.id !== messageId);
+};

--- a/code/workspaces/web-app/src/reducers/messageStorage.spec.js
+++ b/code/workspaces/web-app/src/reducers/messageStorage.spec.js
@@ -1,0 +1,85 @@
+import { setDismissedMessage, getDismissedMessages, getMessagesToDisplay, getUpdatedMessages } from './messageStorage';
+import LocalStorageMock from '../core/LocalStorageMock';
+
+const storageMock = new LocalStorageMock();
+const messages = ['id1', 'id2', 'id3'];
+const apiMessages = [{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }];
+const key = 'dismissedMessages';
+
+describe('messageStorage', () => {
+  beforeAll(() => {
+    // Replace the "localStorage" implementation with our mocked version.
+    delete global.localStorage;
+    global.localStorage = storageMock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storageMock.clear();
+  });
+
+  describe('setDismissedMessage', () => {
+    it('merges new ID with existing messages in cache', () => {
+      storageMock.setItem(key, JSON.stringify(messages));
+
+      setDismissedMessage('id4');
+
+      const updated = storageMock.getItem(key);
+      expect(JSON.parse(updated)).toEqual([...messages, 'id4']);
+    });
+
+    it('does not add duplicate messages to cache', () => {
+      storageMock.setItem(key, JSON.stringify(messages));
+
+      setDismissedMessage('id3');
+
+      const updated = storageMock.getItem(key);
+      expect(JSON.parse(updated)).toEqual(messages);
+    });
+  });
+
+  describe('getDismissedMessages', () => {
+    it('returns an empty list if there is nothing in the cache', () => {
+      const dismissed = getDismissedMessages();
+
+      expect(dismissed).toEqual([]);
+    });
+
+    it('returns a list of message IDs', () => {
+      const original = JSON.stringify(messages);
+      storageMock.setItem(key, original);
+
+      const dismissed = getDismissedMessages();
+
+      expect(dismissed).toEqual(messages);
+    });
+  });
+
+  describe('getMessagesToDisplay', () => {
+    it('returns an empty list if there are no input messages', () => {
+      const toDisplay = getMessagesToDisplay(undefined);
+
+      expect(toDisplay).toEqual([]);
+    });
+
+    it('returns a list of message IDs with dismissed ones filtered out', () => {
+      storageMock.setItem(key, JSON.stringify(['id1']));
+
+      const toDisplay = getMessagesToDisplay(apiMessages);
+
+      expect(toDisplay).toEqual([{ id: 'id2' }, { id: 'id3' }]);
+    });
+  });
+
+  describe('getUpdatedMessages', () => {
+    it('adds a message ID to the cache and returns the updated list', () => {
+      const updated = getUpdatedMessages(apiMessages, 'id1');
+
+      const cacheValue = JSON.parse(storageMock.getItem(key));
+
+      expect(updated).toEqual([{ id: 'id2' }, { id: 'id3' }]);
+      expect(cacheValue).toEqual(expect.arrayContaining(['id1']));
+      expect(cacheValue).not.toEqual(expect.arrayContaining(['id2']));
+    });
+  });
+});

--- a/code/workspaces/web-app/src/reducers/messageStorage.spec.js
+++ b/code/workspaces/web-app/src/reducers/messageStorage.spec.js
@@ -1,4 +1,4 @@
-import { setDismissedMessage, getDismissedMessages, getMessagesToDisplay, getUpdatedMessages } from './messageStorage';
+import { setDismissedMessage, getDismissedMessages, filterExpiredMessages, getMessagesToDisplay, getUpdatedMessages } from './messageStorage';
 import LocalStorageMock from '../core/LocalStorageMock';
 
 const storageMock = new LocalStorageMock();
@@ -52,6 +52,16 @@ describe('messageStorage', () => {
       const dismissed = getDismissedMessages();
 
       expect(dismissed).toEqual(messages);
+    });
+  });
+
+  describe('filterExpiredMessages', () => {
+    it('clears any expired messages from the cache and returns the remaining ones', () => {
+      const original = JSON.stringify([...messages, 'old', 'older']);
+      storageMock.setItem(key, original);
+
+      const activeDismissedMessages = filterExpiredMessages(apiMessages);
+      expect(activeDismissedMessages).toEqual(messages);
     });
   });
 

--- a/code/workspaces/web-app/src/reducers/messagesReducer.js
+++ b/code/workspaces/web-app/src/reducers/messagesReducer.js
@@ -1,0 +1,23 @@
+import typeToReducer from 'type-to-reducer';
+import {
+  PROMISE_TYPE_PENDING,
+  PROMISE_TYPE_SUCCESS,
+  PROMISE_TYPE_FAILURE,
+} from '../actions/actionTypes';
+import { GET_MESSAGES_ACTION, DISMISS_MESSAGE_ACTION } from '../actions/messagesActions';
+import { getMessagesToDisplay, getUpdatedMessages } from './messageStorage';
+
+const initialState = {
+  fetching: false,
+  value: [],
+  error: null,
+};
+
+export default typeToReducer({
+  [GET_MESSAGES_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: state.value }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: getMessagesToDisplay(action.payload.messages) }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
+  },
+  [DISMISS_MESSAGE_ACTION]: (state, action) => ({ ...initialState, value: getUpdatedMessages(state.value, action.payload) }),
+}, initialState);

--- a/code/workspaces/web-app/src/reducers/messagesReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/messagesReducer.spec.js
@@ -1,0 +1,97 @@
+import messagesReducer from './messagesReducer';
+import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
+import {
+  GET_MESSAGES_ACTION, DISMISS_MESSAGE_ACTION,
+} from '../actions/messagesActions';
+import { getMessagesToDisplay, getUpdatedMessages } from './messageStorage';
+
+const baseState = () => ({
+  fetching: false,
+  value: [],
+  error: null,
+});
+
+jest.mock('./messageStorage');
+
+describe('messagesReducer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMessagesToDisplay.mockImplementation(m => m);
+    getUpdatedMessages.mockReturnValue([]);
+  });
+
+  describe('GET_MESSAGES_ACTION', () => {
+    it('handles pending action type correctly', () => {
+      const currentState = baseState();
+      const type = `${GET_MESSAGES_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      const nextState = messagesReducer(currentState, action);
+
+      expect(nextState).toEqual({
+        ...baseState(),
+        fetching: true,
+      });
+      expect(getMessagesToDisplay).toHaveBeenCalledTimes(0);
+    });
+
+    it('handles successful action type correctly', () => {
+      const messages = [{ id: 'id1' }];
+      const currentState = baseState();
+      const type = `${GET_MESSAGES_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = { messages };
+      const action = { type, payload };
+
+      const nextState = messagesReducer(currentState, action);
+
+      expect(nextState).toEqual({
+        ...baseState(),
+        value: messages,
+      });
+      expect(getMessagesToDisplay).toHaveBeenCalledTimes(1);
+      expect(getMessagesToDisplay).toHaveBeenCalledWith(messages);
+    });
+
+    it('handles failed action type correctly', () => {
+      const messages = [{ id: 'id1' }];
+      const currentState = {
+        ...baseState(),
+        value: messages,
+      };
+      const type = `${GET_MESSAGES_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'error';
+      const action = { type, payload };
+
+      const nextState = messagesReducer(currentState, action);
+
+      expect(nextState).toEqual({
+        ...baseState(),
+        value: messages,
+        error: 'error',
+      });
+      expect(getMessagesToDisplay).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('DISMISS_MESSAGE_ACTION', () => {
+    it('handles action correctly', () => {
+      const messages = [{ id: 'id1' }];
+      const currentState = {
+        ...baseState(),
+        value: messages,
+      };
+      const type = DISMISS_MESSAGE_ACTION;
+      const payload = 'id1';
+      const action = { type, payload };
+
+      const nextState = messagesReducer(currentState, action);
+
+      expect(nextState).toEqual({
+        ...baseState(),
+        value: [],
+      });
+      expect(getUpdatedMessages).toHaveBeenCalledTimes(1);
+      expect(getUpdatedMessages).toHaveBeenCalledWith(messages, payload);
+    });
+  });
+});

--- a/code/workspaces/web-app/src/theme.js
+++ b/code/workspaces/web-app/src/theme.js
@@ -78,7 +78,6 @@ const theme = createMuiTheme({
     topBarPaddingTopBottom: spacing,
     topBarPaddingLeftRight: 2 * spacing,
     borderRadius: 5,
-    messageHeight: 40,
   },
   spacing,
   cardImageSize,

--- a/code/workspaces/web-app/src/theme.js
+++ b/code/workspaces/web-app/src/theme.js
@@ -21,6 +21,9 @@ const highlightMonoTransparent = 'rgba(248, 248, 248, 0.25)';
 const text = backgroundDark;
 const textLight = 'hsl(0, 0%, 40%)';
 
+const message = 'rgba(64, 64, 191, 1.0)';
+const messageBackground = 'rgba(189, 221, 255, 0.5)';
+
 // Lengths
 const spacing = 5;
 const navBarHeight = 8 * spacing;
@@ -41,6 +44,8 @@ const theme = createMuiTheme({
     sideBarBackground,
     highlightMono,
     highlightMonoTransparent,
+    message,
+    messageBackground,
   },
   typography: {
     color: text,
@@ -73,6 +78,7 @@ const theme = createMuiTheme({
     topBarPaddingTopBottom: spacing,
     topBarPaddingLeftRight: 2 * spacing,
     borderRadius: 5,
+    messageHeight: 40,
   },
   spacing,
   cardImageSize,


### PR DESCRIPTION
Added messages to the webapp.
Messages that have not expired are retrieved from the backend. A list of dismissed messages is cached in the localStorage, so when a user closes one, they won't see it again unless they empty the cache.
When the messages are retrieved, any expired messages that have been dismissed are cleared from the cache.

Current message theme is blue, though this is simple enough to change.