### PR TITLE
NERCDL-515: Fix make Jupyter private

### DIFF
--- a/code/workspaces/infrastructure-api/resources/default.job.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.job.template.yml
@@ -20,13 +20,17 @@ spec:
           - mountPath: {{{ mountPath }}}
             name: persistentfsvol
         {{/volumeMount}}
-      {{#kubectlCommand}}
-      - name: kubectl-job
-        image: bitnami/kubectl
+      {{#curlCommand}}
+      - name: curl-job
+        image: curlimages/curl
         imagePullPolicy: IfNotPresent
         command: ["sh"]
-        args: ["-c", "{{{ kubectlCommand }}}"]
-      {{/kubectlCommand}}
+        # Command in single quotes as there are double quotes in the command itself
+        args: ["-c", '{{{ curlCommand }}}']
+        env:
+        - name: TOKEN
+          value: "{{{ userToken }}}"
+      {{/curlCommand}}
       volumes:
         {{#volumeMount}}
         - name: persistentfsvol
@@ -34,4 +38,3 @@ spec:
             claimName: {{ volumeMount }}-claim
         {{/volumeMount}}
       restartPolicy: Never
-    

--- a/code/workspaces/infrastructure-api/resources/default.job.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.job.template.yml
@@ -6,6 +6,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
+    securityContext:
+      runAsUser: 1000
     spec:
       containers:
       - name: {{ name }}

--- a/code/workspaces/infrastructure-api/src/config/config.js
+++ b/code/workspaces/infrastructure-api/src/config/config.js
@@ -34,6 +34,18 @@ const config = convict({
     default: 'http://localhost:8001',
     env: 'KUBERNETES_API',
   },
+  deployedNamespace: {
+    doc: 'The namespace the infrastructure API is deployed in Kubernetes',
+    format: 'String',
+    default: 'test',
+    env: 'KUBERNETES_NAMESPACE',
+  },
+  deployedInCluster: {
+    doc: 'If the service is running in the cluster',
+    format: 'Boolean',
+    default: false,
+    env: 'DEPLOYED_IN_CLUSTER',
+  },
   authSigninUrl: {
     doc: 'The sign in URL',
     format: 'url',

--- a/code/workspaces/infrastructure-api/src/controllers/stackController.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.js
@@ -92,7 +92,7 @@ async function createStackExec(request, response) {
 
 async function updateStackExec(request, response) {
   // Build request params
-  const { user } = request;
+  const { user, headers } = request;
   const params = matchedData(request);
   const { projectKey, name } = params;
 
@@ -119,9 +119,10 @@ async function updateStackExec(request, response) {
           error: 'Cannot set notebooks to Public',
         });
       }
+      const { authorization: userToken } = headers;
 
       // If the request changes the shared property, then handle the change accordingly.
-      await handleSharedChange(params, existing, params.shared);
+      await handleSharedChange(params, existing, params.shared, userToken);
     }
 
     await stackManager.mountAssetsOnStack({ ...params, type });

--- a/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
+++ b/code/workspaces/infrastructure-api/src/controllers/stackController.spec.js
@@ -569,6 +569,9 @@ function createValidatedRequest(body, validators) {
   request = httpMocks.createRequest({
     method: 'GET',
     body,
+    headers: {
+      authorization: 'token',
+    },
   });
 
   const vals = validators.map(createValidationPromise(request));

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createKubectlJob creates a job to match the snapshot 1`] = `
+exports[`createCurlJob creates a job to match the snapshot 1`] = `
 "---
 apiVersion: batch/v1
 kind: Job
@@ -9,6 +9,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
+    securityContext:
+      runAsUser: 1000
     spec:
       containers:
       - name: job-job
@@ -18,11 +20,10 @@ spec:
         args: [\\"-c\\", \\"echo \\"Hello, World!\\"\\"]
       volumes:
       restartPolicy: Never
-    
 "
 `;
 
-exports[`createKubectlJob creates a job to match the snapshot when a kubectl command is supplied 1`] = `
+exports[`createCurlJob creates a job to match the snapshot when a curl command is supplied 1`] = `
 "---
 apiVersion: batch/v1
 kind: Job
@@ -31,6 +32,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
+    securityContext:
+      runAsUser: 1000
     spec:
       containers:
       - name: job-job
@@ -38,18 +41,21 @@ spec:
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]
         args: [\\"-c\\", \\"echo \\"Hello, World!\\"\\"]
-      - name: kubectl-job
-        image: bitnami/kubectl
+      - name: curl-job
+        image: curlimages/curl
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]
-        args: [\\"-c\\", \\"kubectl get pods\\"]
+        # Command in single quotes as there are double quotes in the command itself
+        args: [\\"-c\\", 'curl -X PUT localhost:8000/restart']
+        env:
+        - name: TOKEN
+          value: \\"Bearer token\\"
       volumes:
       restartPolicy: Never
-    
 "
 `;
 
-exports[`createKubectlJob creates a job to match the snapshot when a volume and path is supplied 1`] = `
+exports[`createCurlJob creates a job to match the snapshot when a volume and path is supplied 1`] = `
 "---
 apiVersion: batch/v1
 kind: Job
@@ -58,6 +64,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
+    securityContext:
+      runAsUser: 1000
     spec:
       containers:
       - name: job-job
@@ -73,6 +81,5 @@ spec:
           persistentVolumeClaim:
             claimName: volume-claim
       restartPolicy: Never
-    
 "
 `;

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.js
@@ -3,20 +3,21 @@ import nameGenerators from '../common/nameGenerators';
 
 const { jobName } = nameGenerators;
 
-export const createKubectlJob = ({ name, runCommand, kubectlCommand, volumeMount, mountPath }) => {
+export const createCurlJob = ({ name, runCommand, curlCommand, volumeMount, mountPath, userToken }) => {
   const job = jobName(name);
 
   const context = {
     name: job,
     runCommand,
-    kubectlCommand,
+    curlCommand,
     volumeMount,
     mountPath,
+    userToken,
   };
 
   return generateManifest(context, JobTemplates.DEFAULT_JOB);
 };
 
 export default {
-  createKubectlJob,
+  createCurlJob,
 };

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
@@ -1,23 +1,24 @@
-import { createKubectlJob } from './jobGenerator';
+import { createCurlJob } from './jobGenerator';
 
 const getInputs = () => ({
   name: 'job',
   runCommand: 'echo "Hello, World!"',
 });
 
-describe('createKubectlJob', () => {
+describe('createCurlJob', () => {
   it('creates a job to match the snapshot', async () => {
-    const manifest = await createKubectlJob(getInputs());
+    const manifest = await createCurlJob(getInputs());
 
     expect(manifest).toMatchSnapshot();
   });
 
-  it('creates a job to match the snapshot when a kubectl command is supplied', async () => {
+  it('creates a job to match the snapshot when a curl command is supplied', async () => {
     const inputs = {
       ...getInputs(),
-      kubectlCommand: 'kubectl get pods',
+      curlCommand: 'curl -X PUT localhost:8000/restart',
+      userToken: 'Bearer token',
     };
-    const manifest = await createKubectlJob(inputs);
+    const manifest = await createCurlJob(inputs);
 
     expect(manifest).toMatchSnapshot();
   });
@@ -28,7 +29,7 @@ describe('createKubectlJob', () => {
       volumeMount: 'volume',
       mountPath: '/mnt/data',
     };
-    const manifest = await createKubectlJob(inputs);
+    const manifest = await createCurlJob(inputs);
 
     expect(manifest).toMatchSnapshot();
   });

--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
@@ -9,6 +9,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
+    securityContext:
+      runAsUser: 1000
     spec:
       containers:
       - name: job-stackname
@@ -19,16 +21,19 @@ spec:
         volumeMounts:
           - mountPath: /mnt/persistentfs
             name: persistentfsvol
-      - name: kubectl-job
-        image: bitnami/kubectl
+      - name: curl-job
+        image: curlimages/curl
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]
-        args: [\\"-c\\", \\"kubectl rollout restart deployment/jupyterlab-stackname\\"]
+        # Command in single quotes as there are double quotes in the command itself
+        args: [\\"-c\\", 'curl -X PUT host.docker.internal:undefined/stack/project/restart -H \\"Authorization: $TOKEN\\" -H \\"Content-Type: application/json\\" -d ''{\\"projectKey\\":\\"project\\",\\"name\\":\\"stackname\\",\\"type\\":\\"jupyterlab\\"}''']
+        env:
+        - name: TOKEN
+          value: \\"Bearer token\\"
       volumes:
         - name: persistentfsvol
           persistentVolumeClaim:
             claimName: volume-claim
       restartPolicy: Never
-    
 "
 `;


### PR DESCRIPTION
Fixed Jupyter being made private so:
* It runs as user 1000 which has permissions to delete the cookie file
* Instead of using kubectl to restart (which would need a service account), use curl to make a request to the infrastructure API with the user's token to restart the deployment