### PR TITLE
NERCDL-1135: Added new asset action

### DIFF
--- a/code/workspaces/web-app/src/actions/assetRepoActions.js
+++ b/code/workspaces/web-app/src/actions/assetRepoActions.js
@@ -5,6 +5,7 @@ export const EDIT_REPO_METADATA_ACTION = 'EDIT_REPO_METADATA_ACTION';
 export const CLEAR_REPO_METADATA_ACTION = 'CLEAR_REPO_METADATA_ACTION';
 export const LOAD_VISIBLE_ASSETS_ACTION = 'LOAD_VISIBLE_ASSETS_ACTION';
 export const LOAD_ALL_ASSETS_ACTION = 'LOAD_ALL_ASSETS_ACTION';
+export const LOAD_ONLY_VISIBLE_ASSETS_ACTION = 'LOAD_ONLY_VISIBLE_ASSETS_ACTION';
 
 const addRepoMetadata = metadata => ({
   type: ADD_REPO_METADATA_ACTION,
@@ -31,11 +32,18 @@ const loadAllAssets = () => ({
   payload: assetRepoService.loadAllAssets(),
 });
 
+// This gets the same assets as 'loadVisibleAssets', but overwrites the content in the state, rather than merges.
+const loadOnlyVisibleAssets = projectKey => ({
+  type: LOAD_ONLY_VISIBLE_ASSETS_ACTION,
+  payload: assetRepoService.loadVisibleAssets(projectKey),
+});
+
 const assetRepoActions = {
   addRepoMetadata,
   editRepoMetadata,
   clearRepoMetadata,
   loadVisibleAssets,
   loadAllAssets,
+  loadOnlyVisibleAssets,
 };
 export default assetRepoActions;

--- a/code/workspaces/web-app/src/actions/assetRepoActions.spec.js
+++ b/code/workspaces/web-app/src/actions/assetRepoActions.spec.js
@@ -35,6 +35,48 @@ describe('assetRepoActions', () => {
       expect(output.payload).toBe('expectedPayload');
     });
 
+    it('loadVisibleAssets', () => {
+      // Arrange
+      const loadVisibleAssetsMock = jest.fn().mockReturnValue('expectedPayload');
+      assetRepoService.loadVisibleAssets = loadVisibleAssetsMock;
+
+      // Act
+      const output = assetRepoActions.loadVisibleAssets();
+
+      // Assert
+      expect(loadVisibleAssetsMock).toHaveBeenCalledTimes(1);
+      expect(output.type).toBe('LOAD_VISIBLE_ASSETS_ACTION');
+      expect(output.payload).toBe('expectedPayload');
+    });
+
+    it('loadAllAssets', () => {
+      // Arrange
+      const loadAllAssetsMock = jest.fn().mockReturnValue('expectedPayload');
+      assetRepoService.loadAllAssets = loadAllAssetsMock;
+
+      // Act
+      const output = assetRepoActions.loadAllAssets();
+
+      // Assert
+      expect(loadAllAssetsMock).toHaveBeenCalledTimes(1);
+      expect(output.type).toBe('LOAD_ALL_ASSETS_ACTION');
+      expect(output.payload).toBe('expectedPayload');
+    });
+
+    it('loadOnlyVisibleAssets', () => {
+      // Arrange
+      const loadVisibleAssetsMock = jest.fn().mockReturnValue('expectedPayload');
+      assetRepoService.loadVisibleAssets = loadVisibleAssetsMock;
+
+      // Act
+      const output = assetRepoActions.loadOnlyVisibleAssets();
+
+      // Assert
+      expect(loadVisibleAssetsMock).toHaveBeenCalledTimes(1);
+      expect(output.type).toBe('LOAD_ONLY_VISIBLE_ASSETS_ACTION');
+      expect(output.payload).toBe('expectedPayload');
+    });
+
     describe('exports correct value for', () => {
       it('ADD_REPO_METADATA_ACTION', () => {
         expect(ADD_REPO_METADATA_ACTION).toBe('ADD_REPO_METADATA_ACTION');

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { change, reset, initialize } from 'redux-form';
 import queryString from 'query-string';
 import { NOTEBOOK_CATEGORY } from 'common/src/config/images';
+import { Typography } from '@material-ui/core';
 import projectActions from '../../actions/projectActions';
 import stackActions from '../../actions/stackActions';
 import assetRepoActions from '../../actions/assetRepoActions';
@@ -173,11 +174,17 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
   const notebookOptions = getNotebookOptions(notebooks || [], selectedProject);
 
   return (
-    <AddAssetsToNotebookForm
-      projectOptions={projectOptions}
-      notebookOptions={notebookOptions}
-      onSubmit={confirmAddAsset(dispatch, history)}
-      handleClear={clearForm(dispatch, setResetForm)}
-    />
+    <div>
+      <Typography variant="body1">
+        Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected.
+        If any assets are selected that already exist on the notebook, these won't be re-added.
+      </Typography>
+      <AddAssetsToNotebookForm
+        projectOptions={projectOptions}
+        notebookOptions={notebookOptions}
+        onSubmit={confirmAddAsset(dispatch, history)}
+        handleClear={clearForm(dispatch, setResetForm)}
+      />
+    </div>
   );
 };

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
@@ -85,7 +85,7 @@ export const addAssets = (dispatch, history, data) => async () => {
     notify.error('Unable to add asset(s) to notebook.');
   } finally {
     await dispatch(stackActions.loadStacksByCategory(project, NOTEBOOK_CATEGORY));
-    await dispatch(assetRepoActions.loadVisibleAssets(project));
+    await dispatch(assetRepoActions.loadOnlyVisibleAssets(project));
   }
 };
 
@@ -142,7 +142,7 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
     dispatch(stackActions.loadStacksByCategory(selectedProject, NOTEBOOK_CATEGORY));
 
     if (selectedProject) {
-      dispatch(assetRepoActions.loadVisibleAssets(selectedProject));
+      dispatch(assetRepoActions.loadOnlyVisibleAssets(selectedProject));
     }
   }, [dispatch, selectedProject, resetForm]);
 

--- a/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookContainer.spec.js.snap
@@ -3,7 +3,14 @@
 exports[`AddAssetsToNotebookContainer initialises correctly when all properties are specified in the URL 1`] = `
 <div>
   <div>
-    Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+    </p>
+    <div>
+      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    </div>
   </div>
 </div>
 `;
@@ -11,7 +18,14 @@ exports[`AddAssetsToNotebookContainer initialises correctly when all properties 
 exports[`AddAssetsToNotebookContainer initialises correctly when project and notebook are specified in the URL 1`] = `
 <div>
   <div>
-    Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+    </p>
+    <div>
+      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    </div>
   </div>
 </div>
 `;
@@ -19,7 +33,14 @@ exports[`AddAssetsToNotebookContainer initialises correctly when project and not
 exports[`AddAssetsToNotebookContainer passes the correct props to the form when there are no projects or notebooks 1`] = `
 <div>
   <div>
-    Form: {"projectOptions":[],"notebookOptions":[]}
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+    </p>
+    <div>
+      Form: {"projectOptions":[],"notebookOptions":[]}
+    </div>
   </div>
 </div>
 `;
@@ -27,7 +48,14 @@ exports[`AddAssetsToNotebookContainer passes the correct props to the form when 
 exports[`AddAssetsToNotebookContainer passes the correct props to the form when there are projects and notebooks and a project is selected 1`] = `
 <div>
   <div>
-    Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    <p
+      class="MuiTypography-root MuiTypography-body1"
+    >
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+    </p>
+    <div>
+      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+    </div>
   </div>
 </div>
 `;

--- a/code/workspaces/web-app/src/reducers/assetRepoReducer.js
+++ b/code/workspaces/web-app/src/reducers/assetRepoReducer.js
@@ -4,7 +4,13 @@ import {
   PROMISE_TYPE_SUCCESS,
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
-import { ADD_REPO_METADATA_ACTION, CLEAR_REPO_METADATA_ACTION, LOAD_VISIBLE_ASSETS_ACTION, LOAD_ALL_ASSETS_ACTION } from '../actions/assetRepoActions';
+import {
+  ADD_REPO_METADATA_ACTION,
+  CLEAR_REPO_METADATA_ACTION,
+  LOAD_VISIBLE_ASSETS_ACTION,
+  LOAD_ALL_ASSETS_ACTION,
+  LOAD_ONLY_VISIBLE_ASSETS_ACTION,
+} from '../actions/assetRepoActions';
 
 const initialState = {
   fetching: false,
@@ -40,6 +46,11 @@ export default typeToReducer({
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: addNewAssets(state.value.assets, action.payload) } }),
   },
   [LOAD_ALL_ASSETS_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, value: state.value, fetching: true }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: action.payload } }),
+  },
+  [LOAD_ONLY_VISIBLE_ASSETS_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, value: state.value, fetching: true }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: action.payload } }),

--- a/code/workspaces/web-app/src/reducers/assetRepoReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/assetRepoReducer.spec.js
@@ -1,5 +1,11 @@
 import { PROMISE_TYPE_FAILURE, PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS } from '../actions/actionTypes';
-import { ADD_REPO_METADATA_ACTION, CLEAR_REPO_METADATA_ACTION, LOAD_VISIBLE_ASSETS_ACTION, LOAD_ALL_ASSETS_ACTION } from '../actions/assetRepoActions';
+import {
+  ADD_REPO_METADATA_ACTION,
+  CLEAR_REPO_METADATA_ACTION,
+  LOAD_VISIBLE_ASSETS_ACTION,
+  LOAD_ALL_ASSETS_ACTION,
+  LOAD_ONLY_VISIBLE_ASSETS_ACTION,
+} from '../actions/assetRepoActions';
 import assetRepoReducer, { addNewAssets } from './assetRepoReducer';
 
 describe('assetRepoReducer', () => {
@@ -137,6 +143,56 @@ describe('assetRepoReducer', () => {
 
       // Assert
       expect(nextState).toEqual({ error: payload, fetching: false, value: null });
+    });
+  });
+
+  describe('LOAD_ONLY_VISIBLE_ASSETS_ACTION', () => {
+    const baseState = () => ({
+      fetching: false,
+      value: {
+        createdAssetId: null,
+        assets: [],
+      },
+      error: null,
+    });
+
+    it('should handle LOAD_ONLY_VISIBLE_ASSETS_ACTION_PENDING', () => {
+      // Arrange
+      const type = `${LOAD_ONLY_VISIBLE_ASSETS_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextState = assetRepoReducer(baseState(), action);
+
+      // Assert
+      expect(nextState).toEqual({ ...baseState(), fetching: true });
+    });
+
+    it('should handle LOAD_ONLY_VISIBLE_ASSETS_ACTION_ACTION_SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_ONLY_VISIBLE_ASSETS_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ assetId: 'asset-1234' }];
+      const action = { type, payload };
+      const state = baseState();
+
+      // Act
+      const nextState = assetRepoReducer(state, action);
+
+      // Assert
+      expect(nextState).toEqual({ ...state, value: { ...state.value, assets: action.payload } });
+    });
+
+    it('should handle LOAD_ONLY_VISIBLE_ASSETS_ACTION_FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_ONLY_VISIBLE_ASSETS_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextState = assetRepoReducer(baseState(), action);
+
+      // Assert
+      expect(nextState).toEqual({ ...baseState(), error: payload });
     });
   });
 });


### PR DESCRIPTION
Added a new asset retrieval action that gets the assets visible to a project, and overwrites the state with the response (the existing asset loading actions either merge the state, or get all assets).
This is so in the add-assets-to-notebook form, changing projects will cause any assets that should be hidden to disappear.