### PR TITLE
NERCDL-515: Private stacks frontend

### DIFF
--- a/code/workspaces/common/src/index.js
+++ b/code/workspaces/common/src/index.js
@@ -1,9 +1,11 @@
 import * as permissionTypes from './permissionTypes';
 import * as stackTypes from './stackTypes';
 import * as statusTypes from './statusTypes';
+import * as visibilityTypes from './visibilityTypes';
 
 export {
   permissionTypes,
   stackTypes,
   statusTypes,
+  visibilityTypes,
 };

--- a/code/workspaces/common/src/visibilityTypes.js
+++ b/code/workspaces/common/src/visibilityTypes.js
@@ -1,0 +1,10 @@
+const PRIVATE = 'private';
+const PROJECT = 'project';
+const PUBLIC = 'public';
+
+export {
+  PRIVATE,
+  PROJECT,
+  PUBLIC,
+};
+

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/__snapshots__/StackCardActions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/__snapshots__/StackCardActions.spec.js.snap
@@ -100,26 +100,35 @@ exports[`StackCardActions creates correct snapshot 2`] = `
     userpermissions="open,delete,edit"
   >
     Edit
+    disabled: undefined
   </div>
   <div
-    disabletooltip="true"
     requiredpermission="delete"
-    tooltiptext="Resource is already shared within the project"
     userpermissions="open,delete,edit"
   >
-    Share
+    Set Access: Private
+    disabled: true
+  </div>
+  <div
+    requiredpermission="delete"
+    userpermissions="open,delete,edit"
+  >
+    Set Access: Project
+    disabled: false
   </div>
   <div
     requiredpermission="edit"
     userpermissions="open,delete,edit"
   >
     Restart
+    disabled: false
   </div>
   <div
     requiredpermission="delete"
     userpermissions="open,delete,edit"
   >
     Delete
+    disabled: undefined
   </div>
 </ul>
 `;
@@ -135,38 +144,49 @@ exports[`StackCardActions creates correct snapshot if there are multiple copy sn
     userpermissions="open,delete,edit"
   >
     Edit
+    disabled: undefined
   </div>
   <div
-    disabletooltip="true"
     requiredpermission="delete"
-    tooltiptext="Resource is already shared within the project"
     userpermissions="open,delete,edit"
   >
-    Share
+    Set Access: Private
+    disabled: true
+  </div>
+  <div
+    requiredpermission="delete"
+    userpermissions="open,delete,edit"
+  >
+    Set Access: Project
+    disabled: false
   </div>
   <div
     requiredpermission="edit"
     userpermissions="open,delete,edit"
   >
     Restart
+    disabled: false
   </div>
   <div
     requiredpermission="open"
     userpermissions="open,delete,edit"
   >
     Copy Python snippet
+    disabled: undefined
   </div>
   <div
     requiredpermission="open"
     userpermissions="open,delete,edit"
   >
     Copy R snippet
+    disabled: undefined
   </div>
   <div
     requiredpermission="delete"
     userpermissions="open,delete,edit"
   >
     Delete
+    disabled: undefined
   </div>
 </ul>
 `;

--- a/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/stacks/__snapshots__/StacksContainer.spec.js.snap
@@ -36,10 +36,26 @@ Object {
 }
 `;
 
-exports[`StacksContainer is a container which confirmShareStack generates correct dialog 1`] = `
+exports[`StacksContainer is a container which confirmShareStack generates correct dialog for setting access to private 1`] = `
+Object {
+  "body": "Please confirm you wish to make the expectedDisplayName Notebook private.
+        This will stop all other users from being able to access it.",
+  "title": "Share Notebook",
+}
+`;
+
+exports[`StacksContainer is a container which confirmShareStack generates correct dialog for setting access to project 1`] = `
 Object {
   "body": "Please confirm you wish to share the expectedDisplayName Notebook with other users within the project.
-      WARNING: This action cannot currently be reversed.",
+        It will not be accessible to users outside DataLab.",
+  "title": "Share Notebook",
+}
+`;
+
+exports[`StacksContainer is a container which confirmShareStack generates correct dialog for setting access to public 1`] = `
+Object {
+  "body": "Please confirm you wish to share the expectedDisplayName Notebook publicly.
+      It will be accessible to users outside DataLab.",
   "title": "Share Notebook",
 }
 `;
@@ -80,12 +96,14 @@ exports[`StacksContainer is a container which passes correct props to StackCard 
           "category": "ANALYSIS",
           "projectKey": "project-key",
           "prop": "prop1",
+          "shared": "private",
           "type": "jupyter",
         },
         Object {
           "category": "ANALYSIS",
           "projectKey": "project-key",
           "prop": "prop2",
+          "shared": "project",
           "type": "jupyter",
         },
       ],


### PR DESCRIPTION
Updated webapp to include various options for sharing/unsharing stacks.
Instead of just "Share", there are now up to 3 buttons in the stack card actions: "Set Access: Private/Project/Public"

Only Sites can use the "Public" option.