### PR TITLE
ED-68 Enable pre-creation of users

### DIFF
--- a/code/workspaces/auth-service/src/controllers/projectController.js
+++ b/code/workspaces/auth-service/src/controllers/projectController.js
@@ -20,6 +20,7 @@ async function getUserRoles(req, res) {
   const mappedUsers = userPermissions.map(user => ({
     userId: user.userId,
     role: find(user.projectRoles, { projectKey }).role,
+    verified: user.verified,
   }));
 
   res.send(mappedUsers);

--- a/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
+++ b/code/workspaces/auth-service/src/dataaccess/__snapshots__/userRolesRepository.spec.js.snap
@@ -18,6 +18,7 @@ Array [
     ],
     "userId": "uid1",
     "userName": "user1",
+    "verified": true,
   },
   Object {
     "catalogueRole": "publisher",
@@ -35,6 +36,7 @@ Array [
     ],
     "userId": "uid2",
     "userName": "user2",
+    "verified": true,
   },
 ]
 `;
@@ -57,6 +59,7 @@ Array [
     ],
     "userId": "uid1",
     "userName": "user1",
+    "verified": true,
   },
   Object {
     "catalogueRole": "publisher",
@@ -70,6 +73,7 @@ Array [
     ],
     "userId": "uid2",
     "userName": "user2",
+    "verified": true,
   },
   Object {
     "catalogueRole": "user",
@@ -83,6 +87,7 @@ Array [
     ],
     "userId": "uid2",
     "userName": "user2",
+    "verified": true,
   },
   Object {
     "catalogueRole": "user",
@@ -103,6 +108,7 @@ exports[`userRolesRepository read operations getUser returns expected snapshot 1
 Object {
   "name": "user1",
   "userId": "uid1",
+  "verified": true,
 }
 `;
 
@@ -111,10 +117,12 @@ Array [
   Object {
     "name": "user1",
     "userId": "uid1",
+    "verified": true,
   },
   Object {
     "name": "user2",
     "userId": "uid2",
+    "verified": true,
   },
 ]
 `;

--- a/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
+++ b/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
@@ -12,7 +12,7 @@ const wrapUser = user => ({
 // flatten to ensure that the return is simply the record itself
 function flattenUpdateEntity(entity) {
   const flatObj = {};
-  Object.keys(entity).forEach(key => {
+  Object.keys(entity).forEach((key) => {
     if (key === '$set' || key === '$setOnInsert') {
       Object.assign(flatObj, entity[key]);
     } else {

--- a/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
+++ b/code/workspaces/auth-service/src/dataaccess/testUtil/databaseMock.js
@@ -8,6 +8,20 @@ const wrapUser = user => ({
   toObject: () => user,
 });
 
+// For specific findAndUpdate queries things are either set explictly on insert or updated
+// flatten to ensure that the return is simply the record itself
+function flattenUpdateEntity(entity) {
+  const flatObj = {};
+  Object.keys(entity).forEach(key => {
+    if (key === '$set' || key === '$setOnInsert') {
+      Object.assign(flatObj, entity[key]);
+    } else {
+      flatObj[key] = entity[key];
+    }
+  });
+  return flatObj;
+}
+
 function createDatabaseMock(users) {
   const documents = users.map(cloneUser).map(wrapUser);
   let lastInvocation;
@@ -23,8 +37,9 @@ function createDatabaseMock(users) {
       return { exec: () => Promise.resolve(findOneReturn) };
     },
     findOneAndUpdate: (query, entity, params) => {
+      const updatedEntity = wrapUser(cloneUser(flattenUpdateEntity(entity)));
       lastInvocation = { query, entity, params };
-      return Promise.resolve(entity);
+      return Promise.resolve(updatedEntity);
     },
     remove: (query) => {
       lastInvocation = { query };

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.js
@@ -28,21 +28,18 @@ function addDefaults(roles) {
 async function getRoles(userId, userName) {
   let roles = await UserRoles().findOne({ userId }).exec();
   if (!roles) {
-    roles = await createNonVerifiedUserRecord(userId, userName);
+    // User has logged in and roles are being retrieved hence they are verified
+    roles = await createVerifiedUserRecord(userId, userName);
   }
 
   return addDefaults(roles);
 }
 
-// User has logged in for the first time, set up userRoles database record if does not exist
-// and set the user as verified
-async function createNonVerifiedUserRecord(userId, userName) {
+async function createVerifiedUserRecord(userId, userName) {
   return addRecordForNewUser(userId, userName, true);
 }
 
-// User has not logged in, however their e-mail is being added to an existing project, hence
-// set up userRoles record and set as not verified
-async function createVerifiedUserRecord(userId, userName) {
+async function createNonVerifiedUserRecord(userId, userName) {
   return addRecordForNewUser(userId, userName, false);
 }
 
@@ -161,9 +158,8 @@ async function addRole(userId, projectKey, role) {
   const query = { userId };
   let user = await UserRoles().findOne(query).exec();
   if (!user) {
-    // If a role is added to a non-existant user, set verfied
-    await createVerifiedUserRecord(userId, userId);
-    user = await UserRoles().findOne(query).exec();
+    // If a user record does not exist, generate it with verified field set to false
+    user = await createNonVerifiedUserRecord(userId, userId);
   }
   // Either add role or update existing role
   const { projectRoles } = user;

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -1,7 +1,7 @@
 import { permissionTypes } from 'common';
-import userRoleRepository from './userRolesRepository';
 import database from '../config/database';
 import databaseMock from './testUtil/databaseMock';
+import userRoleRepository from './userRolesRepository';
 
 const { INSTANCE_ADMIN_ROLE_KEY } = permissionTypes;
 
@@ -10,6 +10,7 @@ const user1 = {
   userName: 'user1',
   instanceAdmin: false,
   dataManager: false,
+  verified: true,
   projectRoles: [
     { projectKey: 'project 1', role: 'admin' },
     { projectKey: 'project 2', role: 'user' },
@@ -21,6 +22,7 @@ const user2 = {
   userName: 'user2',
   instanceAdmin: true,
   dataManager: true,
+  verified: true,
   catalogueRole: 'publisher',
   projectRoles: [
     { projectKey: 'project 2', role: 'viewer' },
@@ -30,6 +32,7 @@ const user2 = {
 const duplicateUser2 = {
   userId: 'uid2',
   userName: 'user2',
+  verified: true,
   projectRoles: [
     { projectKey: 'project 3', role: 'admin' },
   ],
@@ -117,12 +120,6 @@ describe('userRolesRepository', () => {
       mockDatabase().clear();
     });
 
-    it('should reject if the user is not in roles collection', async () => {
-      mockDatabase = databaseMock([]);
-      database.getModel = mockDatabase;
-      await expect(userRoleRepository.addRole('uid1', 'project', 'admin')).rejects.toThrow('Unrecognised user uid1');
-    });
-
     it('should add role to existing user if the user has no role on project', async () => {
       mockDatabase().setFindOneReturn(user1);
       const addRole = await userRoleRepository.addRole('uid1', 'project', 'admin');
@@ -139,6 +136,7 @@ describe('userRolesRepository', () => {
           userName: 'user1',
           instanceAdmin: false,
           dataManager: false,
+          verified: true,
           projectRoles: [
             { projectKey: 'project 1', role: 'admin' },
             { projectKey: 'project 2', role: 'user' },
@@ -160,6 +158,7 @@ describe('userRolesRepository', () => {
         userName: 'user1',
         instanceAdmin: false,
         dataManager: false,
+        verified: true,
         projectRoles: [
           { projectKey: 'project 1', role: 'admin' },
           { projectKey: 'project 2', role: 'admin' },
@@ -176,25 +175,25 @@ describe('userRolesRepository', () => {
     });
 
     it('throws an error if the user already exists', async () => {
-      await expect(userRoleRepository.addRecordForNewUser('uid1', 'user1')).rejects.toThrow(new Error('Creating new user for uid1 user1, but they already exist'));
+      await expect(userRoleRepository.addRecordForNewUser('uid1', 'user1')).rejects.toThrow(new Error('Creating new user for userId: uid1 user1, but they already exist'));
     });
 
     it('adds an empty record for a new user that does not exist', async () => {
       // Act
-      const userRoles = await userRoleRepository.addRecordForNewUser('uid999', 'user999');
+      const userRoles = await userRoleRepository.addRecordForNewUser('uid999', 'user999', true);
 
       // Assert
       expect(mockDatabase().invocation()).toEqual({
         // create a user
-        query: undefined,
-        entity: { userId: 'uid999', userName: 'user999', projectRoles: [] },
-        params: undefined,
+        query: { userName: 'user999' },
+        entity: { $set: { userId: 'uid999', verified: true }, $setOnInsert: { projectRoles: [] } },
+        params: { new: true, upsert: true },
       });
       expect(unwrapUser(userRoles)).toEqual({
-        // created roles
+        // created update
         userId: 'uid999',
-        userName: 'user999',
         projectRoles: [],
+        verified: true,
       });
     });
 
@@ -209,16 +208,12 @@ describe('userRolesRepository', () => {
       // Assert
       expect(mockDatabase().invocation()).toEqual({
         // create a user
-        query: undefined,
-        entity: { userId: 'uid999', userName: 'user999', projectRoles: [], instanceAdmin: true },
-        params: undefined,
+        query: { userName: 'user999' },
+        entity: { $set: { userId: 'uid999', verified: true, instanceAdmin: true }, $setOnInsert: { projectRoles: [] } },
+        params: { new: true, upsert: true },
       });
       expect(unwrapUser(userRoles)).toEqual({
-        // created roles
-        userId: 'uid999',
-        userName: 'user999',
-        projectRoles: [],
-        instanceAdmin: true,
+        userId: 'uid999', verified: true, instanceAdmin: true, projectRoles: []
       });
     });
   });
@@ -258,18 +253,18 @@ describe('userRolesRepository', () => {
       // Assert
       expect(mockDatabase().invocation()).toEqual({
         // create a user
-        query: undefined,
-        entity: { userId: 'uid999', userName: 'user999', projectRoles: [] },
-        params: undefined,
+        query: { userName: 'user999' },
+        entity: { $set: { userId: 'uid999', verified: true }, $setOnInsert: { projectRoles: [] } },
+        params: { new: true, upsert: true },
       });
       expect(userRoles).toEqual({
         // add default roles
         userId: 'uid999',
-        userName: 'user999',
         catalogueRole: 'user',
         instanceAdmin: false,
         dataManager: false,
         projectRoles: [],
+        verified: true,
       });
     });
 
@@ -284,14 +279,14 @@ describe('userRolesRepository', () => {
       // Assert
       expect(mockDatabase().invocation()).toEqual({
         // create a user
-        query: undefined,
-        entity: { userId: 'uid999', userName: 'user999', projectRoles: [], instanceAdmin: true },
-        params: undefined,
+        query: { userName: 'user999' },
+        entity: { $set: { userId: 'uid999', verified: true, instanceAdmin: true }, $setOnInsert: { projectRoles: [] } },
+        params: { new: true, upsert: true },
       });
       expect(userRoles).toEqual({
         // add default roles
         userId: 'uid999',
-        userName: 'user999',
+        verified: true,
         catalogueRole: 'user',
         instanceAdmin: true,
         dataManager: false,
@@ -315,6 +310,7 @@ describe('userRolesRepository', () => {
         userName: 'user1',
         instanceAdmin: false,
         dataManager: false,
+        verified: true,
         projectRoles: [
           { projectKey: 'project 1', role: 'admin' },
         ],

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -213,7 +213,7 @@ describe('userRolesRepository', () => {
         params: { new: true, upsert: true },
       });
       expect(unwrapUser(userRoles)).toEqual({
-        userId: 'uid999', verified: true, instanceAdmin: true, projectRoles: []
+        userId: 'uid999', verified: true, instanceAdmin: true, projectRoles: [],
       });
     });
   });

--- a/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
+++ b/code/workspaces/auth-service/src/dataaccess/userRolesRepository.spec.js
@@ -165,6 +165,29 @@ describe('userRolesRepository', () => {
         ],
       });
     });
+
+    it('should add userRole record with verified: false if user does not exist', async () => {
+      mockDatabase().setFindOneReturn(false);
+      jest.spyOn(userRoleRepository, 'createNonVerifiedUserRecord').mockReturnValue({
+        ...user1,
+        verified: false,
+      });
+
+      const addRole = await userRoleRepository.addRole(user1.userName, 'project 10', 'admin');
+
+      expect(addRole).toEqual(true);
+      expect(mockDatabase().query()).toEqual({
+        userId: user1.userName,
+      });
+
+      expect(unwrapUser(mockDatabase().entity())).toEqual({
+        userId: user1.userName,
+        verified: false,
+        projectRoles: [
+          { projectKey: 'project 10', role: 'admin' },
+        ],
+      });
+    });
   });
 
   describe('addRecordForNewUser', () => {

--- a/code/workspaces/auth-service/src/models/userRoles.model.js
+++ b/code/workspaces/auth-service/src/models/userRoles.model.js
@@ -1,6 +1,6 @@
-import mongoose from 'mongoose';
 import { permissionTypes } from 'common';
-import { CATALOGUE_ROLE_KEY, INSTANCE_ADMIN_ROLE_KEY, DATA_MANAGER_ROLE_KEY } from 'common/src/permissionTypes';
+import { CATALOGUE_ROLE_KEY, DATA_MANAGER_ROLE_KEY, INSTANCE_ADMIN_ROLE_KEY } from 'common/src/permissionTypes';
+import mongoose from 'mongoose';
 
 const { Schema } = mongoose;
 const { CATALOGUE_ROLES, PROJECT_ROLES } = permissionTypes;
@@ -8,6 +8,7 @@ const { CATALOGUE_ROLES, PROJECT_ROLES } = permissionTypes;
 const UserRolesSchema = new Schema({
   userId: String,
   userName: String,
+  verified: { type: Boolean, default: false },
   [INSTANCE_ADMIN_ROLE_KEY]: { type: Boolean, default: false },
   [DATA_MANAGER_ROLE_KEY]: { type: Boolean, default: false },
   [CATALOGUE_ROLE_KEY]: { type: String, enum: CATALOGUE_ROLES },

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -349,6 +349,7 @@ type ProjectUser {
     userId: ID!
     name: String!
     role: ProjectRole!
+    verified: Boolean!
 }
 
 type Resource {

--- a/code/workspaces/client-api/src/schema/schema.graphql
+++ b/code/workspaces/client-api/src/schema/schema.graphql
@@ -302,6 +302,7 @@ type User {
     userId: ID
     name: String!
     permissions: [Permission!]!
+    verified: Boolean!
 }
 
 type Project {

--- a/code/workspaces/web-app/src/api/__snapshots__/listUserService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/listUserService.spec.js.snap
@@ -3,6 +3,6 @@
 exports[`listUserService listUsers should build the correct query and unpack the results 1`] = `
 "
   Users {
-      users { name userId }
+      users { name userId verified }
   }"
 `;

--- a/code/workspaces/web-app/src/api/__snapshots__/projectSettingsService.spec.js.snap
+++ b/code/workspaces/web-app/src/api/__snapshots__/projectSettingsService.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`projectSettingsService addProjectUserPermission should build correct query and unpack the result 1`] = `
 "
     AddProjectPermission($permission: PermissionAddRequest) {
-      addProjectPermission(permission: $permission) { 
+      addProjectPermission(permission: $permission) {
         projectKey, role
       }
     }"
@@ -13,8 +13,8 @@ exports[`projectSettingsService getProjectUsers should build correct query and u
 "
     GetProjectUsers($projectKey: String!) {
       project(projectKey: $projectKey) {
-        projectUsers { 
-          userId, name, role
+        projectUsers {
+          userId, name, role, verified
         },
       }
     }"

--- a/code/workspaces/web-app/src/api/listUsersService.js
+++ b/code/workspaces/web-app/src/api/listUsersService.js
@@ -4,7 +4,7 @@ import errorHandler from './graphqlErrorHandler';
 function listUsers() {
   const query = `
   Users {
-      users { name userId }
+      users { name userId verified }
   }`;
 
   return gqlQuery(query)

--- a/code/workspaces/web-app/src/api/projectSettingsService.js
+++ b/code/workspaces/web-app/src/api/projectSettingsService.js
@@ -5,8 +5,8 @@ export function getProjectUsers(projectKey) {
   const query = `
     GetProjectUsers($projectKey: String!) {
       project(projectKey: $projectKey) {
-        projectUsers { 
-          userId, name, role
+        projectUsers {
+          userId, name, role, verified
         },
       }
     }`;
@@ -18,7 +18,7 @@ export function getProjectUsers(projectKey) {
 export function addProjectUserPermission(projectKey, userId, role) {
   const mutation = `
     AddProjectPermission($permission: PermissionAddRequest) {
-      addProjectPermission(permission: $permission) { 
+      addProjectPermission(permission: $permission) {
         projectKey, role
       }
     }`;

--- a/code/workspaces/web-app/src/components/common/form/UserMultiSelect.js
+++ b/code/workspaces/web-app/src/components/common/form/UserMultiSelect.js
@@ -5,6 +5,7 @@ import sortByName from '../sortByName';
 
 function UserMultiSelect({ input, meta = null, fixedOptions = [], ...custom }) {
   const users = useUsers();
+
   const sortedUsers = sortByName(users.value);
   const [currentValue, setCurrentValue] = useState(input.value || []); // use to give current value to onBlur
 
@@ -17,7 +18,7 @@ function UserMultiSelect({ input, meta = null, fixedOptions = [], ...custom }) {
           meta,
           currentValue,
           setCurrentValue,
-          options: sortedUsers,
+          options: sortedUsers.filter(user => user.verified),
           label: 'Users',
           placeholder: "Type user's email address",
           getOptionLabel: val => val.name,

--- a/code/workspaces/web-app/src/components/common/form/UserMultiSelect.spec.js
+++ b/code/workspaces/web-app/src/components/common/form/UserMultiSelect.spec.js
@@ -8,8 +8,10 @@ jest.mock('react-redux');
 jest.mock('../../../hooks/usersHooks');
 jest.mock('@mui/lab/Autocomplete', () => props => (<div>Autocomplete mock {JSON.stringify(props)}</div>));
 
-const user1 = { userId: 'user-1', name: 'User 1' };
-const user2 = { userId: 'user-2', name: 'User 2' };
+const user1 = { userId: 'user-1', name: 'User 1', verified: true };
+const user2 = { userId: 'user-2', name: 'User 2', verified: true };
+const user3 = { userId: 'user-3', name: 'User 3', verified: true };
+const user4 = { userId: 'user-3', name: 'User 4', verified: false };
 
 describe('UserMultiSelect', () => {
   const shallowRender = () => {
@@ -25,7 +27,7 @@ describe('UserMultiSelect', () => {
 
   beforeEach(() => {
     useDispatch.mockReturnValue(jest.fn().mockName('dispatch'));
-    useUsers.mockReturnValue({ fetching: false, value: [user1, user2] });
+    useUsers.mockReturnValue({ fetching: false, value: [user1, user2, user3, user4] });
   });
 
   it('renders to match snapshot passing correct props to children', () => {

--- a/code/workspaces/web-app/src/components/common/input/UserSelect.js
+++ b/code/workspaces/web-app/src/components/common/input/UserSelect.js
@@ -21,10 +21,12 @@ const UserSelect = ({ selectedUsers, setSelectedUsers, label, placeholder, multi
     <Autocomplete
       {...otherProps}
       multiple={multiselect}
+      freeSolo={true}
       options={users}
       getOptionLabel={getOptionLabel}
       isOptionEqualToValue={val => (multiselect ? selectedUsers.includes(val) : selectedUsers === val)}
       value={selectedUsers}
+      onInputChange={(event, newValue) => setSelectedUsers({ name: newValue, userId: newValue })}
       onChange={(event, newValue) => setSelectedUsers(newValue)}
       loading={loading}
       autoHighlight

--- a/code/workspaces/web-app/src/components/modal/EditDataStoreDialog.js
+++ b/code/workspaces/web-app/src/components/modal/EditDataStoreDialog.js
@@ -44,7 +44,7 @@ const EditDataStoreDialog = ({
     <DialogTitle>{title}</DialogTitle>
     <DialogContent>
       <EditDataStoreForm
-        userList={sortUsersByLabel(userList)}
+        userList={sortUsersByLabel(userList.filter(user => user.verified))}
         loadUsersPromise={loadUsersPromise}
         onSubmit={getOnDetailsEditSubmit(projectKey, stack.name, typeName)}
         onCancel={onCancel}

--- a/code/workspaces/web-app/src/components/modal/EditDataStoreDialog.spec.js
+++ b/code/workspaces/web-app/src/components/modal/EditDataStoreDialog.spec.js
@@ -21,8 +21,8 @@ describe('Edit data store dialog', () => {
     shallowRender({
       onCancel: jest.fn().mockName('onCancel'),
       title: 'expectedTitle',
-      currentUsers: [{ label: 'expectedLabelOne', value: 'expectedValueOne' }],
-      userList: [{ label: 'expectedLabelTwo', value: 'expectedValueTwo' }],
+      currentUsers: [{ label: 'expectedLabelOne', value: 'expectedValueOne', verified: true }],
+      userList: [{ label: 'expectedLabelTwo', value: 'expectedValueTwo', verified: true }, { label: 'expectedLabelThree', value: 'expectedValueThree', verified: false }],
       loadUsersPromise: {
         error: null,
         fetching: false,

--- a/code/workspaces/web-app/src/components/modal/__snapshots__/EditDataStoreDialog.spec.js.snap
+++ b/code/workspaces/web-app/src/components/modal/__snapshots__/EditDataStoreDialog.spec.js.snap
@@ -17,7 +17,7 @@ exports[`Edit data store dialog creates correct snapshot 1`] = `
   >
     <div>
       EditDataStoreForm mock 
-      {"userList":[{"label":"expectedLabelTwo","value":"expectedValueTwo"}],"loadUsersPromise":{"error":null,"fetching":false,"value":[]},"initialValues":{"displayName":"Stack Display Name","description":"Stack description","users":[{"label":"expectedLabelOne","value":"expectedValueOne"}]}}
+      {"userList":[{"label":"expectedLabelTwo","value":"expectedValueTwo","verified":true}],"loadUsersPromise":{"error":null,"fetching":false,"value":[]},"initialValues":{"displayName":"Stack Display Name","description":"Stack description","users":[{"label":"expectedLabelOne","value":"expectedValueOne","verified":true}]}}
     </div>
   </div>
 </div>

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
@@ -134,7 +134,6 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
       <div>
         <PrimaryActionButton
           className={classes.addButton}
-          disabled={!!disabledMessage}
           onClick={() => onClickFn(projectKey, selectedUser, selectedPermissions, dispatch)}
         >
           Add

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
@@ -124,10 +124,11 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
   let disabledMessage = ''; // empty string stops tooltip displaying
 
   if (!selectedUser) {
-    disabledMessage = "Please enter a registered user's email.";
+    disabledMessage = "Please enter a user's email.";
   } else if (selectedUser.userId === currentUserId && !currentUserSystemAdmin) {
     disabledMessage = 'You can not add permissions for yourself.';
   }
+  const disabled = selectedUser ? '' : 'disabled';
 
   return (
     <Tooltip title={disabledMessage} placement="top">
@@ -135,6 +136,7 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
         <PrimaryActionButton
           className={classes.addButton}
           onClick={() => onClickFn(projectKey, selectedUser, selectedPermissions, dispatch)}
+          disabled={disabled}
         >
           Add
         </PrimaryActionButton>

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
@@ -135,7 +135,7 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
         <PrimaryActionButton
           className={classes.addButton}
           onClick={() => onClickFn(projectKey, selectedUser, selectedPermissions, dispatch)}
-          disabled={!selectedUser}
+          disabled={!!disabledMessage}
         >
           Add
         </PrimaryActionButton>

--- a/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
+++ b/code/workspaces/web-app/src/components/settings/AddUserPermissions.js
@@ -128,7 +128,6 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
   } else if (selectedUser.userId === currentUserId && !currentUserSystemAdmin) {
     disabledMessage = 'You can not add permissions for yourself.';
   }
-  const disabled = selectedUser ? '' : 'disabled';
 
   return (
     <Tooltip title={disabledMessage} placement="top">
@@ -136,7 +135,7 @@ export function AddUserButton({ currentUserId, currentUserSystemAdmin, selectedU
         <PrimaryActionButton
           className={classes.addButton}
           onClick={() => onClickFn(projectKey, selectedUser, selectedPermissions, dispatch)}
-          disabled={disabled}
+          disabled={!selectedUser}
         >
           Add
         </PrimaryActionButton>

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.js
@@ -201,7 +201,7 @@ export function UserPermissionsTableRow({ user, isCurrentUser, currentUserSystem
   return (
     <TableRow key={rowKey}>
       <TableCell className={classes.tableCell} key={`${rowKey}-username`}>
-        <Typography variant="body1">{user.name}</Typography>
+        <Typography variant="body1">{user.name} ({(user.verified ? 'verified' : 'not verified')})</Typography>
       </TableCell>
       {checkBoxColumnOrder.map(permission => (
         <CheckboxCell

--- a/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
+++ b/code/workspaces/web-app/src/components/settings/UserPermissionsTable.spec.js
@@ -168,9 +168,10 @@ describe('UserPermissionsTableBody', () => {
     const users = {
       ...initialUsers,
       value: [
-        { name: 'admin name', userId: 'admin-user-id', role: 'admin' },
-        { name: 'user name', userId: 'user-user-id', role: 'user' },
-        { name: 'viewer name', userId: 'viewer-user-id', role: 'viewer' },
+        { name: 'admin name', userId: 'admin-user-id', role: 'admin', verified: true },
+        { name: 'user name', userId: 'user-user-id', role: 'user', verified: true },
+        { name: 'viewer name', userId: 'viewer-user-id', role: 'viewer', verified: true },
+        { name: 'unverified viewer name', userId: 'unverified-viewer-user-id', role: 'viewer', verified: false },
       ],
     };
 
@@ -235,7 +236,7 @@ describe('UserPermissionsTableRow', () => {
   };
 
   describe('for a given user', () => {
-    const user = { name: 'admin name', role: 'admin' };
+    const user = { name: 'admin name', role: 'admin', verified: true };
 
     it('correctly renders passing props to children when not current user', () => {
       expect(
@@ -296,7 +297,7 @@ describe('dispatchAddUserPermissions', () => {
     projectSettingsActions.addUserPermission.mockReturnValue('expected-result');
 
     const projectKey = 'project';
-    const user = { name: 'User One', userId: 'user-one-id' };
+    const user = { name: 'User One', userId: 'user-one-id', verified: true };
     const role = PERMISSIONS.ADMIN;
     const mockDispatch = jest.fn();
 
@@ -317,7 +318,7 @@ describe('dispatchRemoveUserPermissions', () => {
     projectSettingsActions.removeUserPermission.mockReturnValue('expected-result');
 
     const projectKey = 'project';
-    const user = { name: 'User One', userId: 'user-one-id' };
+    const user = { name: 'User One', userId: 'user-one-id', verified: true };
     const mockDispatch = jest.fn();
 
     dispatchRemoveUserPermissions(projectKey, user, mockDispatch);

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
@@ -3,19 +3,17 @@
 exports[`AddUserButton renders as disabled with explanatory tooltip when the selected user name is not in the list of possibilities 1`] = `
 <div>
   <div
-    aria-label="Please enter a registered user's email."
+    aria-label="Please enter a user's email."
     class=""
     data-mui-internal-clone-element="true"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+      disabled=""
+      tabindex="-1"
       type="button"
     >
       Add
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </div>

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
@@ -8,12 +8,14 @@ exports[`AddUserButton renders as disabled with explanatory tooltip when the sel
     data-mui-internal-clone-element="true"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-      disabled=""
-      tabindex="-1"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
       type="button"
     >
       Add
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
     </button>
   </div>
 </div>
@@ -27,12 +29,14 @@ exports[`AddUserButton when selected user is the current user renders as disable
     data-mui-internal-clone-element="true"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-      disabled=""
-      tabindex="-1"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
       type="button"
     >
       Add
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
     </button>
   </div>
 </div>
@@ -153,12 +157,14 @@ exports[`AddUserPermissions renders pure component with correct props 1`] = `
       data-mui-internal-clone-element="true"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium AddUserPermission-addButton-6 css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-        disabled=""
-        tabindex="-1"
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium AddUserPermission-addButton-6 css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
         type="button"
       >
         Add
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
       </button>
     </div>
   </div>

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
@@ -152,19 +152,17 @@ exports[`AddUserPermissions renders pure component with correct props 1`] = `
       </div>
     </div>
     <div
-      aria-label="Please enter a registered user's email."
+      aria-label="Please enter a user's email."
       class=""
       data-mui-internal-clone-element="true"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium AddUserPermission-addButton-6 css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium AddUserPermission-addButton-6 css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+        disabled=""
+        tabindex="-1"
         type="button"
       >
         Add
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/AddUserPermissions.spec.js.snap
@@ -27,14 +27,12 @@ exports[`AddUserButton when selected user is the current user renders as disable
     data-mui-internal-clone-element="true"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium addButton css-o0h1hg-MuiButtonBase-root-MuiButton-root"
+      disabled=""
+      tabindex="-1"
       type="button"
     >
       Add
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </div>

--- a/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
+++ b/code/workspaces/web-app/src/components/settings/__snapshots__/UserPermissionsTable.spec.js.snap
@@ -281,23 +281,26 @@ exports[`UserPermissionsTableBody when there are users correctly renders row for
             class="MuiTypography-root MuiTypography-body1 css-12gb3o9-MuiTypography-root"
           >
             admin name
+             (
+            verified
+            )
           </p>
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin"},"isCurrentUser":true,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-admin"}
+          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin","verified":true},"isCurrentUser":true,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-admin"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin"},"isCurrentUser":true,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-user"}
+          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin","verified":true},"isCurrentUser":true,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-user"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin"},"isCurrentUser":true,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-viewer"}
+          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin","verified":true},"isCurrentUser":true,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-0-viewer"}
         </td>
         <td>
           RemoveUserButtonCell mock 
-          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin"},"isCurrentUser":true,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
+          {"user":{"name":"admin name","userId":"admin-user-id","role":"admin","verified":true},"isCurrentUser":true,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
         </td>
       </tr>
       <tr
@@ -310,23 +313,26 @@ exports[`UserPermissionsTableBody when there are users correctly renders row for
             class="MuiTypography-root MuiTypography-body1 css-12gb3o9-MuiTypography-root"
           >
             user name
+             (
+            verified
+            )
           </p>
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"user name","userId":"user-user-id","role":"user"},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-admin"}
+          {"user":{"name":"user name","userId":"user-user-id","role":"user","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-admin"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"user name","userId":"user-user-id","role":"user"},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-user"}
+          {"user":{"name":"user name","userId":"user-user-id","role":"user","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-user"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"user name","userId":"user-user-id","role":"user"},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-viewer"}
+          {"user":{"name":"user name","userId":"user-user-id","role":"user","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-1-viewer"}
         </td>
         <td>
           RemoveUserButtonCell mock 
-          {"user":{"name":"user name","userId":"user-user-id","role":"user"},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
+          {"user":{"name":"user name","userId":"user-user-id","role":"user","verified":true},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
         </td>
       </tr>
       <tr
@@ -339,23 +345,58 @@ exports[`UserPermissionsTableBody when there are users correctly renders row for
             class="MuiTypography-root MuiTypography-body1 css-12gb3o9-MuiTypography-root"
           >
             viewer name
+             (
+            verified
+            )
           </p>
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer"},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-admin"}
+          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-admin"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer"},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-user"}
+          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-user"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer"},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-viewer"}
+          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-2-viewer"}
         </td>
         <td>
           RemoveUserButtonCell mock 
-          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer"},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
+          {"user":{"name":"viewer name","userId":"viewer-user-id","role":"viewer","verified":true},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
+        </td>
+      </tr>
+      <tr
+        class="MuiTableRow-root css-xbnhev-MuiTableRow-root"
+      >
+        <td
+          class="MuiTableCell-root MuiTableCell-sizeMedium tableCell css-1yyjf55-MuiTableCell-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-12gb3o9-MuiTypography-root"
+          >
+            unverified viewer name
+             (
+            not verified
+            )
+          </p>
+        </td>
+        <td>
+          CheckboxCell mock 
+          {"user":{"name":"unverified viewer name","userId":"unverified-viewer-user-id","role":"viewer","verified":false},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-3-admin"}
+        </td>
+        <td>
+          CheckboxCell mock 
+          {"user":{"name":"unverified viewer name","userId":"unverified-viewer-user-id","role":"viewer","verified":false},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-3-user"}
+        </td>
+        <td>
+          CheckboxCell mock 
+          {"user":{"name":"unverified viewer name","userId":"unverified-viewer-user-id","role":"viewer","verified":false},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"},"cellKey":"row-3-viewer"}
+        </td>
+        <td>
+          RemoveUserButtonCell mock 
+          {"user":{"name":"unverified viewer name","userId":"unverified-viewer-user-id","role":"viewer","verified":false},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableHeader":"tableHeader","tableCell":"tableCell"}}
         </td>
       </tr>
     </tbody>
@@ -425,23 +466,26 @@ exports[`UserPermissionsTableRow for a given user correctly renders passing prop
             class="MuiTypography-root MuiTypography-body1 css-12gb3o9-MuiTypography-root"
           >
             admin name
+             (
+            verified
+            )
           </p>
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","role":"admin"},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-admin"}
+          {"user":{"name":"admin name","role":"admin","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"admin","value":2},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-admin"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","role":"admin"},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-user"}
+          {"user":{"name":"admin name","role":"admin","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"user","value":1},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-user"}
         </td>
         <td>
           CheckboxCell mock 
-          {"user":{"name":"admin name","role":"admin"},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-viewer"}
+          {"user":{"name":"admin name","role":"admin","verified":true},"isCurrentUser":false,"checkboxSpec":{"name":"viewer","value":0},"projectKey":"projectKey","classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"},"cellKey":"row-2-viewer"}
         </td>
         <td>
           RemoveUserButtonCell mock 
-          {"user":{"name":"admin name","role":"admin"},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"}}
+          {"user":{"name":"admin name","role":"admin","verified":true},"isCurrentUser":false,"classes":{"activeSelection":"activeSelection","implicitSelection":"implicitSelection","tableCell":"tableCell"}}
         </td>
       </tr>
     </tbody>

--- a/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
+++ b/code/workspaces/web-app/src/containers/dataStorage/DataStorageContainer.js
@@ -120,6 +120,7 @@ class DataStorageContainer extends Component {
       userKeysMapping: {
         name: 'label',
         userId: 'value',
+        verified: 'verified',
       },
       stack,
       typeName: STORAGE_TYPE_NAME,

--- a/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
+++ b/code/workspaces/web-app/src/containers/dataStorage/__snapshots__/DataStorageContainer.spec.js.snap
@@ -56,6 +56,7 @@ Object {
   "userKeysMapping": Object {
     "name": "label",
     "userId": "value",
+    "verified": "verified",
   },
 }
 `;


### PR DESCRIPTION
This adds the backend and frontend changes to pre-create users and add them to a project.

Note to aid reviewing: the exclusion of unvalidated (ie pre-created) users from the autocomplete dropdowns of the Asset and Project Storage editor pages, can be reviewed by taking a look at this commit (its just a tiny change really): https://github.com/NERC-CEH/datalab/pull/949/commits/e56b90d40f5eaf9e234a51366bc4bbc391748879