### PR TITLE
NERCDL-1125: Set minimum message expiry date

### DIFF
--- a/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
+++ b/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
@@ -15,6 +15,7 @@ const styles = theme => ({
 });
 
 export const getSevenDaysFromNow = () => moment().startOf('day').add(7, 'days').toDate();
+export const tomorrow = () => moment().startOf('day').add(1, 'days').toDate();
 
 const MessageCreator = ({ classes, createMessage }) => {
   const [preview, showPreview] = useState(false);
@@ -43,7 +44,7 @@ const MessageCreator = ({ classes, createMessage }) => {
         <Grid item xs={2}>
           <DateTimePicker
             variant="inline"
-            disablePast
+            minDate={tomorrow()}
             label={'Expiry'}
             value={selectedDate}
             onChange={handleDateChange}

--- a/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
+++ b/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
@@ -43,6 +43,7 @@ const MessageCreator = ({ classes, createMessage }) => {
         <Grid item xs={2}>
           <DateTimePicker
             variant="inline"
+            disablePast
             label={'Expiry'}
             value={selectedDate}
             onChange={handleDateChange}


### PR DESCRIPTION
Set the minimum message expiry date to "tomorrow".
The "disablePast" flag on the picker still includes earlier hours in the current day, so using a minDate of tomorrow restricts all in-the-past expiries 