### PR TITLE
NERCDL-914: Get Assets for User (frontend)

### DIFF
--- a/code/workspaces/web-app/src/PrivateApp.js
+++ b/code/workspaces/web-app/src/PrivateApp.js
@@ -12,7 +12,7 @@ import AddAssetsToNotebookPage from './pages/AddAssetsToNotebookPage';
 import RoutePermissions from './components/common/RoutePermissionWrapper';
 import { useCurrentUserPermissions } from './hooks/authHooks';
 
-const { SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER } = permissionTypes;
+const { SYSTEM_INSTANCE_ADMIN } = permissionTypes;
 
 const PrivateApp = () => {
   const userPermissions = useCurrentUserPermissions().value;
@@ -28,7 +28,7 @@ const PrivateApp = () => {
         <RoutePermissions
           path="/assets"
           component={AssetRepoNavigationContainer}
-          permission={SYSTEM_DATA_MANAGER}
+          permission={''}
           alt={NotFoundPage}
         />
         <RoutePermissions

--- a/code/workspaces/web-app/src/actions/assetRepoActions.js
+++ b/code/workspaces/web-app/src/actions/assetRepoActions.js
@@ -5,6 +5,7 @@ export const EDIT_REPO_METADATA_ACTION = 'EDIT_REPO_METADATA_ACTION';
 export const CLEAR_REPO_METADATA_ACTION = 'CLEAR_REPO_METADATA_ACTION';
 export const LOAD_VISIBLE_ASSETS_ACTION = 'LOAD_VISIBLE_ASSETS_ACTION';
 export const LOAD_ALL_ASSETS_ACTION = 'LOAD_ALL_ASSETS_ACTION';
+export const LOAD_ASSETS_FOR_USER_ACTION = 'LOAD_ASSETS_FOR_USER_ACTION';
 export const LOAD_ONLY_VISIBLE_ASSETS_ACTION = 'LOAD_ONLY_VISIBLE_ASSETS_ACTION';
 
 const addRepoMetadata = metadata => ({
@@ -32,6 +33,11 @@ const loadAllAssets = () => ({
   payload: assetRepoService.loadAllAssets(),
 });
 
+const loadAssetsForUser = () => ({
+  type: LOAD_ASSETS_FOR_USER_ACTION,
+  payload: assetRepoService.loadAssetsForUser(),
+});
+
 // This gets the same assets as 'loadVisibleAssets', but overwrites the content in the state, rather than merges.
 const loadOnlyVisibleAssets = projectKey => ({
   type: LOAD_ONLY_VISIBLE_ASSETS_ACTION,
@@ -44,6 +50,7 @@ const assetRepoActions = {
   clearRepoMetadata,
   loadVisibleAssets,
   loadAllAssets,
+  loadAssetsForUser,
   loadOnlyVisibleAssets,
 };
 export default assetRepoActions;

--- a/code/workspaces/web-app/src/actions/assetRepoActions.spec.js
+++ b/code/workspaces/web-app/src/actions/assetRepoActions.spec.js
@@ -77,6 +77,20 @@ describe('assetRepoActions', () => {
       expect(output.payload).toBe('expectedPayload');
     });
 
+    it('loadAssetsForUser', () => {
+      // Arrange
+      const loadAssetsForUserMock = jest.fn().mockReturnValue('expectedPayload');
+      assetRepoService.loadAssetsForUser = loadAssetsForUserMock;
+
+      // Act
+      const output = assetRepoActions.loadAssetsForUser();
+
+      // Assert
+      expect(loadAssetsForUserMock).toHaveBeenCalledTimes(1);
+      expect(output.type).toBe('LOAD_ASSETS_FOR_USER_ACTION');
+      expect(output.payload).toBe('expectedPayload');
+    });
+
     describe('exports correct value for', () => {
       it('ADD_REPO_METADATA_ACTION', () => {
         expect(ADD_REPO_METADATA_ACTION).toBe('ADD_REPO_METADATA_ACTION');

--- a/code/workspaces/web-app/src/api/__snapshots__/assetRepoService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/assetRepoService.spec.js.snap
@@ -27,6 +27,15 @@ exports[`assetRepoService loadAllAssets should build the correct query and unpac
     }"
 `;
 
+exports[`assetRepoService loadAssetsForUser should build the correct query and unpack the results 1`] = `
+"
+    CentralAssetsAvailableToUser {
+      centralAssetsAvailableToUser {
+        assetId, name, version, fileLocation, visible, projects {key, name}, owners {userId}
+      }
+    }"
+`;
+
 exports[`assetRepoService loadVisibleAssets should build the correct query and unpack the results 1`] = `
 "
     CentralAssetsAvailableToProject($projectKey: String!) {

--- a/code/workspaces/web-app/src/api/__snapshots__/assetRepoService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/assetRepoService.spec.js.snap
@@ -31,7 +31,7 @@ exports[`assetRepoService loadAssetsForUser should build the correct query and u
 "
     CentralAssetsAvailableToUser {
       centralAssetsAvailableToUser {
-        assetId, name, version, fileLocation, visible, projects {key, name}, owners {userId}
+        assetId, name, version, fileLocation, masterUrl, owners {userId, name}, visible, projects {key, name}, registrationDate
       }
     }"
 `;

--- a/code/workspaces/web-app/src/api/assetRepoService.js
+++ b/code/workspaces/web-app/src/api/assetRepoService.js
@@ -37,6 +37,18 @@ function loadVisibleAssets(projectKey) {
     .then(errorHandler('data.centralAssetsAvailableToProject'));
 }
 
+function loadAssetsForUser() {
+  const query = `
+    CentralAssetsAvailableToUser {
+      centralAssetsAvailableToUser {
+        assetId, name, version, fileLocation, visible, projects {key, name}, owners {userId}
+      }
+    }`;
+
+  return gqlQuery(query)
+    .then(errorHandler('data.centralAssetsAvailableToUser'));
+}
+
 function loadAllAssets() {
   const query = `
     CentralAssets {
@@ -54,5 +66,6 @@ const assetRepoService = {
   editRepoMetadata,
   loadVisibleAssets,
   loadAllAssets,
+  loadAssetsForUser,
 };
 export default assetRepoService;

--- a/code/workspaces/web-app/src/api/assetRepoService.js
+++ b/code/workspaces/web-app/src/api/assetRepoService.js
@@ -41,7 +41,7 @@ function loadAssetsForUser() {
   const query = `
     CentralAssetsAvailableToUser {
       centralAssetsAvailableToUser {
-        assetId, name, version, fileLocation, visible, projects {key, name}, owners {userId}
+        assetId, name, version, fileLocation, masterUrl, owners {userId, name}, visible, projects {key, name}, registrationDate
       }
     }`;
 

--- a/code/workspaces/web-app/src/api/assetRepoService.spec.js
+++ b/code/workspaces/web-app/src/api/assetRepoService.spec.js
@@ -87,4 +87,23 @@ describe('assetRepoService', () => {
       });
     });
   });
+
+  describe('loadAssetsForUser', () => {
+    it('should build the correct query and unpack the results', () => {
+      mockClient.prepareSuccess({ centralAssetsAvailableToUser: 'expectedValue' });
+
+      return assetRepoService.loadAssetsForUser().then((response) => {
+        expect(response).toEqual('expectedValue');
+        expect(mockClient.lastQuery()).toMatchSnapshot();
+      });
+    });
+
+    it('should throw an error if the query fails', () => {
+      mockClient.prepareFailure('error');
+
+      return assetRepoService.loadAssetsForUser().catch((error) => {
+        expect(error).toEqual({ error: 'error' });
+      });
+    });
+  });
 });

--- a/code/workspaces/web-app/src/components/app/AssetRepoSideBar.js
+++ b/code/workspaces/web-app/src/components/app/AssetRepoSideBar.js
@@ -2,15 +2,21 @@ import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { permissionTypes } from 'common';
 import SideBarGroup from './SideBarGroup';
 import SideBarButton from './SideBarButton';
 import sideBarStyles from './sideBarStyles';
+import { CurrentUserPermissionWrapper } from '../common/ComponentPermissionWrapper';
+
+const { SYSTEM_DATA_MANAGER } = permissionTypes;
 
 const AssetRepoSideBar = ({ classes }) => (
   <div className={classes.sideBar}>
     <List className={classes.itemList}>
       <SideBarGroup title='Asset Repo'>
-        <SideBarButton to="/assets/add-metadata" label="Add Metadata" icon="dashboard"/>
+        <CurrentUserPermissionWrapper permission={SYSTEM_DATA_MANAGER}>
+          <SideBarButton to="/assets/add-metadata" label="Add Metadata" icon="dashboard"/>
+        </CurrentUserPermissionWrapper>
         <SideBarButton to="/assets/find" label="Find Asset" icon="dashboard"/>
       </SideBarGroup>
     </List>

--- a/code/workspaces/web-app/src/components/app/AssetRepoSideBar.spec.js
+++ b/code/workspaces/web-app/src/components/app/AssetRepoSideBar.spec.js
@@ -17,9 +17,7 @@ describe('AssetRepoSideBar', () => {
   it('renders correctly when user has no permissions', () => {
     const props = { classes };
 
-    const state = {
-      ...buildDefaultTestState(),
-    };
+    const state = buildDefaultTestState();
 
     const { wrapper } = renderWithState(state, AssetRepoSideBar, props);
 
@@ -29,17 +27,8 @@ describe('AssetRepoSideBar', () => {
   it('renders correctly when user is a Data Manager', () => {
     const props = { classes };
 
-    const defaultState = buildDefaultTestState();
-    const state = {
-      ...defaultState,
-      authentication: {
-        ...defaultState.authentication,
-        permissions: {
-          ...defaultState.permissions,
-          value: [permissionTypes.SYSTEM_DATA_MANAGER],
-        },
-      },
-    };
+    const state = buildDefaultTestState();
+    state.authentication.permissions.value = [permissionTypes.SYSTEM_DATA_MANAGER];
 
     const { wrapper } = renderWithState(state, AssetRepoSideBar, props);
 

--- a/code/workspaces/web-app/src/components/app/AssetRepoSideBar.spec.js
+++ b/code/workspaces/web-app/src/components/app/AssetRepoSideBar.spec.js
@@ -1,6 +1,12 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { permissionTypes } from 'common';
+import {
+  renderWithState,
+  buildDefaultTestState,
+} from '../../testUtils/renderWithState';
 import AssetRepoSideBar from './AssetRepoSideBar';
+
+jest.mock('./SideBarButton', () => props => <div {...props}>{props.label}</div>);
 
 const classes = {
   itemList: 'itemList',
@@ -8,8 +14,35 @@ const classes = {
 };
 
 describe('AssetRepoSideBar', () => {
-  it('renders correctly passing props to children', () => {
+  it('renders correctly when user has no permissions', () => {
     const props = { classes };
-    expect(shallow(<AssetRepoSideBar {...props} />)).toMatchSnapshot();
+
+    const state = {
+      ...buildDefaultTestState(),
+    };
+
+    const { wrapper } = renderWithState(state, AssetRepoSideBar, props);
+
+    expect(wrapper.container).toMatchSnapshot();
+  });
+
+  it('renders correctly when user is a Data Manager', () => {
+    const props = { classes };
+
+    const defaultState = buildDefaultTestState();
+    const state = {
+      ...defaultState,
+      authentication: {
+        ...defaultState.authentication,
+        permissions: {
+          ...defaultState.permissions,
+          value: [permissionTypes.SYSTEM_DATA_MANAGER],
+        },
+      },
+    };
+
+    const { wrapper } = renderWithState(state, AssetRepoSideBar, props);
+
+    expect(wrapper.container).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/components/app/TopBar.js
+++ b/code/workspaces/web-app/src/components/app/TopBar.js
@@ -10,7 +10,7 @@ import navBarLinks from '../../constants/navBarLinks';
 import { useCurrentUserPermissions } from '../../hooks/authHooks';
 import { getCatalogue } from '../../config/catalogue';
 
-const { SYSTEM_INSTANCE_ADMIN, SYSTEM_DATA_MANAGER } = permissionTypes;
+const { SYSTEM_INSTANCE_ADMIN } = permissionTypes;
 
 const styles = theme => createStyles({
   appBar: {
@@ -53,9 +53,7 @@ const TopBar = ({ classes, identity }) => {
           {userPermissions.includes(SYSTEM_INSTANCE_ADMIN)
           && <TopBarButton to="/admin" label="Admin"/>
           }
-          {userPermissions.includes(SYSTEM_DATA_MANAGER)
-          && <TopBarButton to="/assets" label="Asset Repo"/>
-          }
+          <TopBarButton to="/assets" label="Asset Repo"/>
           <TopBarButton to="/projects" label="Projects"/>
           {catalogue.available
           && catalogue.url

--- a/code/workspaces/web-app/src/components/app/__snapshots__/AssetRepoSideBar.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/AssetRepoSideBar.spec.js.snap
@@ -1,12 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssetRepoSideBar renders correctly passing props to children 1`] = `
-<AssetRepoSideBar
-  classes={
-    Object {
-      "itemList": "AssetRepoSideBar-itemList-1 itemList",
-      "sideBar": "AssetRepoSideBar-sideBar-2 sideBar",
-    }
-  }
-/>
+exports[`AssetRepoSideBar renders correctly when user has no permissions 1`] = `
+<div>
+  <div
+    class="AssetRepoSideBar-sideBar-2 sideBar"
+  >
+    <ul
+      class="MuiList-root AssetRepoSideBar-itemList-1 itemList MuiList-padding"
+    >
+      <div
+        class="SideBarGroup-sidebarGroup-7"
+      >
+        <h6
+          class="MuiTypography-root SideBarGroup-title-8 MuiTypography-h6"
+        >
+          Asset Repo
+        </h6>
+        <div
+          icon="dashboard"
+          label="Find Asset"
+          to="/assets/find"
+        >
+          Find Asset
+        </div>
+      </div>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`AssetRepoSideBar renders correctly when user is a Data Manager 1`] = `
+<div>
+  <div
+    class="AssetRepoSideBar-sideBar-40 sideBar"
+  >
+    <ul
+      class="MuiList-root AssetRepoSideBar-itemList-39 itemList MuiList-padding"
+    >
+      <div
+        class="SideBarGroup-sidebarGroup-45"
+      >
+        <h6
+          class="MuiTypography-root SideBarGroup-title-46 MuiTypography-h6"
+        >
+          Asset Repo
+        </h6>
+        <div>
+          <div
+            icon="dashboard"
+            label="Add Metadata"
+            to="/assets/add-metadata"
+          >
+            Add Metadata
+          </div>
+        </div>
+        <div
+          icon="dashboard"
+          label="Find Asset"
+          to="/assets/find"
+        >
+          Find Asset
+        </div>
+      </div>
+    </ul>
+  </div>
+</div>
 `;

--- a/code/workspaces/web-app/src/components/app/__snapshots__/TopBar.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/TopBar.spec.js.snap
@@ -16,57 +16,8 @@ exports[`TopBar correctly renders correct snapshot 1`] = `
       className="TopBar-buttons-4"
     >
       <WithStyles(TopBarButton)
-        label="Projects"
-        to="/projects"
-      />
-      <WithStyles(TopBarButton)
-        key="nav-link-Slack"
-        label="Slack"
-        onClick={[Function]}
-      />
-      <WithStyles(TopBarButton)
-        key="nav-link-Help"
-        label="Help"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    />
-    <WithStyles(UserIcon)
-      identity={
-        Object {
-          "expected": "identity",
-          "picture": "expectedUrl",
-        }
-      }
-    />
-  </div>
-</div>
-`;
-
-exports[`TopBar correctly renders correct snapshot for instance admin permission 1`] = `
-<div
-  className="TopBar-appBar-1"
->
-  <div
-    className="TopBar-toolBar-2"
-  >
-    <img
-      alt="datalabs-logo"
-      className="TopBar-datalabsLogo-3"
-      src="datalabs-hori.png"
-    />
-    <div
-      className="TopBar-buttons-4"
-    >
-      <WithStyles(TopBarButton)
-        label="Admin"
-        to="/admin"
+        label="Asset Repo"
+        to="/assets"
       />
       <WithStyles(TopBarButton)
         label="Projects"
@@ -155,6 +106,63 @@ exports[`TopBar correctly renders correct snapshot for data manager permission 1
 </div>
 `;
 
+exports[`TopBar correctly renders correct snapshot for instance admin permission 1`] = `
+<div
+  className="TopBar-appBar-1"
+>
+  <div
+    className="TopBar-toolBar-2"
+  >
+    <img
+      alt="datalabs-logo"
+      className="TopBar-datalabsLogo-3"
+      src="datalabs-hori.png"
+    />
+    <div
+      className="TopBar-buttons-4"
+    >
+      <WithStyles(TopBarButton)
+        label="Admin"
+        to="/admin"
+      />
+      <WithStyles(TopBarButton)
+        label="Asset Repo"
+        to="/assets"
+      />
+      <WithStyles(TopBarButton)
+        label="Projects"
+        to="/projects"
+      />
+      <WithStyles(TopBarButton)
+        key="nav-link-Slack"
+        label="Slack"
+        onClick={[Function]}
+      />
+      <WithStyles(TopBarButton)
+        key="nav-link-Help"
+        label="Help"
+        onClick={[Function]}
+      />
+    </div>
+    <div
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    />
+    <WithStyles(UserIcon)
+      identity={
+        Object {
+          "expected": "identity",
+          "picture": "expectedUrl",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`TopBar correctly renders correct snapshot if catalogue exists 1`] = `
 <div
   className="TopBar-appBar-1"
@@ -170,6 +178,10 @@ exports[`TopBar correctly renders correct snapshot if catalogue exists 1`] = `
     <div
       className="TopBar-buttons-4"
     >
+      <WithStyles(TopBarButton)
+        label="Asset Repo"
+        to="/assets"
+      />
       <WithStyles(TopBarButton)
         label="Projects"
         to="/projects"

--- a/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.js
+++ b/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.js
@@ -89,12 +89,12 @@ export const onEditAssetConfirm = async (dispatch, asset) => {
 };
 
 const allowEdit = (userId, userPermissions, asset) => {
-  // Only Data Managers and asset owners can edit an asset.
+  // For now, only Data Managers can edit an asset.
   if (userPermissions.value && userPermissions.value.includes(SYSTEM_DATA_MANAGER)) {
     return true;
   }
 
-  return asset.owners && asset.owners.filter(o => o.userId === userId).length > 0;
+  return false;
 };
 
 function AssetAccordion({ asset }) {

--- a/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.js
+++ b/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.js
@@ -8,6 +8,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Icon from '@material-ui/core/Icon';
 import { makeStyles } from '@material-ui/core/styles';
 import { reset } from 'redux-form';
+import { permissionTypes } from 'common';
 import { ResourceAccordion, ResourceAccordionSummary, ResourceAccordionDetails } from '../common/ResourceAccordion';
 import AssetCard from './AssetCard';
 import PrimaryActionButton from '../common/buttons/PrimaryActionButton';
@@ -19,8 +20,11 @@ import assetRepoActions from '../../actions/assetRepoActions';
 import notify from '../common/notify';
 import assetLabel from '../common/form/assetLabel';
 import { BY_PROJECT } from './assetVisibilities';
+import { useCurrentUserId, useCurrentUserPermissions } from '../../hooks/authHooks';
 
 const MORE_ICON = 'more_vert';
+
+const { SYSTEM_DATA_MANAGER } = permissionTypes;
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -84,11 +88,22 @@ export const onEditAssetConfirm = async (dispatch, asset) => {
   }
 };
 
+const allowEdit = (userId, userPermissions, asset) => {
+  // Only Data Managers and asset owners can edit an asset.
+  if (userPermissions.value && userPermissions.value.includes(SYSTEM_DATA_MANAGER)) {
+    return true;
+  }
+
+  return asset.owners && asset.owners.filter(o => o.userId === userId).length > 0;
+};
+
 function AssetAccordion({ asset }) {
   const dispatch = useDispatch();
   const classes = useStyles();
   const history = useHistory();
   const [anchorEl, setAnchorEl] = useState(null);
+  const userPermissions = useCurrentUserPermissions();
+  const userId = useCurrentUserId();
 
   const handleMoreButtonClick = (event) => {
     event.stopPropagation();
@@ -105,18 +120,20 @@ function AssetAccordion({ asset }) {
     setAnchorEl(null);
   };
 
+  const editable = allowEdit(userId, userPermissions, asset);
+
   return (
     <div className={classes.root}>
       <ResourceAccordion defaultExpanded>
         <ResourceAccordionSummary expandIcon={<ExpandMoreIcon />}>
           <Typography variant="h5" className={classes.heading}>{asset.name}: {asset.version}</Typography>
           <div className={classes.buttonDiv}>
-            <PrimaryActionButton
+            {editable && <PrimaryActionButton
               aria-label="edit"
               onClick={(event) => { openEditForm(dispatch, asset); event.stopPropagation(); }}
             >
               Edit
-            </PrimaryActionButton>
+            </PrimaryActionButton>}
             <SecondaryActionButton
               aria-controls="more-menu"
               aria-haspopup="true"

--- a/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.spec.js
+++ b/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.spec.js
@@ -2,12 +2,14 @@ import React from 'react';
 import * as ReactRedux from 'react-redux';
 import { render, fireEvent, screen, within } from '@testing-library/react';
 import AssetAccordion from './AssetAccordion';
+import { useCurrentUserPermissions, useCurrentUserId } from '../../hooks/authHooks';
 
 jest.mock('react-router');
 const dispatchMock = jest.fn().mockName('dispatch');
 jest.spyOn(ReactRedux, 'useDispatch').mockImplementation(() => dispatchMock);
 
 jest.mock('./AssetCard', () => props => (<>{`Asset: ${JSON.stringify(props.asset)}`}</>));
+jest.mock('../../hooks/authHooks');
 
 describe('AssetAccordion', () => {
   const asset = {
@@ -23,9 +25,19 @@ describe('AssetAccordion', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    useCurrentUserPermissions.mockReturnValue({ value: ['permission'] });
+    useCurrentUserId.mockReturnValue('owner-1');
   });
 
   it('renders to match snapshot passing correct props to children', () => {
+    const wrapper = render(<AssetAccordion asset={asset}/>);
+
+    expect(wrapper.container).toMatchSnapshot();
+  });
+
+  it('renders without an Edit button when user is not a data manager or asset owner', () => {
+    useCurrentUserId.mockReturnValueOnce('another-owner');
     const wrapper = render(<AssetAccordion asset={asset}/>);
 
     expect(wrapper.container).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.spec.js
+++ b/code/workspaces/web-app/src/components/assetRepo/AssetAccordion.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as ReactRedux from 'react-redux';
 import { render, fireEvent, screen, within } from '@testing-library/react';
+import { permissionTypes } from 'common';
 import AssetAccordion from './AssetAccordion';
 import { useCurrentUserPermissions, useCurrentUserId } from '../../hooks/authHooks';
 
@@ -26,7 +27,7 @@ describe('AssetAccordion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useCurrentUserPermissions.mockReturnValue({ value: ['permission'] });
+    useCurrentUserPermissions.mockReturnValue({ value: [permissionTypes.SYSTEM_DATA_MANAGER] });
     useCurrentUserId.mockReturnValue('owner-1');
   });
 
@@ -36,8 +37,8 @@ describe('AssetAccordion', () => {
     expect(wrapper.container).toMatchSnapshot();
   });
 
-  it('renders without an Edit button when user is not a data manager or asset owner', () => {
-    useCurrentUserId.mockReturnValueOnce('another-owner');
+  it('renders without an Edit button when user is not a data manager', () => {
+    useCurrentUserPermissions.mockReturnValueOnce({ value: [] });
     const wrapper = render(<AssetAccordion asset={asset}/>);
 
     expect(wrapper.container).toMatchSnapshot();

--- a/code/workspaces/web-app/src/components/assetRepo/__snapshots__/AssetAccordion.spec.js.snap
+++ b/code/workspaces/web-app/src/components/assetRepo/__snapshots__/AssetAccordion.spec.js.snap
@@ -135,7 +135,7 @@ exports[`AssetAccordion renders to match snapshot passing correct props to child
 </div>
 `;
 
-exports[`AssetAccordion renders without an Edit button when user is not a data manager or asset owner 1`] = `
+exports[`AssetAccordion renders without an Edit button when user is not a data manager 1`] = `
 <div>
   <div
     class="makeStyles-root-178"

--- a/code/workspaces/web-app/src/components/assetRepo/__snapshots__/AssetAccordion.spec.js.snap
+++ b/code/workspaces/web-app/src/components/assetRepo/__snapshots__/AssetAccordion.spec.js.snap
@@ -134,3 +134,109 @@ exports[`AssetAccordion renders to match snapshot passing correct props to child
   </div>
 </div>
 `;
+
+exports[`AssetAccordion renders without an Edit button when user is not a data manager or asset owner 1`] = `
+<div>
+  <div
+    class="makeStyles-root-178"
+  >
+    <div
+      class="MuiPaper-root MuiExpansionPanel-root WithStyles(ForwardRef(ExpansionPanel))-root-182 Mui-expanded WithStyles(ForwardRef(ExpansionPanel))-expanded-183 MuiExpansionPanel-rounded MuiPaper-elevation1 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="MuiButtonBase-root MuiExpansionPanelSummary-root WithStyles(ForwardRef(ExpansionPanelSummary))-root-216 Mui-expanded WithStyles(ForwardRef(ExpansionPanelSummary))-expanded-218"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiExpansionPanelSummary-content WithStyles(ForwardRef(ExpansionPanelSummary))-content-219 Mui-expanded WithStyles(ForwardRef(ExpansionPanelSummary))-expanded-218"
+        >
+          <h5
+            class="MuiTypography-root makeStyles-heading-180 MuiTypography-h5"
+          >
+            asset name
+            : 
+            asset version
+          </h5>
+          <div
+            class="makeStyles-buttonDiv-181"
+          >
+            <button
+              aria-controls="more-menu"
+              aria-haspopup="true"
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary MuiButton-fullWidth"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-label"
+              >
+                <span
+                  aria-hidden="true"
+                  class="material-icons MuiIcon-root"
+                >
+                  more_vert
+                </span>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          aria-disabled="false"
+          aria-hidden="true"
+          class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon WithStyles(ForwardRef(ExpansionPanelSummary))-expandIcon-217 Mui-expanded WithStyles(ForwardRef(ExpansionPanelSummary))-expanded-218 MuiIconButton-edgeEnd"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-entered"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiExpansionPanelDetails-root WithStyles(ForwardRef(ExpansionPanelDetails))-root-324"
+              >
+                <div
+                  class="makeStyles-resources-179"
+                >
+                  Asset: {"name":"asset name","version":"asset version","assetId":"asset-1","fileLocation":"file location","masterUrl":"master URL","owners":[{"userId":"owner-1","name":"name 1"},{"userId":"owner-2","name":"name 2"}],"visibility":"BY_PROJECT","projects":[{"projectKey":"project-1","name":"project 1"},{"projectKey":"project-2","name":"project 2"}]}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/code/workspaces/web-app/src/containers/app/AssetRepoNavigationContainer.js
+++ b/code/workspaces/web-app/src/containers/app/AssetRepoNavigationContainer.js
@@ -26,9 +26,9 @@ function AssetRepoNavigationContainer() {
           exact
           path="/assets/find"
           component={AssetRepoFindPage}
-          permission={SYSTEM_DATA_MANAGER}
+          permission={''}
         />
-        <Redirect exact from="/assets" to="/assets/add-metadata" />
+        <Redirect exact from="/assets" to="/assets/find" />
         <Route component={NotFoundPage} />
       </Switch>
     </SideBarNavigation>

--- a/code/workspaces/web-app/src/containers/app/__snapshots__/AssetRepoNavigationContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/app/__snapshots__/AssetRepoNavigationContainer.spec.js.snap
@@ -15,12 +15,12 @@ exports[`AssetRepoNavigationContainer renders to match snapshot passing correct 
       component={[Function]}
       exact={true}
       path="/assets/find"
-      permission="system:data:manager"
+      permission=""
     />
     <Redirect
       exact={true}
       from="/assets"
-      to="/assets/add-metadata"
+      to="/assets/find"
     />
     <Route
       component={[Function]}

--- a/code/workspaces/web-app/src/containers/assetRepo/AssetRepoFindContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AssetRepoFindContainer.js
@@ -39,7 +39,7 @@ function AssetRepoFindContainer({ userPermissions }) {
     : sortByName(assetRepo.value.assets);
 
   useEffect(() => {
-    dispatch(assetRepoActions.loadAllAssets());
+    dispatch(assetRepoActions.loadAssetsForUser());
     dispatch(projectsActions.loadProjects()); // needed for Asset Edit
     dispatch(userActions.listUsers()); // needed for Asset Edit
   }, [dispatch]);

--- a/code/workspaces/web-app/src/reducers/assetRepoReducer.js
+++ b/code/workspaces/web-app/src/reducers/assetRepoReducer.js
@@ -10,6 +10,7 @@ import {
   LOAD_VISIBLE_ASSETS_ACTION,
   LOAD_ALL_ASSETS_ACTION,
   LOAD_ONLY_VISIBLE_ASSETS_ACTION,
+  LOAD_ASSETS_FOR_USER_ACTION,
 } from '../actions/assetRepoActions';
 
 const initialState = {
@@ -51,6 +52,11 @@ export default typeToReducer({
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: action.payload } }),
   },
   [LOAD_ONLY_VISIBLE_ASSETS_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, value: state.value, fetching: true }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: action.payload } }),
+  },
+  [LOAD_ASSETS_FOR_USER_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, value: state.value, fetching: true }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, value: state.value, error: action.payload }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: { ...state.value, assets: action.payload } }),

--- a/code/workspaces/web-app/src/reducers/assetRepoReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/assetRepoReducer.spec.js
@@ -5,6 +5,7 @@ import {
   LOAD_VISIBLE_ASSETS_ACTION,
   LOAD_ALL_ASSETS_ACTION,
   LOAD_ONLY_VISIBLE_ASSETS_ACTION,
+  LOAD_ASSETS_FOR_USER_ACTION,
 } from '../actions/assetRepoActions';
 import assetRepoReducer, { addNewAssets } from './assetRepoReducer';
 
@@ -185,6 +186,56 @@ describe('assetRepoReducer', () => {
     it('should handle LOAD_ONLY_VISIBLE_ASSETS_ACTION_FAILURE', () => {
       // Arrange
       const type = `${LOAD_ONLY_VISIBLE_ASSETS_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextState = assetRepoReducer(baseState(), action);
+
+      // Assert
+      expect(nextState).toEqual({ ...baseState(), error: payload });
+    });
+  });
+
+  describe('LOAD_ASSETS_FOR_USER_ACTION', () => {
+    const baseState = () => ({
+      fetching: false,
+      value: {
+        createdAssetId: null,
+        assets: [],
+      },
+      error: null,
+    });
+
+    it('should handle LOAD_ASSETS_FOR_USER_ACTION_PENDING', () => {
+      // Arrange
+      const type = `${LOAD_ASSETS_FOR_USER_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextState = assetRepoReducer(baseState(), action);
+
+      // Assert
+      expect(nextState).toEqual({ ...baseState(), fetching: true });
+    });
+
+    it('should handle LOAD_ASSETS_FOR_USER_ACTION_ACTION_SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_ASSETS_FOR_USER_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ assetId: 'asset-1234' }];
+      const action = { type, payload };
+      const state = baseState();
+
+      // Act
+      const nextState = assetRepoReducer(state, action);
+
+      // Assert
+      expect(nextState).toEqual({ ...state, value: { ...state.value, assets: action.payload } });
+    });
+
+    it('should handle LOAD_ASSETS_FOR_USER_ACTION_FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_ASSETS_FOR_USER_ACTION}_${PROMISE_TYPE_FAILURE}`;
       const payload = 'example error';
       const action = { type, payload };
 


### PR DESCRIPTION
* Updated Find Asset page to be accessible by anyone, but users can only see assets that are either public or available to a project they have user/admin permissions for.
* Added Asset Repo to Top Bar for everyone (915) (and changed default page in that tab to "Find Asset" instead of "Add Metadata".
* Currently, Edit asset button is only available for data managers, though this can be extended for 1008 to allow for data owners to edit their own assets.