### PR TITLE
NERCDL-1008: Get projects for user

### DIFF
--- a/code/workspaces/client-api/src/dataaccess/projectService.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.js
@@ -10,6 +10,11 @@ async function listProjects(token) {
   return response.data;
 }
 
+async function listProjectsForUser(token) {
+  const response = await axios.get(`${infraServiceUrl}/projects/forUser`, generateOptions(token));
+  return response.data;
+}
+
 async function getAllProjectsAndResources(token) {
   const response = await axios.get(`${infraServiceUrl}/resources`, generateOptions(token));
   return response.data;
@@ -103,6 +108,7 @@ export function projectActionRequestToProject(actionRequest) {
 
 export default {
   listProjects,
+  listProjectsForUser,
   getAllProjectsAndResources,
   getProjectByKey,
   isProjectKeyUnique,

--- a/code/workspaces/client-api/src/dataaccess/projectService.spec.js
+++ b/code/workspaces/client-api/src/dataaccess/projectService.spec.js
@@ -43,6 +43,14 @@ describe('projectService', () => {
     expect(result).toEqual(testProjects);
   });
 
+  it('listProjectsForUser makes an api call and returns response data', async () => {
+    httpMock.onGet(`${infraServiceUrl}/projects/forUser`)
+      .reply(200, testProjects);
+
+    const result = await projectService.listProjectsForUser(token);
+    expect(result).toEqual(testProjects);
+  });
+
   it('getAllProjectsAndResources makes an api call and returns response data', async () => {
     httpMock.onGet(`${infraServiceUrl}/resources`)
       .reply(200, testProjects);

--- a/code/workspaces/client-api/src/schema/resolvers.js
+++ b/code/workspaces/client-api/src/schema/resolvers.js
@@ -34,6 +34,7 @@ const resolvers = {
     checkNameUniqueness: (obj, args, { token }) => w(internalNameChecker(args.projectKey, args.name, token)),
     users: (obj, args, { token }) => w(usersService.getAll({ token })),
     projects: (obj, args, { token }) => w(projectService.listProjects(token)),
+    projectsForUser: (obj, args, { token }) => w(projectService.listProjectsForUser(token)),
     allProjectsAndResources: (obj, args, { token }) => w(projectService.getAllProjectsAndResources(token)),
     project: (obj, args, { token }) => w(projectService.getProjectByKey(args.projectKey, token)),
     checkProjectKeyUniqueness: (obj, { projectKey }, { token }) => w(projectService.isProjectKeyUnique(projectKey, token)),

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -33,8 +33,11 @@ type Query {
     # List of users within the current DataLab
     users: [User]
 
-    # List of projects where the user is a member
+    # List of projects
     projects: [Project]
+
+    # List of projects where the user is a member
+    projectsForUser: [Project]
 
     # Details of a single project
     project(projectKey: String!): Project

--- a/code/workspaces/infrastructure-api/src/controllers/__snapshots__/projectsController.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/controllers/__snapshots__/projectsController.spec.js.snap
@@ -30,4 +30,6 @@ exports[`getProjectByKey calls next with an error if error thrown while retrievi
 
 exports[`listProjects calls next with error if error thrown getting data from database and does not call send 1`] = `[Error: Error listing projects: expected error message text]`;
 
+exports[`listProjectsForUser calls next with error if error thrown getting data from database and does not call send 1`] = `[Error: Error listing projects: expected error message text]`;
+
 exports[`projectKeyIsUnique calls next with an error if error thrown while checking existence and does not call send 1`] = `[Error: Error checking project key uniqueness: expected error message text]`;

--- a/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.js
@@ -7,6 +7,14 @@ async function getAll() {
   return Project().find().exec();
 }
 
+async function getProjectsWithIds(projectIds) {
+  return Project()
+    .find()
+    .where('key')
+    .in(projectIds)
+    .exec();
+}
+
 async function getByKey(projectKey) {
   return Project().findOne({ key: projectKey }).exec();
 }
@@ -38,6 +46,7 @@ async function deleteByKey(projectKey) {
 
 export default {
   getAll,
+  getProjectsWithIds,
   getByKey,
   exists,
   create,

--- a/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/projectsRepository.spec.js
@@ -15,7 +15,7 @@ const testProject = {
 };
 
 const ProjectMock = {};
-const methods = ['find', 'findOne', 'findOneAndUpdate', 'exec', 'exists', 'create', 'deleteOne'];
+const methods = ['find', 'findOne', 'findOneAndUpdate', 'exec', 'exists', 'create', 'deleteOne', 'where', 'in'];
 methods.forEach((name) => {
   ProjectMock[name] = jest.fn();
   // relies on fact ProjectMock returned by reference and not copied. Allows function chaining.
@@ -32,6 +32,14 @@ describe('projectsRepository', () => {
   it('getAll calls correct methods with correct arguments', async () => {
     await projectsRepository.getAll();
     expectToHaveBeenCalledOnceWith(ProjectMock.find);
+    expectToHaveBeenCalledOnceWith(ProjectMock.exec);
+  });
+
+  it('getProjectsWithIds calls correct methods with correct arguments', async () => {
+    await projectsRepository.getProjectsWithIds(['id1']);
+    expectToHaveBeenCalledOnceWith(ProjectMock.find);
+    expectToHaveBeenCalledOnceWith(ProjectMock.where, 'key');
+    expectToHaveBeenCalledOnceWith(ProjectMock.in, ['id1']);
     expectToHaveBeenCalledOnceWith(ProjectMock.exec);
   });
 

--- a/code/workspaces/infrastructure-api/src/routers/projectsRouter.js
+++ b/code/workspaces/infrastructure-api/src/routers/projectsRouter.js
@@ -14,6 +14,10 @@ projectsRouter.get(
   '/',
   ew(projects.listProjects),
 );
+projectsRouter.get(
+  '/forUser',
+  ew(projects.listProjectsForUser),
+);
 projectsRouter.post(
   '/',
   permissionMiddleware(),

--- a/code/workspaces/web-app/src/actions/projectActions.js
+++ b/code/workspaces/web-app/src/actions/projectActions.js
@@ -1,6 +1,7 @@
 import projectsService from '../api/projectsService';
 
 export const LOAD_PROJECTS_ACTION = 'LOAD_PROJECTS';
+export const LOAD_PROJECTS_FOR_USER_ACTION = 'LOAD_PROJECTS_FOR_USER_ACTION';
 export const GET_ALL_PROJECTS_AND_RESOURCES_ACTION = 'GET_ALL_PROJECTS_AND_RESOURCES_ACTION';
 export const SET_CURRENT_PROJECT_ACTION = 'SET_CURRENT_PROJECT_ACTION';
 export const CLEAR_CURRENT_PROJECT_ACTION = 'CLEAR_CURRENT_PROJECT_ACTION';
@@ -13,6 +14,11 @@ export const CHECK_PROJECT_KEY_UNIQUE_ACTION = 'CHECK_PROJECT_KEY_UNIQUE_ACTION'
 const loadProjects = () => ({
   type: LOAD_PROJECTS_ACTION,
   payload: projectsService.loadProjects(),
+});
+
+const loadProjectsForUser = () => ({
+  type: LOAD_PROJECTS_FOR_USER_ACTION,
+  payload: projectsService.loadProjectsForUser(),
 });
 
 const getAllProjectsAndResources = () => ({
@@ -55,7 +61,16 @@ const updateProject = project => ({
 });
 
 const projectActions = {
-  loadProjects, getAllProjectsAndResources, setCurrentProject, clearCurrentProject, createProject, requestProject, deleteProject, checkProjectKeyUniqueness, updateProject,
+  loadProjects,
+  loadProjectsForUser,
+  getAllProjectsAndResources,
+  setCurrentProject,
+  clearCurrentProject,
+  createProject,
+  requestProject,
+  deleteProject,
+  checkProjectKeyUniqueness,
+  updateProject,
 };
 
 export default projectActions;

--- a/code/workspaces/web-app/src/actions/projectActions.spec.js
+++ b/code/workspaces/web-app/src/actions/projectActions.spec.js
@@ -1,5 +1,6 @@
 import projectActions, {
   LOAD_PROJECTS_ACTION,
+  LOAD_PROJECTS_FOR_USER_ACTION,
   GET_ALL_PROJECTS_AND_RESOURCES_ACTION,
   SET_CURRENT_PROJECT_ACTION,
   CLEAR_CURRENT_PROJECT_ACTION,
@@ -28,6 +29,20 @@ describe('projectActions', () => {
       expect(loadProjectsMock).toHaveBeenCalledTimes(1);
       expect(output.type).toBe(LOAD_PROJECTS_ACTION);
       expect(output.payload).toBe('expectedProjectsPayload');
+    });
+
+    it('loadProjectsForUser', () => {
+      // Arrange
+      const loadProjectsForUserMock = jest.fn().mockReturnValue('expectedProjectsForUserPayload');
+      projectsService.loadProjectsForUser = loadProjectsForUserMock;
+
+      // Act
+      const output = projectActions.loadProjectsForUser();
+
+      // Assert
+      expect(loadProjectsForUserMock).toHaveBeenCalledTimes(1);
+      expect(output.type).toBe(LOAD_PROJECTS_FOR_USER_ACTION);
+      expect(output.payload).toBe('expectedProjectsForUserPayload');
     });
 
     it('getAllProjectsAndResources', () => {

--- a/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectsService.spec.js.snap
@@ -58,3 +58,12 @@ exports[`projectsService loadProjects should build the correct query and unpack 
       }
     }"
 `;
+
+exports[`projectsService loadProjectsForUser should build the correct query and unpack the results 1`] = `
+"
+    LoadProjectsForUser {
+      projectsForUser {
+        id, key, name, description, accessible
+      }
+    }"
+`;

--- a/code/workspaces/web-app/src/api/projectsService.js
+++ b/code/workspaces/web-app/src/api/projectsService.js
@@ -13,6 +13,18 @@ function loadProjects() {
     .then(errorHandler('data.projects'));
 }
 
+function loadProjectsForUser() {
+  const query = `
+    LoadProjectsForUser {
+      projectsForUser {
+        id, key, name, description, accessible
+      }
+    }`;
+
+  return gqlQuery(query)
+    .then(errorHandler('data.projectsForUser'));
+}
+
 async function getAllProjectsAndResources() {
   const query = `
     GetAllProjectsAndResources {
@@ -101,6 +113,7 @@ function checkProjectKeyUniqueness(projectKey) {
 
 const projectsService = {
   loadProjects,
+  loadProjectsForUser,
   getAllProjectsAndResources,
   loadProjectInfo,
   createProject,

--- a/code/workspaces/web-app/src/api/projectsService.spec.js
+++ b/code/workspaces/web-app/src/api/projectsService.spec.js
@@ -25,6 +25,25 @@ describe('projectsService', () => {
     });
   });
 
+  describe('loadProjectsForUser', () => {
+    it('should build the correct query and unpack the results', () => {
+      mockClient.prepareSuccess({ projectsForUser: 'expectedValue' });
+
+      return projectsService.loadProjectsForUser().then((response) => {
+        expect(response).toEqual('expectedValue');
+        expect(mockClient.lastQuery()).toMatchSnapshot();
+      });
+    });
+
+    it('should throw an error if the query fails', () => {
+      mockClient.prepareFailure('error');
+
+      return projectsService.loadProjectsForUser().catch((error) => {
+        expect(error).toEqual({ error: 'error' });
+      });
+    });
+  });
+
   describe('getAllProjectsAndResources', () => {
     it('should build the correct query and unpack the results', () => {
       mockClient.prepareSuccess({ allProjectsAndResources: 'expectedValue' });

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.js
@@ -138,14 +138,13 @@ export const AddAssetsToNotebookContainer = ({ userPermissions }) => {
 
   useEffect(() => {
     // On page load, get projects.
-    dispatch(projectActions.loadProjects());
+    dispatch(projectActions.loadProjectsForUser());
   }, [dispatch, projects.isFetching]);
 
   useEffect(() => {
     // On project selection, get possible notebooks and assets.
-    dispatch(stackActions.loadStacksByCategory(selectedProject, NOTEBOOK_CATEGORY));
-
     if (selectedProject) {
+      dispatch(stackActions.loadStacksByCategory(selectedProject, NOTEBOOK_CATEGORY));
       dispatch(assetRepoActions.loadOnlyVisibleAssets(selectedProject));
     } else {
       dispatch(assetRepoActions.loadAllAssets());

--- a/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.spec.js
+++ b/code/workspaces/web-app/src/containers/assetRepo/AddAssetsToNotebookContainer.spec.js
@@ -94,7 +94,7 @@ describe('AddAssetsToNotebookContainer', () => {
     const wrapper = renderWithLocation(location, AddAssetsToNotebookContainer, props);
 
     expect(wrapper.container).toMatchSnapshot();
-    expect(dispatchMock).toHaveBeenCalledTimes(5);
+    expect(dispatchMock).toHaveBeenCalledTimes(4);
     expect(assetRepoActions.loadAllAssets).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledWith('addAssetsToNotebook', { project: undefined, notebook: undefined });

--- a/code/workspaces/web-app/src/reducers/projectsReducer.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.js
@@ -4,7 +4,7 @@ import {
   PROMISE_TYPE_SUCCESS,
   PROMISE_TYPE_FAILURE,
 } from '../actions/actionTypes';
-import { LOAD_PROJECTS_ACTION, GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
+import { LOAD_PROJECTS_ACTION, LOAD_PROJECTS_FOR_USER_ACTION, GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
 
 const initialState = {
   fetching: false,
@@ -14,6 +14,11 @@ const initialState = {
 
 export default typeToReducer({
   [LOAD_PROJECTS_ACTION]: {
+    [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: state.value }),
+    [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: state.value }),
+    [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),
+  },
+  [LOAD_PROJECTS_FOR_USER_ACTION]: {
     [PROMISE_TYPE_PENDING]: state => ({ ...initialState, fetching: true, value: state.value }),
     [PROMISE_TYPE_FAILURE]: (state, action) => ({ ...initialState, error: action.payload, value: state.value }),
     [PROMISE_TYPE_SUCCESS]: (state, action) => ({ ...initialState, value: action.payload }),

--- a/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
+++ b/code/workspaces/web-app/src/reducers/projectsReducer.spec.js
@@ -1,6 +1,6 @@
 import projectsReducer from './projectsReducer';
 import { PROMISE_TYPE_PENDING, PROMISE_TYPE_SUCCESS, PROMISE_TYPE_FAILURE } from '../actions/actionTypes';
-import { LOAD_PROJECTS_ACTION, GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
+import { LOAD_PROJECTS_ACTION, LOAD_PROJECTS_FOR_USER_ACTION, GET_ALL_PROJECTS_AND_RESOURCES_ACTION } from '../actions/projectActions';
 
 describe('projectsReducer', () => {
   it('should return the initial state', () => {
@@ -49,6 +49,52 @@ describe('projectsReducer', () => {
 
       // Assert
       expect(nextstate).toEqual({ error: payload, fetching: false, value: [] });
+    });
+  });
+
+  describe('LOAD_PROJECTS_FOR_USER_ACTION', () => {
+    const baseState = () => ({
+      error: null,
+      fetching: false,
+      value: [],
+    });
+
+    it('should handle LOAD_PROJECTS_FOR_USER_ACTION_PENDING', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_FOR_USER_ACTION}_${PROMISE_TYPE_PENDING}`;
+      const action = { type };
+
+      // Act
+      const nextstate = projectsReducer(baseState(), action);
+
+      // Assert
+      expect(nextstate).toEqual({ ...baseState(), fetching: true });
+    });
+
+    it('should handle LOAD_PROJECTS_FOR_USER_ACTION_SUCCESS', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_FOR_USER_ACTION}_${PROMISE_TYPE_SUCCESS}`;
+      const payload = [{ project: 'firstProject' }, { project: 'secondProject' }];
+      const action = { type, payload };
+
+      // Act
+      const nextstate = projectsReducer(baseState(), action);
+
+      // Assert
+      expect(nextstate).toEqual({ ...baseState(), value: action.payload });
+    });
+
+    it('should handle LOAD_PROJECTS_FOR_USER_ACTION_FAILURE', () => {
+      // Arrange
+      const type = `${LOAD_PROJECTS_FOR_USER_ACTION}_${PROMISE_TYPE_FAILURE}`;
+      const payload = 'example error';
+      const action = { type, payload };
+
+      // Act
+      const nextstate = projectsReducer(baseState(), action);
+
+      // Assert
+      expect(nextstate).toEqual({ ...baseState(), error: payload });
     });
   });
 


### PR DESCRIPTION
Added a new route that allows for getting a list of projects that a user is at least a "viewer" of.
This is used in the AddAssetToNotebook form so users only have the option of selecting a project where they have some permissions.