### PR TITLE
NERCDL-1136: Fixed add asset form issues

### DIFF
--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
@@ -21,6 +21,9 @@ import {
 import modalDialogActions from '../../actions/modalDialogActions';
 import { MODAL_TYPE_CONFIRM_CREATION } from '../../constants/modaltypes';
 import notify from '../../components/common/notify';
+import { useVisibleAssets } from '../../hooks/assetRepoHooks';
+
+const assetInfo = 'Note: Non-public assets will only appear if an allowed project is selected.';
 
 const getProjectOptions = projects => projects.map(p => ({ value: p.key, text: `${p.name} (${p.key})` }));
 
@@ -129,7 +132,7 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
 
   const projects = useSelector(s => s.projects.value);
   const notebooks = useSelector(s => s.stacks.value);
-  const visibleAssets = useSelector(s => s.assetRepo.value.assets);
+  const visibleAssets = useVisibleAssets(selectedProject).value.assets;
 
   const [resetForm, setResetForm] = useState(true);
 
@@ -144,6 +147,8 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
 
     if (selectedProject) {
       dispatch(assetRepoActions.loadOnlyVisibleAssets(selectedProject));
+    } else {
+      dispatch(assetRepoActions.loadAllAssets());
     }
   }, [dispatch, selectedProject, resetForm]);
 
@@ -178,13 +183,17 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
       <Typography variant="body1">
         Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected.
         If any assets are selected that already exist on the notebook, these won't be re-added.
+        If you cannot see the form, then it likely means you are not part of any projects.
       </Typography>
-      <AddAssetsToNotebookForm
-        projectOptions={projectOptions}
-        notebookOptions={notebookOptions}
-        onSubmit={confirmAddAsset(dispatch, history)}
-        handleClear={clearForm(dispatch, setResetForm)}
-      />
+      <div>
+        {projectOptions.length > 0 ? <AddAssetsToNotebookForm
+            projectOptions={projectOptions}
+            notebookOptions={notebookOptions}
+            onSubmit={confirmAddAsset(dispatch, history)}
+            handleClear={clearForm(dispatch, setResetForm)}
+            assetInfo={assetInfo}
+          /> : undefined}
+      </div>
     </div>
   );
 };

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.spec.js
@@ -6,7 +6,9 @@ import { change, reset, initialize } from 'redux-form';
 import { AddAssetsToNotebookContainer, confirmAddAsset, addAssets, getExistingAssets, clearForm } from './AddAssetsToNotebookContainer';
 import * as addAssetsForm from './AddAssetsToNotebookForm';
 import * as reduxFormHooks from '../../hooks/reduxFormHooks';
+import * as assetRepoHooks from '../../hooks/assetRepoHooks';
 import stackActions from '../../actions/stackActions';
+import assetRepoActions from '../../actions/assetRepoActions';
 import notify from '../../components/common/notify';
 import stackService from '../../api/stackService';
 
@@ -72,12 +74,17 @@ describe('AddAssetsToNotebookContainer', () => {
     jest.mock('react-redux');
     jest.mock('react-router');
     jest.mock('../../hooks/reduxFormHooks');
+    jest.mock('../../hooks/assetRepoHooks');
+    jest.mock('../../actions/assetRepoActions');
     jest.mock('./AddAssetsToNotebookForm');
     addAssetsForm.AddAssetsToNotebookForm = jest.fn(props => <div>{`Form: ${JSON.stringify(props)}`}</div>);
 
     redux.useDispatch = jest.fn().mockReturnValue(dispatchMock);
     redux.useSelector = selectorMock.mockReturnValue([]);
     reduxFormHooks.useReduxFormValue = jest.fn();
+    assetRepoHooks.useVisibleAssets = jest.fn().mockReturnValue({ value: { assets: [] } });
+    assetRepoActions.loadAllAssets = jest.fn();
+    assetRepoActions.loadOnlyVisibleAssets = jest.fn();
   });
 
   it('passes the correct props to the form when there are no projects or notebooks', () => {
@@ -87,7 +94,8 @@ describe('AddAssetsToNotebookContainer', () => {
     const wrapper = renderWithLocation(location, AddAssetsToNotebookContainer, props);
 
     expect(wrapper.container).toMatchSnapshot();
-    expect(dispatchMock).toHaveBeenCalledTimes(4);
+    expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(assetRepoActions.loadAllAssets).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledWith('addAssetsToNotebook', { project: undefined, notebook: undefined });
     expect(change).toHaveBeenCalledTimes(1);
@@ -107,6 +115,8 @@ describe('AddAssetsToNotebookContainer', () => {
 
     expect(wrapper.container).toMatchSnapshot();
     expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledTimes(1);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledWith('project1');
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledWith('addAssetsToNotebook', { project: undefined, notebook: undefined });
     expect(change).toHaveBeenCalledTimes(1);
@@ -122,15 +132,17 @@ describe('AddAssetsToNotebookContainer', () => {
     };
 
     reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue('project1');
+    assetRepoHooks.useVisibleAssets = jest.fn().mockReturnValue({ value: { assets } });
     selectorMock
       .mockReturnValueOnce(projects)
-      .mockReturnValueOnce(notebooks)
-      .mockReturnValueOnce(assets);
+      .mockReturnValueOnce(notebooks);
 
     const wrapper = renderWithLocation(location, AddAssetsToNotebookContainer, props);
 
     expect(wrapper.container).toMatchSnapshot();
     expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledTimes(1);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledWith('project1');
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledWith('addAssetsToNotebook', { project: 'project1', notebook: 'notebook1' });
     expect(change).toHaveBeenCalledTimes(1);
@@ -146,15 +158,17 @@ describe('AddAssetsToNotebookContainer', () => {
     };
 
     reduxFormHooks.useReduxFormValue = jest.fn().mockReturnValue('project1');
+    assetRepoHooks.useVisibleAssets = jest.fn().mockReturnValue({ value: { assets } });
     selectorMock
       .mockReturnValueOnce(projects)
-      .mockReturnValueOnce(notebooks)
-      .mockReturnValueOnce(assets);
+      .mockReturnValueOnce(notebooks);
 
     const wrapper = renderWithLocation(location, AddAssetsToNotebookContainer, props);
 
     expect(wrapper.container).toMatchSnapshot();
     expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledTimes(1);
+    expect(assetRepoActions.loadOnlyVisibleAssets).toHaveBeenCalledWith('project1');
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledWith('addAssetsToNotebook', { project: 'project1', notebook: 'notebook1' });
     expect(change).toHaveBeenCalledTimes(1);

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookForm.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
+import { Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import { useReduxFormValue } from '../../hooks/reduxFormHooks';
 import { UpdateFormControls, formatAndParseMultiSelect, renderSelectField } from '../../components/common/form/controls';
@@ -13,7 +14,7 @@ export const NOTEBOOK_FIELD_NAME = 'notebook';
 export const EXISTING_ASSETS_FIELD_NAME = 'existingAssets';
 export const ASSETS_FIELD_NAME = 'assets';
 
-const AddAssetsToNotebookFormContent = ({ handleSubmit, projectOptions, notebookOptions, handleClear }) => {
+const AddAssetsToNotebookFormContent = ({ handleSubmit, projectOptions, notebookOptions, handleClear, assetInfo }) => {
   const selectedProject = useReduxFormValue(FORM_NAME, PROJECT_FIELD_NAME);
   const selectedNotebook = useReduxFormValue(FORM_NAME, NOTEBOOK_FIELD_NAME);
   const notebooks = useSelector(s => s.stacks.value);
@@ -51,6 +52,7 @@ const AddAssetsToNotebookFormContent = ({ handleSubmit, projectOptions, notebook
           />
         </div>}
         <div>
+          {assetInfo && <Typography variant="body2">{assetInfo}</Typography>}
           <Field
             disabled={!(selectedProject && selectedNotebook)}
             name={ASSETS_FIELD_NAME}
@@ -81,6 +83,7 @@ AddAssetsToNotebookFormContent.propTypes = {
   ...formPropTypes,
   handleSubmit: PropTypes.func.isRequired,
   handleClear: PropTypes.func.isRequired,
+  assetInfo: PropTypes.string,
 };
 
 const AddAssetsToNotebookForm = reduxForm({

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookForm.spec.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookForm.spec.js
@@ -33,6 +33,7 @@ describe('AddAssetsToNotebookForm', () => {
     handleClear,
     projectOptions: [{ text: 'project1', value: 'project1' }, { text: 'project2', value: 'project2' }],
     notebookOptions: [{ text: 'notebook1', value: 'notebook1' }, { text: 'notebook2', value: 'notebook2' }],
+    assetInfo: 'assetInfo',
   });
 
   it('renders correctly when a project and notebook have been selected', () => {

--- a/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookContainer.spec.js.snap
@@ -6,10 +6,12 @@ exports[`AddAssetsToNotebookContainer initialises correctly when all properties 
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added. If you cannot see the form, then it likely means you are not part of any projects.
     </p>
     <div>
-      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+      <div>
+        Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}],"assetInfo":"Note: Non-public assets will only appear if an allowed project is selected."}
+      </div>
     </div>
   </div>
 </div>
@@ -21,10 +23,12 @@ exports[`AddAssetsToNotebookContainer initialises correctly when project and not
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added. If you cannot see the form, then it likely means you are not part of any projects.
     </p>
     <div>
-      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+      <div>
+        Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}],"assetInfo":"Note: Non-public assets will only appear if an allowed project is selected."}
+      </div>
     </div>
   </div>
 </div>
@@ -36,11 +40,9 @@ exports[`AddAssetsToNotebookContainer passes the correct props to the form when 
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added. If you cannot see the form, then it likely means you are not part of any projects.
     </p>
-    <div>
-      Form: {"projectOptions":[],"notebookOptions":[]}
-    </div>
+    <div />
   </div>
 </div>
 `;
@@ -51,10 +53,12 @@ exports[`AddAssetsToNotebookContainer passes the correct props to the form when 
     <p
       class="MuiTypography-root MuiTypography-body1"
     >
-      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added.
+      Add one or multiple assets to a notebook. To choose assets, a project and notebook must first be selected. If any assets are selected that already exist on the notebook, these won't be re-added. If you cannot see the form, then it likely means you are not part of any projects.
     </p>
     <div>
-      Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}]}
+      <div>
+        Form: {"projectOptions":[{"value":"project1","text":"project1 (project1)"},{"value":"project2","text":"project2 (project2)"}],"notebookOptions":[{"value":"n1","text":"notebook1 (n1)"}],"assetInfo":"Note: Non-public assets will only appear if an allowed project is selected."}
+      </div>
     </div>
   </div>
 </div>

--- a/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookForm.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/assetRepo/__snapshots__/AddAssetsToNotebookForm.spec.js.snap
@@ -17,15 +17,20 @@ exports[`AddAssetsToNotebookForm renders correctly when a no notebook has been s
         </div>
       </div>
       <div>
+        <p
+          class="MuiTypography-root MuiTypography-body2"
+        >
+          assetInfo
+        </p>
         <div>
           Field: {"disabled":true,"name":"assets","label":"Assets","projectKey":"project1"}
         </div>
       </div>
       <div
-        class="makeStyles-fromControlContainer-56"
+        class="makeStyles-fromControlContainer-116"
       >
         <span
-          class="makeStyles-button-57"
+          class="makeStyles-button-117"
           title=""
         >
           <button
@@ -44,7 +49,7 @@ exports[`AddAssetsToNotebookForm renders correctly when a no notebook has been s
           </button>
         </span>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-button-57 MuiButton-outlinedSecondary"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-button-117 MuiButton-outlinedSecondary"
           tabindex="0"
           type="button"
         >
@@ -85,15 +90,20 @@ exports[`AddAssetsToNotebookForm renders correctly when a project and notebook h
         </div>
       </div>
       <div>
+        <p
+          class="MuiTypography-root MuiTypography-body2"
+        >
+          assetInfo
+        </p>
         <div>
           Field: {"disabled":false,"name":"assets","label":"Assets","projectKey":"project1"}
         </div>
       </div>
       <div
-        class="makeStyles-fromControlContainer-1"
+        class="makeStyles-fromControlContainer-31"
       >
         <span
-          class="makeStyles-button-2"
+          class="makeStyles-button-32"
           title=""
         >
           <button
@@ -112,7 +122,7 @@ exports[`AddAssetsToNotebookForm renders correctly when a project and notebook h
           </button>
         </span>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-button-2 MuiButton-outlinedSecondary"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-button-32 MuiButton-outlinedSecondary"
           tabindex="0"
           type="button"
         >


### PR DESCRIPTION
Fixed some issues and made some improvements with the add asset form:
* Changed so the form only appears if there are project options (to stop the form (and its validation) being initialised with an empty list of options)
* If no project is selected, it now retrieves all assets so they can be correctly displayed when the form is loaded
* Updated asset selector to get only the visible assets for a project, which means that non-public assets are always hidden by default
* Updated text at the top of the page and added some more info about the asset box