### PR TITLE
NERCDL-1126: Cluster scaling API and web app

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/clustersService.js
+++ b/code/workspaces/client-api/src/dataaccess/clustersService.js
@@ -40,9 +40,29 @@ async function getClustersByMount(projectKey, mount, token) {
   return data;
 }
 
+const scaleDownCluster = async (cluster, token) => {
+  const { data } = await infrastructureApi().put(
+    `/${cluster.projectKey}/scaledown`,
+    cluster,
+    requestConfig(token),
+  );
+  return data;
+};
+
+const scaleUpCluster = async (cluster, token) => {
+  const { data } = await infrastructureApi().put(
+    `/${cluster.projectKey}/scaleup`,
+    cluster,
+    requestConfig(token),
+  );
+  return data;
+};
+
 export default {
   createCluster: wrapWithAxiosErrorWrapper('Error creating cluster.', createCluster),
   deleteCluster: wrapWithAxiosErrorWrapper('Error deleting cluster.', deleteCluster),
   getClusters: wrapWithAxiosErrorWrapper('Error getting clusters.', getClusters),
   getClustersByMount: wrapWithAxiosErrorWrapper('Error getting clusters by mount.', getClustersByMount),
+  scaleDownCluster: wrapWithAxiosErrorWrapper('Error scaling down cluster.', scaleDownCluster),
+  scaleUpCluster: wrapWithAxiosErrorWrapper('Error scaling up cluster.', scaleUpCluster),
 };

--- a/code/workspaces/client-api/src/dataaccess/clustersService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/clustersService.spec.js
@@ -126,4 +126,56 @@ describe('clustersService', () => {
       expect(getMock.headers.authorization).toEqual(token);
     });
   });
+
+  describe('scaleDownCluster', () => {
+    const clusterRequest = {
+      type: 'DASK',
+      projectKey: 'test-project',
+      name: 'cluster1',
+    };
+    const clusterResponse = {
+      message: 'OK',
+    };
+    const { scaleDownCluster } = clustersService;
+
+    it('calls infrastructure-api to scale down a cluster', async () => {
+      httpMock
+        .onPut(`${infrastructureApi}/clusters/test-project/scaledown`)
+        .reply(200, clusterResponse);
+
+      const returnValue = await scaleDownCluster(clusterRequest, token);
+
+      expect(returnValue).toEqual(clusterResponse);
+      expect(httpMock.history.put.length).toBe(1);
+      const [putMock] = httpMock.history.put;
+      expect(putMock.data).toEqual(JSON.stringify(clusterRequest));
+      expect(putMock.headers.authorization).toEqual(token);
+    });
+  });
+
+  describe('scaleUpCluster', () => {
+    const clusterRequest = {
+      type: 'DASK',
+      projectKey: 'test-project',
+      name: 'cluster1',
+    };
+    const clusterResponse = {
+      message: 'OK',
+    };
+    const { scaleUpCluster } = clustersService;
+
+    it('calls infrastructure-api to scale up a cluster', async () => {
+      httpMock
+        .onPut(`${infrastructureApi}/clusters/test-project/scaleup`)
+        .reply(200, clusterResponse);
+
+      const returnValue = await scaleUpCluster(clusterRequest, token);
+
+      expect(returnValue).toEqual(clusterResponse);
+      expect(httpMock.history.put.length).toBe(1);
+      const [putMock] = httpMock.history.put;
+      expect(putMock.data).toEqual(JSON.stringify(clusterRequest));
+      expect(putMock.headers.authorization).toEqual(token);
+    });
+  });
 });

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -69,6 +69,8 @@ const resolvers = {
     setCatalogueRole: (obj, { userId, catalogueRole }, { token }) => w(usersService.setCatalogueRole(userId, catalogueRole, token)),
     createCluster: (obj, { cluster }, { token }) => w(clustersService.createCluster(cluster, token)),
     deleteCluster: (obj, { cluster }, { token }) => w(clustersService.deleteCluster(cluster, token)),
+    scaleupCluster: (obj, { cluster }, { token }) => w(clustersService.scaleUpCluster(cluster, token)),
+    scaledownCluster: (obj, { cluster }, { token }) => w(clustersService.scaleDownCluster(cluster, token)),
     createMessage: (obj, { message }, { token }) => w(messagesService.createMessage(message, token)),
     deleteMessage: (obj, { messageId }, { token }) => w(messagesService.deleteMessage(messageId, token)),
   },

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -76,10 +76,10 @@ type Mutation {
     restartStack(stack: StackRestartRequest): Stack
 
     # Scale up a stack
-    scaleupStack(stack: StackScaleRequest): GeneralResponseMessage
+    scaleupStack(stack: ScaleRequest): GeneralResponseMessage
 
     # Scale down a stack
-    scaledownStack(stack: StackScaleRequest): GeneralResponseMessage
+    scaledownStack(stack: ScaleRequest): GeneralResponseMessage
 
     # Create a new data store
     createDataStore(projectKey: String!, dataStore: DataStorageCreationRequest): DataStore
@@ -131,6 +131,12 @@ type Mutation {
 
     # Delete a cluster
     deleteCluster(cluster: ClusterDeletionRequest!): Cluster!
+
+    # Scale up a cluster
+    scaleupCluster(cluster: ScaleRequest): GeneralResponseMessage
+
+    # Scale down a cluster
+    scaledownCluster(cluster: ScaleRequest): GeneralResponseMessage
 
     # Create a message
     createMessage(message: MessageCreationRequest!): Message!
@@ -242,8 +248,8 @@ input StackRestartRequest {
     type: String
 }
 
-# Type to describe the mutation for scaling a Stack.
-input StackScaleRequest {
+# Type to describe the mutation for scaling a Stack or Cluster.
+input ScaleRequest {
     projectKey: String
     name: String
     type: String
@@ -448,6 +454,7 @@ type Cluster {
     maxWorkerMemoryGb: Float!
     maxWorkerCpu: Float!
     schedulerAddress: String
+    status: StatusType
 }
 
 # Type to describe a message

--- a/code/workspaces/web-app/src/actions/clusterActions.js
+++ b/code/workspaces/web-app/src/actions/clusterActions.js
@@ -2,6 +2,7 @@ import clusterService from '../api/clusterService';
 
 export const CREATE_CLUSTER_ACTION = 'CREATE_CLUSTER_ACTION';
 export const LOAD_CLUSTERS_ACTION = 'LOAD_CLUSTERS_ACTION';
+export const UPDATE_CLUSTERS_ACTION = 'UPDATE_CLUSTERS_ACTION';
 export const DELETE_CLUSTER_ACTION = 'DELETE_CLUSTER_ACTION';
 export const SCALE_CLUSTER_ACTION = 'SCALE_CLUSTER_ACTION';
 
@@ -20,9 +21,14 @@ const loadClusters = projectKey => ({
   payload: clusterService.loadClusters(projectKey).then(clusters => ({ projectKey, clusters })),
 });
 
+const updateClusters = projectKey => ({
+  type: UPDATE_CLUSTERS_ACTION,
+  payload: clusterService.loadClusters(projectKey).then(clusters => ({ projectKey, clusters })),
+});
+
 const scaleCluster = ({ projectKey, name, type }, replicas) => ({
   type: SCALE_CLUSTER_ACTION,
   payload: clusterService.scaleCluster({ projectKey, name, type }, replicas),
 });
 
-export default { createCluster, loadClusters, deleteCluster, scaleCluster };
+export default { createCluster, loadClusters, updateClusters, deleteCluster, scaleCluster };

--- a/code/workspaces/web-app/src/actions/clusterActions.js
+++ b/code/workspaces/web-app/src/actions/clusterActions.js
@@ -3,6 +3,7 @@ import clusterService from '../api/clusterService';
 export const CREATE_CLUSTER_ACTION = 'CREATE_CLUSTER_ACTION';
 export const LOAD_CLUSTERS_ACTION = 'LOAD_CLUSTERS_ACTION';
 export const DELETE_CLUSTER_ACTION = 'DELETE_CLUSTER_ACTION';
+export const SCALE_CLUSTER_ACTION = 'SCALE_CLUSTER_ACTION';
 
 const createCluster = cluster => ({
   type: CREATE_CLUSTER_ACTION,
@@ -19,4 +20,9 @@ const loadClusters = projectKey => ({
   payload: clusterService.loadClusters(projectKey).then(clusters => ({ projectKey, clusters })),
 });
 
-export default { createCluster, loadClusters, deleteCluster };
+const scaleCluster = ({ projectKey, name, type }, replicas) => ({
+  type: SCALE_CLUSTER_ACTION,
+  payload: clusterService.scaleCluster({ projectKey, name, type }, replicas),
+});
+
+export default { createCluster, loadClusters, deleteCluster, scaleCluster };

--- a/code/workspaces/web-app/src/actions/clusterActions.spec.js
+++ b/code/workspaces/web-app/src/actions/clusterActions.spec.js
@@ -1,5 +1,11 @@
 import clusterService from '../api/clusterService';
-import clusterActions, { CREATE_CLUSTER_ACTION, DELETE_CLUSTER_ACTION, LOAD_CLUSTERS_ACTION, SCALE_CLUSTER_ACTION } from './clusterActions';
+import clusterActions, {
+  CREATE_CLUSTER_ACTION,
+  DELETE_CLUSTER_ACTION,
+  LOAD_CLUSTERS_ACTION,
+  SCALE_CLUSTER_ACTION,
+  UPDATE_CLUSTERS_ACTION,
+} from './clusterActions';
 
 jest.mock('../api/clusterService');
 
@@ -80,6 +86,20 @@ describe('clusterActions', () => {
     });
   });
 
+  describe('updateClusters', () => {
+    it('makes correct call to service function and provides result in action payload', async () => {
+      const projectKey = 'project-key';
+      const loadClustersMockReturnValue = 'clusters-loaded';
+      loadClustersMock.mockResolvedValueOnce(loadClustersMockReturnValue);
+
+      const actionReturn = clusterActions.updateClusters(projectKey);
+
+      expect(loadClustersMock).toHaveBeenCalledWith(projectKey);
+      expect(actionReturn.type).toEqual(UPDATE_CLUSTERS_ACTION);
+      expect(await actionReturn.payload).toEqual({ clusters: loadClustersMockReturnValue, projectKey });
+    });
+  });
+
   describe('scaleCluster', () => {
     it('makes correct call to service function and provides result in action payload', async () => {
       const scaleClusterMockReturnValue = 'cluster-scaled';
@@ -105,6 +125,10 @@ describe('clusterActions', () => {
 
     it('LOAD_CLUSTERS', () => {
       expect(LOAD_CLUSTERS_ACTION).toEqual('LOAD_CLUSTERS_ACTION');
+    });
+
+    it('UPDATE_CLUSTERS', () => {
+      expect(UPDATE_CLUSTERS_ACTION).toEqual('UPDATE_CLUSTERS_ACTION');
     });
 
     it('SCALE_CLUSTERS', () => {

--- a/code/workspaces/web-app/src/actions/clusterActions.spec.js
+++ b/code/workspaces/web-app/src/actions/clusterActions.spec.js
@@ -1,5 +1,5 @@
 import clusterService from '../api/clusterService';
-import clusterActions, { CREATE_CLUSTER_ACTION, DELETE_CLUSTER_ACTION, LOAD_CLUSTERS_ACTION } from './clusterActions';
+import clusterActions, { CREATE_CLUSTER_ACTION, DELETE_CLUSTER_ACTION, LOAD_CLUSTERS_ACTION, SCALE_CLUSTER_ACTION } from './clusterActions';
 
 jest.mock('../api/clusterService');
 
@@ -11,6 +11,9 @@ clusterService.deleteCluster = deleteClusterMock;
 
 const loadClustersMock = jest.fn();
 clusterService.loadClusters = loadClustersMock;
+
+const scaleClusterMock = jest.fn();
+clusterService.scaleCluster = scaleClusterMock;
 
 const getClusterCreationObject = () => ({
   displayName: 'Test Cluster',
@@ -24,7 +27,7 @@ const getClusterCreationObject = () => ({
   maxWorkerCpu: 1,
 });
 
-const getClusterDeletionObject = () => ({
+const getSimpleClusterObject = () => ({
   name: 'test-cluster',
   type: 'DASK',
   projectKey: 'test-project',
@@ -53,7 +56,7 @@ describe('clusterActions', () => {
     it('makes correct call to service function and provides result in action payload', () => {
       const deleteClusterMockReturnValue = 'cluster-deleted';
       deleteClusterMock.mockReturnValueOnce(deleteClusterMockReturnValue);
-      const clusterDeletionObject = getClusterDeletionObject();
+      const clusterDeletionObject = getSimpleClusterObject();
 
       const actionReturn = clusterActions.deleteCluster(clusterDeletionObject);
 
@@ -77,6 +80,20 @@ describe('clusterActions', () => {
     });
   });
 
+  describe('scaleCluster', () => {
+    it('makes correct call to service function and provides result in action payload', async () => {
+      const scaleClusterMockReturnValue = 'cluster-scaled';
+      scaleClusterMock.mockResolvedValueOnce(scaleClusterMockReturnValue);
+      const clusterScaleObject = getSimpleClusterObject();
+
+      const actionReturn = clusterActions.scaleCluster(clusterScaleObject, 0);
+
+      expect(scaleClusterMock).toHaveBeenCalledWith(clusterScaleObject, 0);
+      expect(actionReturn.type).toEqual(SCALE_CLUSTER_ACTION);
+      expect(await actionReturn.payload).toEqual(scaleClusterMockReturnValue);
+    });
+  });
+
   describe('exports correct values for', () => {
     it('CREATE_CLUSTER', () => {
       expect(CREATE_CLUSTER_ACTION).toEqual('CREATE_CLUSTER_ACTION');
@@ -88,6 +105,10 @@ describe('clusterActions', () => {
 
     it('LOAD_CLUSTERS', () => {
       expect(LOAD_CLUSTERS_ACTION).toEqual('LOAD_CLUSTERS_ACTION');
+    });
+
+    it('SCALE_CLUSTERS', () => {
+      expect(SCALE_CLUSTER_ACTION).toEqual('SCALE_CLUSTER_ACTION');
     });
   });
 });

--- a/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/clusterService.spec.js.snap
@@ -31,6 +31,7 @@ exports[`clusterService loadClusters should build the correct query and unpack t
         schedulerAddress
         condaPath
         maxWorkerMemoryGb
+        status
       }
     }
   "

--- a/code/workspaces/web-app/src/api/clusterService.js
+++ b/code/workspaces/web-app/src/api/clusterService.js
@@ -52,4 +52,17 @@ function loadClusters(projectKey) {
     .then(errorHandler('data.clusters'));
 }
 
-export default { createCluster, deleteCluster, loadClusters };
+const scaleCluster = async (cluster, replicas) => {
+  const operation = replicas > 0 ? 'scaleupCluster' : 'scaledownCluster';
+  const mutation = `
+    ScaleCluster($cluster: ScaleRequest) {
+      ${operation}(cluster: $cluster) {
+        message
+      }
+    }`;
+
+  const response = await gqlMutation(mutation, { cluster });
+  return errorHandler(`data.${replicas > 0 ? 'scaleupCluster' : 'scaledownCluster'}`)(response);
+};
+
+export default { createCluster, deleteCluster, loadClusters, scaleCluster };

--- a/code/workspaces/web-app/src/api/clusterService.js
+++ b/code/workspaces/web-app/src/api/clusterService.js
@@ -44,6 +44,7 @@ function loadClusters(projectKey) {
         schedulerAddress
         condaPath
         maxWorkerMemoryGb
+        status
       }
     }
   `;

--- a/code/workspaces/web-app/src/api/clusterService.spec.js
+++ b/code/workspaces/web-app/src/api/clusterService.spec.js
@@ -98,4 +98,43 @@ describe('clusterService', () => {
       expect(error).toEqual({ error: 'expected error' });
     });
   });
+
+  describe('scaleCluster', () => {
+    it('should build the correct mutation to scale down', async () => {
+      const data = { cluster: { name: 'name', projectKey: 'test', type: 'DASK' } };
+      mockClient.prepareSuccess(data);
+
+      const response = await clusterService.scaleCluster(data.cluster, 0);
+      expect(response).toEqual(data.scaledownCluster);
+      expect(mockClient.lastQuery()).toEqual(`
+    ScaleCluster($cluster: ScaleRequest) {
+      scaledownCluster(cluster: $cluster) {
+        message
+      }
+    }`);
+      expect(mockClient.lastOptions()).toEqual(data);
+    });
+
+    it('should build the correct mutation to scale up', async () => {
+      const data = { cluster: { name: 'name', projectKey: 'test', type: 'DASK' } };
+      mockClient.prepareSuccess(data);
+
+      const response = await clusterService.scaleCluster(data.cluster, 1);
+      expect(response).toEqual(data.scaleupCluster);
+      expect(mockClient.lastQuery()).toEqual(`
+    ScaleCluster($cluster: ScaleRequest) {
+      scaleupCluster(cluster: $cluster) {
+        message
+      }
+    }`);
+      expect(mockClient.lastOptions()).toEqual(data);
+    });
+
+    it('should throw an error if the mutation fails', async () => {
+      const data = { cluster: { name: 'name', projectKey: 'test', type: 'DASK' } };
+      mockClient.prepareFailure('expected error');
+
+      await expect(clusterService.scaleCluster(data.cluster, 1)).rejects.toEqual({ error: 'expected error' });
+    });
+  });
 });

--- a/code/workspaces/web-app/src/api/stackService.js
+++ b/code/workspaces/web-app/src/api/stackService.js
@@ -87,7 +87,7 @@ function restartStack(stack) {
 const scaleStack = async (stack, replicas) => {
   const operation = replicas > 0 ? 'scaleupStack' : 'scaledownStack';
   const mutation = `
-    ScaleStack($stack: StackScaleRequest) {
+    ScaleStack($stack: ScaleRequest) {
       ${operation}(stack: $stack) {
         message
       }

--- a/code/workspaces/web-app/src/api/stackService.spec.js
+++ b/code/workspaces/web-app/src/api/stackService.spec.js
@@ -144,7 +144,7 @@ describe('stackService', () => {
       const response = await stackService.scaleStack(data.stack, 1);
       expect(response).toEqual(data.scaleupStack);
       expect(mockClient.lastQuery()).toEqual(`
-    ScaleStack($stack: StackScaleRequest) {
+    ScaleStack($stack: ScaleRequest) {
       scaleupStack(stack: $stack) {
         message
       }
@@ -159,7 +159,7 @@ describe('stackService', () => {
       const response = await stackService.scaleStack(data.stack, 0);
       expect(response).toEqual(data.scaleupStack);
       expect(mockClient.lastQuery()).toEqual(`
-    ScaleStack($stack: StackScaleRequest) {
+    ScaleStack($stack: ScaleRequest) {
       scaledownStack(stack: $stack) {
         message
       }

--- a/code/workspaces/web-app/src/containers/clusters/__snapshots__/ClustersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/clusters/__snapshots__/ClustersContainer.spec.js.snap
@@ -13,6 +13,7 @@ exports[`ClustersContainer renders correct snapshot 1`] = `
   editPermission="projects:current-project:clusters:edit"
   openCreationForm={[Function]}
   openPermission="projects:current-project:clusters:open"
+  scaleStack={[Function]}
   showCreateButton={true}
   stacks={
     Object {

--- a/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/clusters/__snapshots__/ProjectClustersContainer.spec.js.snap
@@ -13,6 +13,7 @@ exports[`ProjectClustersContainer renders correct snapshot for Dask clusters 1`]
   editPermission="projects:project-key:clusters:edit"
   openCreationForm={[Function]}
   openPermission="projects:project-key:clusters:open"
+  scaleStack={[Function]}
   showCreateButton={true}
   stacks={
     Object {
@@ -48,6 +49,7 @@ exports[`ProjectClustersContainer renders correct snapshot for Spark clusters 1`
   editPermission="projects:project-key:clusters:edit"
   openCreationForm={[Function]}
   openPermission="projects:project-key:clusters:open"
+  scaleStack={[Function]}
   showCreateButton={true}
   stacks={
     Object {
@@ -82,6 +84,7 @@ exports[`ProjectClustersContainer renders correct snapshot for all clusters 1`] 
   deleteStack={[Function]}
   editPermission="projects:project-key:clusters:edit"
   openPermission="projects:project-key:clusters:open"
+  scaleStack={[Function]}
   showCreateButton={true}
   stacks={
     Object {

--- a/code/workspaces/web-app/src/reducers/clustersReducer.js
+++ b/code/workspaces/web-app/src/reducers/clustersReducer.js
@@ -4,12 +4,13 @@ import {
   PROMISE_TYPE_SUCCESS,
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
-import { LOAD_CLUSTERS_ACTION } from '../actions/clusterActions';
+import { LOAD_CLUSTERS_ACTION, UPDATE_CLUSTERS_ACTION } from '../actions/clusterActions';
 import replaceProjectCategoryItems from './replaceProjectCategoryItems';
 import { GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
 
 const initialState = {
-  fetching: false,
+  fetching: false, // for calling query for first time
+  updating: false, // for calling query again to get updated statuses
   value: [],
   error: null,
 };
@@ -17,6 +18,11 @@ const initialState = {
 export default typeToReducer({
   [LOAD_CLUSTERS_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: state.value }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: replaceProjectCategoryItems(state.value, action.payload.projectKey, undefined, action.payload.clusters) }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
+  },
+  [UPDATE_CLUSTERS_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, updating: true, value: state.value }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: replaceProjectCategoryItems(state.value, action.payload.projectKey, undefined, action.payload.clusters) }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
   },

--- a/code/workspaces/web-app/src/reducers/clustersReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/clustersReducer.spec.js
@@ -1,6 +1,6 @@
 import clustersReducer from './clustersReducer';
 import { PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE, PROMISE_TYPE_PENDING } from '../actions/actionTypes';
-import { LOAD_CLUSTERS_ACTION } from '../actions/clusterActions';
+import { LOAD_CLUSTERS_ACTION, UPDATE_CLUSTERS_ACTION } from '../actions/clusterActions';
 import { GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
 
 const clustersArray = [
@@ -13,39 +13,86 @@ const getFailureActionType = action => `${action}_${PROMISE_TYPE_FAILURE}`;
 
 describe('LOAD_CLUSTERS_ACTION reducer', () => {
   it('handles pending action type correctly', () => {
-    const currentState = { fetching: false, value: clustersArray, error: null };
+    const currentState = { fetching: false, updating: false, value: clustersArray, error: null };
     const action = { type: getPendingActionType(LOAD_CLUSTERS_ACTION) };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: true,
+      updating: false,
       value: clustersArray,
       error: null,
     });
   });
 
   it('handles successful action type correctly', () => {
-    const currentState = { fetching: true, value: [], error: null };
+    const currentState = { fetching: true, updating: false, value: [], error: null };
     const action = { type: getSuccessActionType(LOAD_CLUSTERS_ACTION), payload: { clusters: clustersArray, projectKey: 'project-key' } };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: false,
+      updating: false,
       value: clustersArray,
       error: null,
     });
   });
 
   it('handle failed action type correctly', () => {
-    const currentState = { fetching: true, value: clustersArray, error: null };
+    const currentState = { fetching: true, updating: false, value: clustersArray, error: null };
     const action = { type: getFailureActionType(LOAD_CLUSTERS_ACTION), payload: { message: 'expected error' } };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: false,
+      updating: false,
+      value: currentState.value,
+      error: { message: 'expected error' },
+    });
+  });
+});
+
+describe('UPDATE_CLUSTERS_ACTION reducer', () => {
+  it('handles pending action type correctly', () => {
+    const currentState = { fetching: false, updating: false, value: clustersArray, error: null };
+    const action = { type: getPendingActionType(UPDATE_CLUSTERS_ACTION) };
+
+    const nextState = clustersReducer(currentState, action);
+
+    expect(nextState).toEqual({
+      fetching: false,
+      updating: true,
+      value: clustersArray,
+      error: null,
+    });
+  });
+
+  it('handles successful action type correctly', () => {
+    const currentState = { fetching: false, updating: true, value: [], error: null };
+    const action = { type: getSuccessActionType(UPDATE_CLUSTERS_ACTION), payload: { clusters: clustersArray, projectKey: 'project-key' } };
+
+    const nextState = clustersReducer(currentState, action);
+
+    expect(nextState).toEqual({
+      fetching: false,
+      updating: false,
+      value: clustersArray,
+      error: null,
+    });
+  });
+
+  it('handle failed action type correctly', () => {
+    const currentState = { fetching: false, updating: true, value: clustersArray, error: null };
+    const action = { type: getFailureActionType(UPDATE_CLUSTERS_ACTION), payload: { message: 'expected error' } };
+
+    const nextState = clustersReducer(currentState, action);
+
+    expect(nextState).toEqual({
+      fetching: false,
+      updating: false,
       value: currentState.value,
       error: { message: 'expected error' },
     });
@@ -54,39 +101,42 @@ describe('LOAD_CLUSTERS_ACTION reducer', () => {
 
 describe('GET_ALL_PROJECTS_AND_RESOURCES_ACTION reducer', () => {
   it('handles pending action type correctly', () => {
-    const currentState = { fetching: false, value: clustersArray, error: null };
+    const currentState = { fetching: false, updating: false, value: clustersArray, error: null };
     const action = { type: getPendingActionType(GET_ALL_PROJECTS_AND_RESOURCES_ACTION) };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: true,
+      updating: false,
       value: clustersArray,
       error: null,
     });
   });
 
   it('handles successful action type correctly', () => {
-    const currentState = { fetching: true, value: [], error: null };
+    const currentState = { fetching: true, updating: false, value: [], error: null };
     const action = { type: getSuccessActionType(GET_ALL_PROJECTS_AND_RESOURCES_ACTION), payload: { clusters: clustersArray } };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: false,
+      updating: false,
       value: clustersArray,
       error: null,
     });
   });
 
   it('handle failed action type correctly', () => {
-    const currentState = { fetching: true, value: clustersArray, error: null };
+    const currentState = { fetching: true, updating: false, value: clustersArray, error: null };
     const action = { type: getFailureActionType(GET_ALL_PROJECTS_AND_RESOURCES_ACTION), payload: { message: 'expected error' } };
 
     const nextState = clustersReducer(currentState, action);
 
     expect(nextState).toEqual({
       fetching: false,
+      updating: false,
       value: currentState.value,
       error: { message: 'expected error' },
     });


### PR DESCRIPTION
Added scaleup and scaledown for clusters in client-api.
Updated the webapp so the cluster card actions includes the Suspend and Turn On options.
Also added an interval so the clusters are updated regularly in case their status changes, along with a new action to make this work without flickering.