### PR TITLE
Correcting env-control remove command in docs

### DIFF
--- a/docs/src/tutorials/conda_environments.md
+++ b/docs/src/tutorials/conda_environments.md
@@ -42,7 +42,7 @@ kernels will be visible which correspond to the newly created Conda environment.
 There is a corresponding command;
 
 ```bash
-env-control del environment-name
+env-control remove environment-name
 ```
 
 This will remove a Conda environment called `environment-name`, and is useful in


### PR DESCRIPTION
Hope you guys are open to PRs? If so, here is a very brief one to correct the docs: They say that `env-control del` should be used to remove Conda envs, but I'm pretty certain this should be `env-control remove` instead. I hope I've managed to modify the correct file?