### PR TITLE
NERCDL-515: Timestamp in Job names

### DIFF
--- a/code/workspaces/infrastructure-api/src/common/nameGenerators.js
+++ b/code/workspaces/infrastructure-api/src/common/nameGenerators.js
@@ -29,7 +29,8 @@ const sparkDriverHeadlessService = deploymentServiceName => `${deploymentService
 const sparkJob = deploymentName => `${deploymentName}-spark-job`;
 
 // Jobs
-const jobName = name => `job-${name}`;
+// Add the timestamp to the job name so we don't have duplicate names in case old jobs are not cleared.
+const jobName = name => `job-${name}-${Date.now()}`;
 
 export default {
   assetVolume,

--- a/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/kubernetes/__snapshots__/jobGenerator.spec.js.snap
@@ -5,7 +5,7 @@ exports[`createCurlJob creates a job to match the snapshot 1`] = `
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: job-job
+  name: job-job-1609459200
 spec:
   ttlSecondsAfterFinished: 0
   template:
@@ -13,7 +13,7 @@ spec:
       securityContext:
         runAsUser: 1000
       containers:
-      - name: job-job
+      - name: job-job-1609459200
         image: busybox
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]
@@ -28,7 +28,7 @@ exports[`createCurlJob creates a job to match the snapshot when a curl command i
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: job-job
+  name: job-job-1609459200
 spec:
   ttlSecondsAfterFinished: 0
   template:
@@ -36,7 +36,7 @@ spec:
       securityContext:
         runAsUser: 1000
       containers:
-      - name: job-job
+      - name: job-job-1609459200
         image: busybox
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]
@@ -60,7 +60,7 @@ exports[`createCurlJob creates a job to match the snapshot when a volume and pat
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: job-job
+  name: job-job-1609459200
 spec:
   ttlSecondsAfterFinished: 0
   template:
@@ -68,7 +68,7 @@ spec:
       securityContext:
         runAsUser: 1000
       containers:
-      - name: job-job
+      - name: job-job-1609459200
         image: busybox
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]

--- a/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
+++ b/code/workspaces/infrastructure-api/src/kubernetes/jobGenerator.spec.js
@@ -6,6 +6,11 @@ const getInputs = () => ({
 });
 
 describe('createCurlJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(1609459200);
+  });
+
   it('creates a job to match the snapshot', async () => {
     const manifest = await createCurlJob(getInputs());
 

--- a/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
+++ b/code/workspaces/infrastructure-api/src/stacks/__snapshots__/shareStackManager.spec.js.snap
@@ -5,7 +5,7 @@ exports[`handleSharedChange handles Jupyter notebooks changing to private 1`] = 
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: job-stackname
+  name: job-stackname-1609459200
 spec:
   ttlSecondsAfterFinished: 0
   template:
@@ -13,7 +13,7 @@ spec:
       securityContext:
         runAsUser: 1000
       containers:
-      - name: job-stackname
+      - name: job-stackname-1609459200
         image: busybox
         imagePullPolicy: IfNotPresent
         command: [\\"sh\\"]

--- a/code/workspaces/infrastructure-api/src/stacks/shareStackManager.spec.js
+++ b/code/workspaces/infrastructure-api/src/stacks/shareStackManager.spec.js
@@ -152,6 +152,7 @@ describe('handleSharedChange', () => {
       category: NOTEBOOK_CATEGORY,
       type: JUPYTERLAB,
     };
+    jest.spyOn(Date, 'now').mockReturnValue(1609459200);
 
     secretManager.createNewJupyterCredentials = jest.fn(() => ({ token: 'token' }));
     deploymentApi.getDeployment.mockResolvedValueOnce({


### PR DESCRIPTION
As we are not yet on Kubernetes 1.21, the `ttlSecondsAfterFinished` property (which deletes jobs when they are finished) is not available.
This means that if a notebook is made private, then public again, and back to private, the second "make private" job will have the same name as the first, so it won't work.

Added the timestamp to job names to make job names unique so the same notebook can be made private several times.
This may require some manual cleanup of completed jobs occasionally, though this could be done in a cronjob if it becomes annoying (and will be solved anyway when the cluster(s) move to k8s 1.21).