### PR TITLE
NERCDL-1138: Fixed message buttons styling

### DIFF
--- a/code/workspaces/web-app/src/containers/adminMessages/AdminMessage.js
+++ b/code/workspaces/web-app/src/containers/adminMessages/AdminMessage.js
@@ -18,6 +18,10 @@ const styles = theme => ({
     alignItems: 'center',
     color: theme.palette.secondary[400],
   },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
 });
 
 const AdminMessage = ({ classes, message, deleteMessage }) => {
@@ -30,11 +34,11 @@ const AdminMessage = ({ classes, message, deleteMessage }) => {
       <Grid item xs={10}>
         <div>{message.message}</div>
       </Grid>
-      <Grid item xs={1}>
-        <Button onClick={() => showPreview(!preview)} color={'primary'} variant={preview ? 'contained' : 'outlined'}>Preview</Button>
-      </Grid>
-      <Grid item xs={1}>
-        <PrimaryActionButton onClick={() => deleteMessage(message)}>Delete</PrimaryActionButton>
+      <Grid item xs={2}>
+        <div className={classes.buttonContainer}>
+          <Button onClick={() => showPreview(!preview)} color={'primary'} variant={preview ? 'contained' : 'outlined'}>Preview</Button>
+          <PrimaryActionButton onClick={() => deleteMessage(message)}>Delete</PrimaryActionButton>
+        </div>
       </Grid>
       <Grid item xs={12}>
         <div className={classes.date}>{expiryString}</div>

--- a/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
+++ b/code/workspaces/web-app/src/containers/adminMessages/MessageCreator.js
@@ -12,6 +12,10 @@ const styles = theme => ({
   creator: {
     padding: `${theme.spacing(4)}px 0`,
   },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
 });
 
 export const getSevenDaysFromNow = () => moment().startOf('day').add(7, 'days').toDate();
@@ -51,22 +55,22 @@ const MessageCreator = ({ classes, createMessage }) => {
             ampm={false}
           />
         </Grid>
-        <Grid item xs={1}>
-          <Button
-            onClick={() => showPreview(!preview)}
-            color={'primary'}
-            variant={preview ? 'contained' : 'outlined'}
-          >
-            Preview
-          </Button>
-        </Grid>
-        <Grid item xs={1}>
-          <PagePrimaryActionButton
-            onClick={() => createMessage(messageText, selectedDate, clearMessage)}
-            disabled={!messageText}
-          >
-            Create
-          </PagePrimaryActionButton>
+        <Grid item xs={2}>
+          <div className={classes.buttonContainer}>
+            <Button
+              onClick={() => showPreview(!preview)}
+              color={'primary'}
+              variant={preview ? 'contained' : 'outlined'}
+              >
+              Preview
+            </Button>
+            <PagePrimaryActionButton
+              onClick={() => createMessage(messageText, selectedDate, clearMessage)}
+              disabled={!messageText}
+              >
+              Create
+            </PagePrimaryActionButton>
+            </div>
         </Grid>
         <Grid item xs={12} hidden={!preview} id={'messagePreview'}>
           <Message message={{ message: messageText }} allowDismiss={false} />

--- a/code/workspaces/web-app/src/containers/adminMessages/__snapshots__/AdminMessage.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminMessages/__snapshots__/AdminMessage.spec.js.snap
@@ -13,40 +13,40 @@ exports[`AdminMessage renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2"
     >
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
-        tabindex="0"
-        type="button"
+      <div
+        class="AdminMessage-buttonContainer-3"
       >
-        <span
-          class="MuiButton-label"
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+          tabindex="0"
+          type="button"
         >
-          Preview
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
-    >
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-label"
+          <span
+            class="MuiButton-label"
+          >
+            Preview
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+          tabindex="0"
+          type="button"
         >
-          Delete
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
+          <span
+            class="MuiButton-label"
+          >
+            Delete
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
     </div>
     <div
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"

--- a/code/workspaces/web-app/src/containers/adminMessages/__snapshots__/MessageCreator.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/adminMessages/__snapshots__/MessageCreator.spec.js.snap
@@ -72,38 +72,38 @@ exports[`MessageCreator renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2"
       >
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
-          tabindex="0"
-          type="button"
+        <div
+          class="MessageCreator-buttonContainer-2"
         >
-          <span
-            class="MuiButton-label"
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary"
+            tabindex="0"
+            type="button"
           >
-            Preview
-          </span>
-          <span
-            class="MuiTouchRipple-root"
-          />
-        </button>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
-      >
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
-          disabled=""
-          tabindex="-1"
-          type="button"
-        >
-          <span
-            class="MuiButton-label"
+            <span
+              class="MuiButton-label"
+            >
+              Preview
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+            disabled=""
+            tabindex="-1"
+            type="button"
           >
-            Create
-          </span>
-        </button>
+            <span
+              class="MuiButton-label"
+            >
+              Create
+            </span>
+          </button>
+        </div>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"


### PR DESCRIPTION
Moved the Preview/Create and Preview/Delete buttons into the same part of the flex grid, so they don't overlap when the window is shrunk.