### PR TITLE
auth: redirect to signup page when clicking on sign up links

### DIFF
--- a/code/workspaces/web-app/src/auth/auth.js
+++ b/code/workspaces/web-app/src/auth/auth.js
@@ -26,7 +26,7 @@ class Auth {
 
   selfServiceSignUp() {
     // Re-direct to login screen
-    this.oidcInit.signinRedirect();
+    this.oidcInit.signinRedirect({ login_hint: 'signUp' });
   }
 
   signUpConfig() {


### PR DESCRIPTION
Following the instructions in the Auth0 docs[0], specify a login_hint when redirecting.  We might have to revisit this if/when we enable the "New" Universal Login Experience.

[0]: https://community.auth0.com/t/how-do-i-redirect-users-directly-to-the-hosted-signup-page/42520