### PR TITLE
NERCDL-914: Get Assets for User (backend)

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.js
@@ -41,6 +41,14 @@ async function listCentralAssetsAvailableToProject(projectKey, token) {
   return data;
 }
 
+async function listCentralAssetsAvailableToUser(token) {
+  const { data } = await infrastructureApi().get(
+    '/allowedMetadata',
+    requestConfig(token),
+  );
+  return data;
+}
+
 async function getAssetByIdAndProjectKey(assetId, projectKey, token) {
   const { data } = await infrastructureApi().get(
     `/metadata/${assetId}?projectKey=${projectKey}`,
@@ -54,5 +62,6 @@ export default {
   updateAssetMetadata: wrapWithAxiosErrorWrapper('Error updating metadata.', updateAssetMetadata),
   listCentralAssets: wrapWithAxiosErrorWrapper('Error listing metadata.', listCentralAssets),
   listCentralAssetsAvailableToProject: wrapWithAxiosErrorWrapper('Error listing metadata from project.', listCentralAssetsAvailableToProject),
+  listCentralAssetsAvailableToUser: wrapWithAxiosErrorWrapper('Error listing metadata for user.', listCentralAssetsAvailableToUser),
   getAssetByIdAndProjectKey: wrapWithAxiosErrorWrapper('Error getting metadata by assetId and projectKey', getAssetByIdAndProjectKey),
 };

--- a/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/centralAssetRepoService.spec.js
@@ -100,6 +100,23 @@ describe('listCentralAssetsAvailableToProject', () => {
   });
 });
 
+describe('listCentralAssetsAvailableToUser', () => {
+  const { listCentralAssetsAvailableToUser } = centralAssetRepoService;
+
+  it('calls infrastructure-api to get metadata of assets visible to the calling user', async () => {
+    httpMock
+      .onGet(`${infrastructureApi}/centralAssetRepo/allowedMetadata`)
+      .reply(200, [metadataResponse]);
+
+    const returnValue = await listCentralAssetsAvailableToUser(token);
+
+    expect(returnValue).toEqual([metadataResponse]);
+    expect(httpMock.history.get.length).toBe(1);
+    const [getMock] = httpMock.history.get;
+    expect(getMock.headers.authorization).toEqual(token);
+  });
+});
+
 describe('getAssetByIdAndProjectKey', () => {
   const { getAssetByIdAndProjectKey } = centralAssetRepoService;
   const assetId = 'test-asset-id';

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -40,6 +40,7 @@ const resolvers = {
     logs: (obj, args, { token }) => w(logsService.getLogsByName(args.projectKey, args.name, token)),
     centralAssets: (obj, args, { token }) => w(centralAssetRepoService.listCentralAssets(token)),
     centralAssetsAvailableToProject: (obj, { projectKey }, { token }) => w(centralAssetRepoService.listCentralAssetsAvailableToProject(projectKey, token)),
+    centralAssetsAvailableToUser: (obj, args, { token }) => w(centralAssetRepoService.listCentralAssetsAvailableToUser(token)),
     clusters: (obj, args, { token }) => w(clustersService.getClusters(args.projectKey, token)),
     messages: (obj, args, { token }) => w(messagesService.getMessages(token)),
     allMessages: (obj, args, { token }) => w(messagesService.getAllMessages(token)),

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -51,6 +51,9 @@ type Query {
     # Return all central asset repo metadata items that are available to given project
     centralAssetsAvailableToProject(projectKey: String!): [CentralAssetMetadata]
 
+    # Return all central asset repo metadata items that are available to the requesting user
+    centralAssetsAvailableToUser: [CentralAssetMetadata]
+
     # List of clusters in a project
     clusters(projectKey: String!): [Cluster]
 

--- a/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/centralAssetRepoController.js
@@ -93,6 +93,19 @@ async function listAssetMetadata(request, response, next) {
   }
 }
 
+const getAllMetadata = async (request, response, next) => {
+  const { user: { sub, roles } } = request;
+
+  try {
+    const metadata = (roles.instanceAdmin || roles.dataManager)
+      ? await centralAssetRepoRepository.listMetadata()
+      : await centralAssetRepoRepository.metadataAvailableToUser(sub, roles.projectRoles);
+    return response.status(200).send(metadata);
+  } catch (error) {
+    return next(new Error(`Error getting asset metadata: ${error.message}`));
+  }
+};
+
 function handleMissingResourceLocator(metadata, response) {
   const { fileLocation, masterUrl } = metadata;
   if (!(fileLocation || masterUrl)) {
@@ -123,4 +136,5 @@ export default {
   stackCanUseAsset,
   getAssetById,
   listAssetMetadata,
+  getAllMetadata,
 };

--- a/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/centralAssetRepoRepository.spec.js
@@ -102,6 +102,30 @@ describe('metadataAvailableToProject', () => {
   });
 });
 
+describe('metadataAvailableToUser', () => {
+  it('performs correct query on central asset metadata model and returns the result', async () => {
+    const metadata = getMinimalMetadata();
+    centralAssetMetadataModelMock.exec.mockResolvedValueOnce([metadata]);
+    const projectRoles = [
+      { projectKey: 'test-project', role: 'admin' },
+      { projectKey: 'test-project2', role: 'user' },
+      { projectKey: 'test-project3', role: 'viewer' },
+    ];
+    const expectedAllowedProjects = ['test-project', 'test-project2'];
+
+    const returnValue = await centralAssetRepoRepository.metadataAvailableToUser('user', projectRoles);
+
+    expect(returnValue).toEqual([metadata]);
+    expect(centralAssetMetadataModelMock.find).toHaveBeenCalledWith();
+    expect(centralAssetMetadataModelMock.or).toHaveBeenCalledWith([
+      { visible: 'PUBLIC' },
+      { ownerUserIds: 'user' },
+      { visible: 'BY_PROJECT', projectKeys: { $elemMatch: { $in: expectedAllowedProjects } } },
+    ]);
+    expect(centralAssetMetadataModelMock.exec).toHaveBeenCalledWith();
+  });
+});
+
 describe('getMetadataWithIds', () => {
   it('performs correct query on central asset metadata model and returns the result', async () => {
     const metadata = getMinimalMetadata();

--- a/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/centralAssetRepoRouter.js
@@ -37,6 +37,12 @@ centralAssetRepoRouter.get(
   errorWrapper(centralAssetRepo.listAssetMetadata),
 );
 
+// No permission middleware on this as we handle specific cases on metadata retrieval at the DB level.
+centralAssetRepoRouter.get(
+  '/allowedMetadata',
+  errorWrapper(centralAssetRepo.getAllMetadata),
+);
+
 // Use /metadata/:assetId?projectKey=<projectKey value> to filter by metadata available to project
 // When projectKey query added, user's project permissions are checked, otherwise requires system permission to access
 centralAssetRepoRouter.get(


### PR DESCRIPTION
Added routes in infrastructure and client APIs to get the assets that a user is allowed to see, based on what projects they have access to.
Admins and Data Managers can see all assets, other users will see assets that are either public, ones they have created/own, or available to projects where they are a user or admin.