### PR TITLE
NERCDL-515: SecurityContext fix and add tooltips

### DIFF
--- a/code/workspaces/infrastructure-api/resources/default.job.template.yml
+++ b/code/workspaces/infrastructure-api/resources/default.job.template.yml
@@ -6,9 +6,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
-    securityContext:
-      runAsUser: 1000
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: {{ name }}
         image: busybox

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
@@ -9,9 +9,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
-    securityContext:
-      runAsUser: 1000
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: job-job
         image: busybox
@@ -32,9 +32,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
-    securityContext:
-      runAsUser: 1000
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: job-job
         image: busybox
@@ -64,9 +64,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
-    securityContext:
-      runAsUser: 1000
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: job-job
         image: busybox

--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
@@ -9,9 +9,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 0
   template:
-    securityContext:
-      runAsUser: 1000
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: job-stackname
         image: busybox

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.js
@@ -48,6 +48,8 @@ const getShareButton = (stack, shareStack, permission) => (newStatus, label, dis
   requiredPermission: permission,
   name: label,
   disabled,
+  tooltipText: `Access already set to ${newStatus}`,
+  disableTooltip: !disabled,
 });
 
 export const getSharedButtons = (stack, shareStack, permission) => {

--- a/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCardActions/StackCardActions.spec.js
@@ -264,18 +264,24 @@ describe('getSharedButtons', () => {
     requiredPermission: permission,
     name: 'Set Access: Private',
     disabled,
+    tooltipText: 'Access already set to private',
+    disableTooltip: !disabled,
   });
   const projectButton = disabled => ({
     onClick: expect.any(Function),
     requiredPermission: permission,
     name: 'Set Access: Project',
     disabled,
+    tooltipText: 'Access already set to project',
+    disableTooltip: !disabled,
   });
   const publicButton = disabled => ({
     onClick: expect.any(Function),
     requiredPermission: permission,
     name: 'Set Access: Public',
     disabled,
+    tooltipText: 'Access already set to public',
+    disableTooltip: !disabled,
   });
 
   it('creates the correct buttons for a private stack', () => {


### PR DESCRIPTION
* Fixed security context of job template so it's in the right place
* Added tooltip to whichever "Set Access" button is disabled to explain that it is disabled because that is the current access level