### PR TITLE
feat: updated admin resources to show actions list for stacks

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
@@ -6,6 +6,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { statusTypes } from 'common';
+import { SYSTEM_INSTANCE_ADMIN } from 'common/src/permissionTypes';
 import { useCurrentUserId } from '../../../hooks/authHooks';
 import PermissionWrapper from '../../common/ComponentPermissionWrapper';
 import PrimaryActionButton from '../../common/buttons/PrimaryActionButton';
@@ -46,6 +47,7 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
   // This is the case for projects which also use this component. This will mean that
   // projects rely solely on the permissions passed to determine correct rendering.
   const ownsStack = !stack.users || stack.users.includes(currentUserId);
+  const isInstanceAdmin = userPermissions.includes(SYSTEM_INSTANCE_ADMIN);
   const [anchorEl, setAnchorEl] = useState(null);
   const shared = ['project'].includes(stack.shared) || ['project', 'public'].includes(stack.visible);
 
@@ -101,7 +103,7 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
     },
   ].filter(m => !!m);
 
-  const shouldRenderMenuItems = stackMenuItems.length > 0;
+  const shouldRenderMenuItems = (ownsStack || isInstanceAdmin) && stackMenuItems.length > 0;
 
   return (
     <div className={classes.cardActions}>
@@ -121,7 +123,7 @@ export const PureStackCardActions = ({ stack, openStack, deleteStack, editStack,
           </div>
         </Tooltip>
       </PermissionWrapper>}
-      {ownsStack && shouldRenderMenuItems && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={deletePermission}>
+      {shouldRenderMenuItems && <PermissionWrapper className={classes.buttonWrapper} userPermissions={userPermissions} permission={deletePermission}>
         <SecondaryActionButton
           aria-controls="more-menu"
           aria-haspopup="true"

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
@@ -205,6 +205,15 @@ describe('StackCardActions', () => {
     expect(wrapper.container).toMatchSnapshot();
   });
 
+  it('Should render edit/delete/share/restart buttons if current user is not owner but is instance admin', () => {
+    const props = generateProps();
+    props.userPermissions = [...props.userPermissions, 'system:instance:admin'];
+    useCurrentUserId.mockReturnValue('not-the-owner-id');
+
+    const wrapper = render(<StackCardActions {...props} />);
+    expect(wrapper.getByText('more_vert')).not.toBeNull();
+  });
+
   it('Should not render edit/delete buttons if functions not defined', () => {
     const props = {
       ...generateProps(),

--- a/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
+++ b/code/workspaces/web-app/src/containers/stacks/StacksContainer.js
@@ -234,11 +234,11 @@ class StacksContainer extends Component {
         typeNamePlural={this.props.typeNamePlural}
         getLogs={this.getLogs}
         openStack={this.openStack}
-        deleteStack={this.props.modifyData ? this.confirmDeleteStack : undefined}
-        shareStack={this.props.modifyData ? this.confirmShareStack : undefined}
-        editStack={this.props.modifyData ? this.openEditForm : undefined}
-        restartStack={this.props.modifyData ? this.confirmRestartStack : undefined}
-        scaleStack={this.props.modifyData ? this.confirmScaleStack : undefined}
+        deleteStack={this.confirmDeleteStack}
+        shareStack={this.confirmShareStack}
+        editStack={this.openEditForm}
+        restartStack={this.confirmRestartStack}
+        scaleStack={this.confirmScaleStack}
         openCreationForm={this.props.modifyData ? this.openCreationForm : undefined}
         showCreateButton={this.props.modifyData}
         userPermissions={() => this.props.userPermissions}
@@ -284,7 +284,7 @@ function mapStateToProps(state) {
   return {
     stacks: state.stacks,
     projectKey: currentProjectSelectors.currentProjectKey(state),
-    modifyData: true, // default
+    modifyData: true,
   };
 }
 
@@ -292,7 +292,7 @@ function mapProjectStateToProps(state) {
   return {
     stacks: state.stacks,
     // leave projectKey as a prop, rather than reading from state
-    modifyData: false, // don't load (or cause a load of) the stacks in this view, admin sees more
+    modifyData: false,
   };
 }
 


### PR DESCRIPTION
Updated the admin resources page so it now shows the actions for a stack.