### PR TITLE
NERCDL-515: Private stacks backend

### DIFF
--- a/code/workspaces/infrastructure-api/resources/default.job.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.job.template.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ name }}
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: {{ name }}
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sh"]
+        args: ["-c", "{{{ runCommand }}}"]
+        {{#volumeMount}}
+        volumeMounts:
+          - mountPath: {{{ mountPath }}}
+            name: persistentfsvol
+        {{/volumeMount}}
+      {{#kubectlCommand}}
+      - name: kubectl-job
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command: ["sh"]
+        args: ["-c", "{{{ kubectlCommand }}}"]
+      {{/kubectlCommand}}
+      volumes:
+        {{#volumeMount}}
+        - name: persistentfsvol
+          persistentVolumeClaim:
+            claimName: {{ volumeMount }}-claim
+        {{/volumeMount}}
+      restartPolicy: Never
+    

--- a/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
+++ b/code/workspaces/infrastructure-api/resources/jupyter.deployment.template.yml
@@ -65,7 +65,7 @@ spec:
             - name: R_LIBS_USER
               value: "/data/packages/R/%p/%v"
             - name: JUPYTER_DATA_DIR
-              value: "/data/.jupyter"
+              value: "/data/notebooks/{{ name }}/.jupyter"
             - name: CONDA_ENV_DIR
               value: "/data/conda/"
             - name: JUPYTER_ALLOW_INSECURE_WRITES

--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.js
@@ -28,6 +28,9 @@ const rStudioConfigMap = deploymentName => `${deploymentName}-proxy-headers-conf
 const sparkDriverHeadlessService = deploymentServiceName => `${deploymentServiceName}-spark-driver-headless-service`;
 const sparkJob = deploymentName => `${deploymentName}-spark-job`;
 
+// Jobs
+const jobName = name => `job-${name}`;
+
 export default {
   assetVolume,
   isAssetVolume,
@@ -50,4 +53,5 @@ export default {
   sparkDriverHeadlessService,
   sparkJob,
   stackCredentialSecret,
+  jobName,
 };

--- a/code/workspaces/infrastructure-api/src/controllers/stackController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.js
@@ -1,11 +1,13 @@
 import { body, check, matchedData } from 'express-validator';
 import { isBoolean, indexOf } from 'lodash';
-import { notebookList, stackList, siteList, versionList } from 'common/src/config/images';
+import { notebookList, stackList, siteList, versionList, NOTEBOOK_CATEGORY } from 'common/src/config/images';
+
 import controllerHelper from './controllerHelper';
 import stackRepository from '../dataaccess/stacksRepository';
 import stackManager from '../stacks/stackManager';
 import centralAssetRepoRepository from '../dataaccess/centralAssetRepoRepository';
 import { visibility, getEnumValues } from '../models/stackEnums';
+import { handleSharedChange } from '../stacks/shareStackManager';
 
 const TYPE = 'stack';
 const USER_UPDATEABLE_FIELDS = ['displayName', 'description', 'shared', 'assetIds'];
@@ -106,14 +108,27 @@ async function updateStackExec(request, response) {
   // Handle request
   await updateLinkedAssets(params, response);
 
-  const { type } = await stackRepository.getOneByName(projectKey, user, name);
+  const existing = await stackRepository.getOneByName(projectKey, user, name);
+  const { type, category } = existing;
 
   try {
+    if (params.shared) {
+      if (params.shared === visibility.PUBLIC && category === NOTEBOOK_CATEGORY) {
+        response.status(405);
+        return response.send({
+          error: 'Cannot set notebooks to Public',
+        });
+      }
+
+      // If the request changes the shared property, then handle the change accordingly.
+      await handleSharedChange(params, existing, params.shared);
+    }
+
     await stackManager.mountAssetsOnStack({ ...params, type });
     const updateResult = await stackRepository.update(projectKey, user, name, updatedDetails);
-    response.send(updateResult);
+    return response.send(updateResult);
   } catch (error) {
-    controllerHelper.handleError(response, 'updating', TYPE, name)(error);
+    return controllerHelper.handleError(response, 'updating', TYPE, name)(error);
   }
 }
 

--- a/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
@@ -6,6 +6,7 @@ import stackController from './stackController';
 import stackManager from '../stacks/stackManager';
 import * as stackRepository from '../dataaccess/stacksRepository';
 import centralAssetRepoRepository from '../dataaccess/centralAssetRepoRepository';
+import * as shareStackManager from '../stacks/shareStackManager';
 
 jest.mock('../stacks/stackManager');
 jest.mock('../dataaccess/stacksRepository');
@@ -224,8 +225,11 @@ describe('Stack Controller', () => {
       assetIds: ['test-update-asset-one', 'test-update-asset-two'],
     });
 
+    const shareStackMock = jest.spyOn(shareStackManager, 'handleSharedChange');
+
     beforeEach(async () => {
       updateMock.mockClear();
+      jest.clearAllMocks();
       await createValidatedRequest(
         getRequestBody(),
         stackController.updateStackValidator,
@@ -250,6 +254,31 @@ describe('Stack Controller', () => {
         .then(() => {
           expect(response.statusCode).toBe(500);
           expect(response._getData()).toEqual({ error: 'error', message: 'Error updating stack: abcd1234' }); // eslint-disable-line no-underscore-dangle
+        })
+        .catch(() => {
+          expect(true).toBeFalsy();
+        });
+    });
+
+    it('should return 405 for disallowed request', async () => {
+      const projectKey = 'projectKey';
+      const name = 'stackname';
+      const requestBody = {
+        name,
+        projectKey,
+        shared: 'public',
+      };
+
+      await createValidatedRequest(requestBody, stackController.updateStackValidator);
+
+      const response = httpMocks.createResponse();
+      getOneByNameMock.mockResolvedValueOnce({ type: 'expected-type', category: 'ANALYSIS' });
+
+      return stackController.updateStack(request, response)
+        .then(() => {
+          expect(response.statusCode).toBe(405);
+          expect(response._getData()).toEqual({ error: 'Cannot set notebooks to Public' }); // eslint-disable-line no-underscore-dangle
+          expect(shareStackMock).toHaveBeenCalledTimes(0);
         })
         .catch(() => {
           expect(true).toBeFalsy();
@@ -328,6 +357,7 @@ describe('Stack Controller', () => {
 
       expect(updateMock).toBeCalledTimes(1);
       expect(updateMock).toBeCalledWith(projectKey, request.user, name, userUpdateableDetails);
+      expect(shareStackMock).toHaveBeenCalledTimes(1);
     });
 
     it('should not pass undefined or null values to update but should pass other falsy values', async () => {
@@ -348,6 +378,7 @@ describe('Stack Controller', () => {
 
       expect(updateMock).toBeCalledTimes(1);
       expect(updateMock).toBeCalledWith(projectKey, request.user, name, { displayName: '' });
+      expect(shareStackMock).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.js
@@ -184,12 +184,18 @@ function updateAssets(_id, assetIds) {
 }
 
 function update(projectKey, user, name, updatedValues) {
+  // Make sure the visible field is kept in sync with the shared field.
+  const updatedWithVisible = updatedValues.shared ? {
+    ...updatedValues,
+    visible: updatedValues.shared,
+  } : updatedValues;
+
   // Filter exclusively by owner (User)
   return Stack()
     .find()
     .filterByUser(user)
     .filterByProject(projectKey)
-    .findOneAndUpdate({ name }, updatedValues, { new: true, omitUndefined: true })
+    .findOneAndUpdate({ name }, updatedWithVisible, { new: true, omitUndefined: true })
     .exec();
 }
 

--- a/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.spec.js
+++ b/code/workspaces/infrastructure-api/src/dataaccess/stacksRepository.spec.js
@@ -120,15 +120,29 @@ describe('stacksRepository', () => {
     expect(mockDatabase().entity()).toEqual({ assetIds: ['asset-id'] });
   });
 
-  it('update should query for stacks of the same name', async () => {
-    const name = 'stack';
-    const updatedValues = { displayName: 'Display Name' };
+  describe('update', () => {
+    it('should query for stacks of the same name', async () => {
+      const name = 'stack';
+      const updatedValues = { displayName: 'Display Name' };
 
-    await stacksRepository.update(project, user, name, updatedValues);
-    expect(mockDatabase().queries()).toContainEqual({ name });
-    expect(mockDatabase().project()).toBe('expectedProject');
-    expect(mockDatabase().user()).toBe('username');
-    expect(mockDatabase().entity()).toEqual(updatedValues);
+      await stacksRepository.update(project, user, name, updatedValues);
+      expect(mockDatabase().queries()).toContainEqual({ name });
+      expect(mockDatabase().project()).toBe('expectedProject');
+      expect(mockDatabase().user()).toBe('username');
+      expect(mockDatabase().entity()).toEqual(updatedValues);
+    });
+
+    it('should update visible status if shared is changed', async () => {
+      const name = 'stack';
+      const updatedValues = { displayName: 'Display Name', shared: 'private' };
+      const expectedUpdatedValues = { displayName: 'Display Name', shared: 'private', visible: 'private' };
+
+      await stacksRepository.update(project, user, name, updatedValues);
+      expect(mockDatabase().queries()).toContainEqual({ name });
+      expect(mockDatabase().project()).toBe('expectedProject');
+      expect(mockDatabase().user()).toBe('username');
+      expect(mockDatabase().entity()).toEqual(expectedUpdatedValues);
+    });
   });
 });
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/deploymentGenerator.spec.js.snap
@@ -700,7 +700,7 @@ spec:
             - name: R_LIBS_USER
               value: \\"/data/packages/R/%p/%v\\"
             - name: JUPYTER_DATA_DIR
-              value: \\"/data/.jupyter\\"
+              value: \\"/data/notebooks/deployment-name/.jupyter\\"
             - name: CONDA_ENV_DIR
               value: \\"/data/conda/\\"
             - name: JUPYTER_ALLOW_INSECURE_WRITES

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createKubectlJob creates a job to match the snapshot 1`] = `
+"---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-job
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: job-job
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"echo \\"Hello, World!\\"\\"]
+      volumes:
+      restartPolicy: Never
+    
+"
+`;
+
+exports[`createKubectlJob creates a job to match the snapshot when a kubectl command is supplied 1`] = `
+"---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-job
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: job-job
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"echo \\"Hello, World!\\"\\"]
+      - name: kubectl-job
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"kubectl get pods\\"]
+      volumes:
+      restartPolicy: Never
+    
+"
+`;
+
+exports[`createKubectlJob creates a job to match the snapshot when a volume and path is supplied 1`] = `
+"---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-job
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: job-job
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"echo \\"Hello, World!\\"\\"]
+        volumeMounts:
+          - mountPath: /mnt/data
+            name: persistentfsvol
+      volumes:
+        - name: persistentfsvol
+          persistentVolumeClaim:
+            claimName: volume-claim
+      restartPolicy: Never
+    
+"
+`;

--- a/code/workspaces/infrastructure-api/src/kubernetes/core.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/core.js
@@ -21,6 +21,16 @@ export const handleDeleteError = (type, name) => (error) => {
   throw createError(error.message);
 };
 
+export const handlePatchError = (type, name) => (error) => {
+  if (has(error, 'response.status') && get(error, 'response.status') === 404) {
+    logger.warn(`Kubernetes API: Could not find ${type}: ${name} to patch it`);
+    return Promise.resolve();
+  }
+
+  logger.error(`Error patching ${type}: ${name}`);
+  throw createError(error.message);
+};
+
 function createError(message) {
   return new Error(`Kubernetes API: ${message}`);
 }

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobApi.js
@@ -12,7 +12,7 @@ const getJobUrl = (namespace, name) => {
 
 const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
 
-export const createJob = async (name, namespace, manifest) => {
+const createJob = async (name, namespace, manifest) => {
   logger.info('Creating job: %s in namespace: %s', name, namespace);
 
   try {

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobApi.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobApi.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import logger from '../config/logger';
+import config from '../config/config';
+import { handleCreateError } from './core';
+
+const API_BASE = config.get('kubernetesApi');
+
+const getJobUrl = (namespace, name) => {
+  const nameComponent = name ? `/${name}` : '';
+  return `${API_BASE}/apis/batch/v1/namespaces/${namespace}/jobs${nameComponent}`;
+};
+
+const YAML_CONTENT_HEADER = { headers: { 'Content-Type': 'application/yaml' } };
+
+export const createJob = async (name, namespace, manifest) => {
+  logger.info('Creating job: %s in namespace: %s', name, namespace);
+
+  try {
+    return await axios.post(getJobUrl(namespace), manifest, YAML_CONTENT_HEADER);
+  } catch (e) {
+    return handleCreateError('job', name)(e);
+  }
+};
+
+export default {
+  createJob,
+};

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobApi.spec.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { createJob } from './jobApi';
+
+import config from '../config/config';
+
+const mock = new MockAdapter(axios);
+
+const API_BASE = config.get('kubernetesApi');
+const NAMESPACE = 'namespace';
+
+const JOB_URL = `${API_BASE}/apis/batch/v1/namespaces/${NAMESPACE}/jobs`;
+const JOB_NAME = 'test-job';
+
+const getJobManifest = () => `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-job
+`;
+
+const getJob = () => ({
+  apiVersion: 'batch/v1',
+  kind: 'Job',
+  metadata: { name: JOB_NAME },
+});
+
+describe('Kubernetes Job API', () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+  afterAll(() => {
+    mock.restore();
+  });
+
+  describe('createJob', () => {
+    it('sends a POST request to create a job', async () => {
+      mock.onPost(JOB_URL, getJobManifest()).reply((requestConfig) => {
+        expect(requestConfig.headers['Content-Type']).toBe('application/yaml');
+        return [200, getJob()];
+      });
+
+      const response = await createJob(JOB_NAME, NAMESPACE, getJobManifest());
+      expect(response.data).toEqual(getJob());
+    });
+
+    it('return an error if the job creation fails', async () => {
+      mock.onPost(JOB_URL).reply(400, { message: 'error-message' });
+
+      await expect(createJob(JOB_NAME, NAMESPACE, getJobManifest())).rejects.toThrowError(
+        'Kubernetes API: Unable to create kubernetes job \'test-job\' - error-message',
+      );
+    });
+  });
+});

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobApi.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobApi.spec.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { createJob } from './jobApi';
-
+import jobApi from './jobApi';
 import config from '../config/config';
+
+const { createJob } = jobApi;
 
 const mock = new MockAdapter(axios);
 

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.js
@@ -1,0 +1,22 @@
+import { JobTemplates, generateManifest } from './manifestGenerator';
+import nameGenerators from '../common/nameGenerators';
+
+const { jobName } = nameGenerators;
+
+export const createKubectlJob = ({ name, runCommand, kubectlCommand, volumeMount, mountPath }) => {
+  const job = jobName(name);
+
+  const context = {
+    name: job,
+    runCommand,
+    kubectlCommand,
+    volumeMount,
+    mountPath,
+  };
+
+  return generateManifest(context, JobTemplates.DEFAULT_JOB);
+};
+
+export default {
+  createKubectlJob,
+};

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
@@ -1,0 +1,35 @@
+import { createKubectlJob } from './jobGenerator';
+
+const getInputs = () => ({
+  name: 'job',
+  runCommand: 'echo "Hello, World!"',
+});
+
+describe('createKubectlJob', () => {
+  it('creates a job to match the snapshot', async () => {
+    const manifest = await createKubectlJob(getInputs());
+
+    expect(manifest).toMatchSnapshot();
+  });
+
+  it('creates a job to match the snapshot when a kubectl command is supplied', async () => {
+    const inputs = {
+      ...getInputs(),
+      kubectlCommand: 'kubectl get pods',
+    };
+    const manifest = await createKubectlJob(inputs);
+
+    expect(manifest).toMatchSnapshot();
+  });
+
+  it('creates a job to match the snapshot when a volume and path is supplied', async () => {
+    const inputs = {
+      ...getInputs(),
+      volumeMount: 'volume',
+      mountPath: '/mnt/data',
+    };
+    const manifest = await createKubectlJob(inputs);
+
+    expect(manifest).toMatchSnapshot();
+  });
+});

--- a/code/workspaces/infrastructure-api/src/kubernetes/manifestGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/manifestGenerator.js
@@ -36,6 +36,10 @@ const IngressTemplates = Object.freeze({
   DEFAULT_INGRESS: 'default.ingress.template.yml',
 });
 
+const JobTemplates = Object.freeze({
+  DEFAULT_JOB: 'default.job.template.yml',
+});
+
 const VolumeTemplates = Object.freeze({
   DEFAULT_VOLUME: 'default.pvc.template.yml',
 });
@@ -67,4 +71,4 @@ function generateManifest(context, template) {
     .then(templateContent => render(templateContent, context));
 }
 
-export { ServiceTemplates, DeploymentTemplates, IngressTemplates, VolumeTemplates, ConfigTemplates, ConfigMapTemplates, NetworkPolicyTemplates, AutoScalerTemplates, generateManifest };
+export { ServiceTemplates, DeploymentTemplates, IngressTemplates, JobTemplates, VolumeTemplates, ConfigTemplates, ConfigMapTemplates, NetworkPolicyTemplates, AutoScalerTemplates, generateManifest };

--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handleSharedChange handles Jupyter notebooks changing to private 1`] = `
+"---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-stackname
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: job-stackname
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"rm -f /mnt/persistentfs/notebooks/jupyterlab-stackname/.jupyter/runtime/jupyter_cookie_secret\\"]
+        volumeMounts:
+          - mountPath: /mnt/persistentfs
+            name: persistentfsvol
+      - name: kubectl-job
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command: [\\"sh\\"]
+        args: [\\"-c\\", \\"kubectl rollout restart deployment/jupyterlab-stackname\\"]
+      volumes:
+        - name: persistentfsvol
+          persistentVolumeClaim:
+            claimName: volume-claim
+      restartPolicy: Never
+    
+"
+`;

--- a/code/workspaces/infrastructure-api/src/stacks/shareStackManager.js
+++ b/code/workspaces/infrastructure-api/src/stacks/shareStackManager.js
@@ -1,0 +1,98 @@
+import { stackTypes } from 'common';
+import { NOTEBOOK_CATEGORY, SITE_CATEGORY } from 'common/src/config/images';
+import config from '../config/config';
+import secretManager from '../credentials/secretManager';
+import { createKubectlJob } from '../kubernetes/jobGenerator';
+import jobApi from '../kubernetes/jobApi';
+import ingressApi from '../kubernetes/ingressApi';
+import deploymentApi from '../kubernetes/deploymentApi';
+import nameGenerators from '../common/nameGenerators';
+import { visibility } from '../models/stackEnums';
+import zeppelin from './zeppelinStack';
+
+const { deploymentName } = nameGenerators;
+const { JUPYTER, JUPYTERLAB, ZEPPELIN } = stackTypes;
+
+const mountPath = '/mnt/persistentfs';
+
+const getJupyterCookiePath = deployment => `${mountPath}/notebooks/${deployment}/.jupyter/runtime/jupyter_cookie_secret`;
+
+const getIngressPatch = authValue => ({
+  metadata: {
+    annotations: {
+      'nginx.ingress.kubernetes.io/auth-url': authValue,
+    },
+  },
+});
+
+export const makeJupyterPrivate = async (name, type, projectKey, volumeMount) => {
+  // Changing a Jupyter notebook to private requires a token refresh, and to remove a file from the notebook's storage.
+  const credentials = secretManager.createNewJupyterCredentials();
+  await secretManager.createStackCredentialSecret(name, type, projectKey, credentials);
+
+  const deployment = deploymentName(name, type);
+
+  // Trigger a job to remove a cookie file from the volume and restart the notebook pod
+  const runCommand = `rm -f ${getJupyterCookiePath(deployment)}`;
+  const kubectlCommand = `kubectl rollout restart deployment/${deployment}`;
+
+  const manifest = await createKubectlJob({ name, runCommand, kubectlCommand, volumeMount, mountPath });
+  await jobApi.createJob(name, projectKey, manifest);
+};
+
+export const makeZeppelinPrivate = async (name, type, projectKey) => {
+  const credentials = secretManager.createNewUserCredentials();
+
+  const shiroIni = await zeppelin.generateNewShiroIni(credentials);
+  await secretManager.createStackCredentialSecret(name, type, projectKey, { ...shiroIni, ...credentials });
+
+  const deployment = deploymentName(name, type);
+  await deploymentApi.restartDeployment(deployment, projectKey);
+};
+
+export const handleSharedChange = async (params, existing, newSharedStatus) => {
+  const { category, shared, type, volumeMount, visible } = existing;
+
+  const oldSharedStatus = shared || visible;
+
+  if (oldSharedStatus === visibility.PRIVATE || oldSharedStatus === newSharedStatus) {
+    // Going from private to another status (or staying at the same status) requires no extra changes.
+    return;
+  }
+
+  const { projectKey, name } = params;
+
+  if (category === SITE_CATEGORY) {
+    const ingressName = deploymentName(name, type);
+    if (newSharedStatus === visibility.PUBLIC) {
+      // When making a site public, remove an ingress annotation
+      await ingressApi.patchIngress(ingressName, projectKey, getIngressPatch(null));
+    }
+
+    if (oldSharedStatus === visibility.PUBLIC) {
+      // When making a site non-public, add an ingress annotation
+      const authServiceUrlRoot = config.get('authorisationServiceForIngress') || config.get('authorisationService');
+      await ingressApi.patchIngress(ingressName, projectKey, getIngressPatch(`${authServiceUrlRoot}/auth`));
+    }
+
+    // No backend changes needed for other status changes
+    return;
+  }
+
+  if (category === NOTEBOOK_CATEGORY && newSharedStatus === visibility.PRIVATE) {
+    if (type === JUPYTER || type === JUPYTERLAB) {
+      await makeJupyterPrivate(name, type, projectKey, volumeMount);
+    }
+
+    if (type === ZEPPELIN) {
+      await makeZeppelinPrivate(name, type, projectKey);
+    }
+
+    // Nothing to do for RStudio, we just have to let the token expire.
+  }
+};
+
+export default {
+  handleSharedChange,
+};
+

--- a/code/workspaces/infrastructure-api/src/stacks/shareStackManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/shareStackManager.spec.js
@@ -1,0 +1,198 @@
+import { stackTypes } from 'common';
+import { NOTEBOOK_CATEGORY, SITE_CATEGORY } from 'common/src/config/images';
+import { handleSharedChange } from './shareStackManager';
+import config from '../config/config';
+import secretManager from '../credentials/secretManager';
+import jobApi from '../kubernetes/jobApi';
+import ingressApi from '../kubernetes/ingressApi';
+import deploymentApi from '../kubernetes/deploymentApi';
+import zeppelin from './zeppelinStack';
+
+const projectKey = 'project';
+const name = 'stackname';
+
+const volumeMount = 'volume';
+
+const { JUPYTERLAB, ZEPPELIN, RSTUDIO, RSHINY } = stackTypes;
+
+const getParams = () => ({
+  projectKey,
+  name,
+});
+const getExisting = () => ({
+  shared: 'project',
+  visible: 'project',
+  volumeMount,
+});
+
+// Function to help 'expect' numbers of calls for certain functions (so we don't need to replicate this several times).
+const expectCalls = ({
+  createJob = 0,
+  patchIngress = 0,
+  createStackCredentialSecret = 0,
+  restartDeployment = 0,
+  generateNewShiroIni = 0,
+}) => {
+  expect(jobApi.createJob).toHaveBeenCalledTimes(createJob);
+  expect(ingressApi.patchIngress).toHaveBeenCalledTimes(patchIngress);
+  expect(secretManager.createStackCredentialSecret).toHaveBeenCalledTimes(createStackCredentialSecret);
+  expect(deploymentApi.restartDeployment).toHaveBeenCalledTimes(restartDeployment);
+  expect(zeppelin.generateNewShiroIni).toHaveBeenCalledTimes(generateNewShiroIni);
+};
+
+describe('handleSharedChange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mock('../credentials/secretManager');
+    jest.mock('../kubernetes/jobApi');
+    jest.mock('../kubernetes/ingressApi');
+    jest.mock('../kubernetes/deploymentApi');
+    jest.mock('./zeppelinStack');
+
+    secretManager.createStackCredentialSecret = jest.fn();
+    jobApi.createJob = jest.fn();
+    ingressApi.patchIngress = jest.fn();
+    deploymentApi.restartDeployment = jest.fn();
+    zeppelin.generateNewShiroIni = jest.fn();
+  });
+
+  it('does nothing if the old status is private', async () => {
+    const existing = {
+      ...getExisting(),
+      shared: 'private',
+    };
+    await handleSharedChange(getParams(), existing, 'project');
+
+    expectCalls({});
+  });
+
+  it('does nothing if the new status is the same as the old status', async () => {
+    await handleSharedChange(getParams(), getExisting(), 'project');
+
+    expectCalls({});
+  });
+
+  it('does nothing if nothing is to be done for the site category', async () => {
+    const existing = {
+      ...getExisting(),
+      category: 'other',
+    };
+    await handleSharedChange(getParams(), existing, 'public');
+
+    expectCalls({});
+  });
+
+  it('does nothing for RStudio notebooks', async () => {
+    const existing = {
+      ...getExisting(),
+      category: NOTEBOOK_CATEGORY,
+      type: RSTUDIO,
+    };
+    await handleSharedChange(getParams(), existing, 'private');
+
+    expectCalls({});
+  });
+
+  it('does nothing for Sites that are not changing to or from public', async () => {
+    const existing = {
+      ...getExisting(),
+      category: SITE_CATEGORY,
+      type: RSHINY,
+    };
+    await handleSharedChange(getParams(), existing, 'private');
+
+    expectCalls({});
+  });
+
+  it('handles Sites changing to public', async () => {
+    const existing = {
+      ...getExisting(),
+      category: SITE_CATEGORY,
+      type: RSHINY,
+    };
+    const expectedPatch = {
+      metadata: {
+        annotations: {
+          'nginx.ingress.kubernetes.io/auth-url': null,
+        },
+      },
+    };
+
+    await handleSharedChange(getParams(), existing, 'public');
+
+    expectCalls({ patchIngress: 1 });
+    expect(ingressApi.patchIngress).toHaveBeenCalledWith('rshiny-stackname', projectKey, expectedPatch);
+  });
+
+  it('handles Sites changing from public', async () => {
+    const existing = {
+      ...getExisting(),
+      category: SITE_CATEGORY,
+      type: RSHINY,
+      shared: 'public',
+      visible: 'public',
+    };
+    jest.spyOn(config, 'get').mockReturnValue('configUrl');
+
+    const expectedPatch = {
+      metadata: {
+        annotations: {
+          'nginx.ingress.kubernetes.io/auth-url': 'configUrl/auth',
+        },
+      },
+    };
+
+    await handleSharedChange(getParams(), existing, 'project');
+
+    expectCalls({ patchIngress: 1 });
+    expect(ingressApi.patchIngress).toHaveBeenCalledWith('rshiny-stackname', projectKey, expectedPatch);
+  });
+
+  it('handles Jupyter notebooks changing to private', async () => {
+    const existing = {
+      ...getExisting(),
+      category: NOTEBOOK_CATEGORY,
+      type: JUPYTERLAB,
+    };
+
+    const expectedCredentials = expect.objectContaining({
+      token: expect.any(String),
+    });
+
+    await handleSharedChange(getParams(), existing, 'private');
+
+    expectCalls({ createJob: 1, createStackCredentialSecret: 1 });
+    expect(secretManager.createStackCredentialSecret).toHaveBeenCalledWith(name, JUPYTERLAB, projectKey, expectedCredentials);
+    expect(jobApi.createJob).toHaveBeenCalledWith(name, projectKey, expect.any(String));
+    expect(jobApi.createJob.mock.calls[0][2]).toMatchSnapshot();
+  });
+
+  it('handles Zeppelin notebooks changing to private', async () => {
+    const existing = {
+      ...getExisting(),
+      category: NOTEBOOK_CATEGORY,
+      type: ZEPPELIN,
+    };
+
+    zeppelin.generateNewShiroIni.mockResolvedValueOnce({ 'shiro.ini': 'shiro' });
+
+    const expectedCredentials = expect.objectContaining({
+      username: 'datalab',
+      password: expect.any(String),
+    });
+    const expectedFullCredentials = expect.objectContaining({
+      'shiro.ini': 'shiro',
+      username: 'datalab',
+      password: expect.any(String),
+    });
+
+    await handleSharedChange(getParams(), existing, 'private');
+
+    expectCalls({ createStackCredentialSecret: 1, restartDeployment: 1, generateNewShiroIni: 1 });
+    expect(zeppelin.generateNewShiroIni).toHaveBeenCalledWith(expectedCredentials);
+    expect(secretManager.createStackCredentialSecret).toHaveBeenCalledWith(name, ZEPPELIN, projectKey, expectedFullCredentials);
+    expect(deploymentApi.restartDeployment).toHaveBeenCalledWith('zeppelin-stackname', projectKey);
+  });
+});
+

--- a/code/workspaces/infrastructure-api/src/stacks/zeppelinStack.js
+++ b/code/workspaces/infrastructure-api/src/stacks/zeppelinStack.js
@@ -43,4 +43,4 @@ function generateNewShiroIni(credentials) {
     .then(body => ({ 'shiro.ini': body }));
 }
 
-export default { createZeppelinStack, deleteZeppelinStack };
+export default { createZeppelinStack, deleteZeppelinStack, generateNewShiroIni };


### PR DESCRIPTION
Added backend functionality for handling when notebooks are set to private from project permissions, and for when sites are set to private/project from public permissions.
Logic for each is as follows:
* Sites: Add/remove ingress auth annotation when going from/to public
* Jupyter notebooks: Change secret, delete cookie file, restart pod (with a k8s Job). This also involved changing the default "Data Directory" for jupyter to be nested on a per-notebook level, rather than one folder for all notebooks in a data storage
* Zeppelin: Change password, restart pod
* RStudio: Nothing to be done, we just have to wait for the cookie to time out (currently about an hour)