### PR TITLE
Update opendap_datalab_aggregate.ipynb np not installable

### DIFF
--- a/code/notebooks/jupyter/opendap_datalab_aggregate.ipynb
+++ b/code/notebooks/jupyter/opendap_datalab_aggregate.ipynb
@@ -21,7 +21,7 @@
     }
    ],
    "source": [
-    "!conda install numpy netcdf4 np --yes"
+    "!conda install numpy netcdf4 --yes"
    ]
   },
   {


### PR DESCRIPTION
If I am not wrong, this is then numpy who is used as np isn't it ?