### PR TITLE
Corrected link to 'how-to' docs for rstudio notebook warning message

### DIFF
--- a/code/workspaces/web-app/src/components/app/SuspendWarning.js
+++ b/code/workspaces/web-app/src/components/app/SuspendWarning.js
@@ -27,7 +27,7 @@ const styles = theme => ({
   },
 });
 
-const SuspendWarning = ({ classes, message }) => (
+const SuspendWarning = ({ classes, message, docId }) => (
   <div className={classes.message}>
     <ErrorOutlineIcon className={classes.icon} />
     <div className={classes.text}>
@@ -41,7 +41,7 @@ const SuspendWarning = ({ classes, message }) => (
           style={{ textDecoration: 'none' }}
           target="_blank"
           color="inherit"
-          href={`${extendSubdomain('docs')}/howto/suspend-and-restart-resources`}
+          href={`${extendSubdomain('docs')}/howto/${docId}`}
         >
             MORE
         </Link>
@@ -53,6 +53,7 @@ const SuspendWarning = ({ classes, message }) => (
 SuspendWarning.propTypes = {
   classes: PropTypes.object.isRequired,
   message: PropTypes.string.isRequired,
+  docId: PropTypes.string.isRequired,
 };
 
 export default withStyles(styles)(SuspendWarning);

--- a/code/workspaces/web-app/src/components/app/SuspendWarning.spec.js
+++ b/code/workspaces/web-app/src/components/app/SuspendWarning.spec.js
@@ -4,7 +4,7 @@ import SuspendWarning from './SuspendWarning';
 
 describe('SuspendWarning', () => {
   it('renders correct snapshot', () => {
-    const wrapper = render(<SuspendWarning message="message">{'expectedChild'}</SuspendWarning>);
+    const wrapper = render(<SuspendWarning message="message" docId="docId">{'expectedChild'}</SuspendWarning>);
     expect(wrapper.container).toMatchSnapshot();
   });
 });

--- a/code/workspaces/web-app/src/components/app/__snapshots__/SuspendWarning.spec.js.snap
+++ b/code/workspaces/web-app/src/components/app/__snapshots__/SuspendWarning.spec.js.snap
@@ -33,7 +33,7 @@ exports[`SuspendWarning renders correct snapshot 1`] = `
       >
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xdxgn1-MuiTypography-root-MuiLink-root"
-          href="http://localhost:undefined/howto/suspend-and-restart-resources"
+          href="http://localhost:undefined/howto/docId"
           style="text-decoration: none;"
           target="_blank"
         >

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -182,7 +182,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
           />
         </div>
       </div>
-      {NOTEBOOK_TYPE_NAME === typeName && warning.message && <SuspendWarning message={warning.message} docId={warning.docId}/>}
+      {NOTEBOOK_TYPE_NAME === typeName && warning.message && <SuspendWarning {...warning}/>}
     </div>
   );
 };

--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -110,7 +110,8 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
   const description = getDescription(stack, typeName);
   const expireStacks = getFeatureFlags().expireUnusedNotebooks;
 
-  const generateWarningMessage = () => {
+  const generateWarning = () => {
+    const warning = { message: '', docId: '' };
     if (expireStacks && stack.accessTime) {
       const { accessTimeWarning, inUseTimeWarning } = expireStacks;
       const daysSinceAccess = daysSinceCreation(stack.accessTime);
@@ -119,18 +120,20 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
       const inUseWarn = (hoursSinceAccess < inUseTimeWarning) && (stackTypes.RSTUDIO === stack.type);
       if (!warn) {
         if (inUseWarn) {
-          return `This notebook was opened ${hoursSinceAccess} hours ago and may still be in use.  Please be aware that opening
+          warning.message = `This notebook was opened ${hoursSinceAccess} hours ago and may still be in use.  Please be aware that opening
           it will close it for the other user.`;
+          warning.docId = 'rstudio-single-user-explanation';
         }
       } else {
-        return `This notebook has not been accessed for some time (${daysSinceAccess} days), please consider suspending
-          if not required. This warning will be dismissed if the notebook is opened.`;
+        warning.message = `This notebook has not been accessed for some time (${daysSinceAccess} days), please consider suspending
+        if not required. This warning will be dismissed if the notebook is opened.`;
+        warning.docId = 'suspend-and-restart-resources';
       }
     }
-    return '';
+    return warning;
   };
 
-  const warningMessage = generateWarningMessage();
+  const warning = generateWarning();
 
   const ResourceInfo = () => {
     if (typeName === NOTEBOOK_TYPE_NAME || typeName === SITE_TYPE_NAME) {
@@ -179,7 +182,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
           />
         </div>
       </div>
-      {NOTEBOOK_TYPE_NAME === typeName && warningMessage && <SuspendWarning message={warningMessage} />}
+      {NOTEBOOK_TYPE_NAME === typeName && warning.message && <SuspendWarning message={warning.message} docId={warning.docId}/>}
     </div>
   );
 };

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -42,18 +42,18 @@ exports[`StackCard a recently opened vscode notebook that should NOT have a RECE
           class="StackCard-statusDiv-82"
         >
           <div>
-            StackStatus mock 
+            StackStatus mock
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"vscode","status":"ready","shared":"private","accessTime":1556863200000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
-    
+
   </div>
 </div>
 `;
@@ -100,14 +100,14 @@ exports[`StackCard an rstudio notebook that should only have a NOT ACCESSED warn
           class="StackCard-statusDiv-67"
         >
           <div>
-            StackStatus mock 
+            StackStatus mock
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"rstudio","status":"ready","shared":"private","accessTime":1555142400000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
@@ -163,25 +163,25 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
 <div>
   <div>
     <div
-      class="StackCard-cardDiv-1"
+      class="StackCard-cardDiv-46"
     >
       <div
-        class="StackCard-imageDiv-2"
+        class="StackCard-imageDiv-47"
       >
         <img
           alt="rstudio logo"
-          class="StackCard-cardImage-8"
+          class="StackCard-cardImage-53"
           src="rstudio-logo.png"
         />
       </div>
       <div
-        class="StackCard-textDiv-3"
+        class="StackCard-textDiv-48"
       >
         <div
-          class="StackCard-displayNameContainer-5"
+          class="StackCard-displayNameContainer-50"
         >
           <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap StackCard-displayName-4 css-ltmxt9-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap StackCard-displayName-49 css-ltmxt9-MuiTypography-root"
           >
             name1
           </h5>
@@ -195,29 +195,29 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
         </p>
       </div>
       <div
-        class="StackCard-actionsDiv-6"
+        class="StackCard-actionsDiv-51"
       >
         <div
-          class="StackCard-statusDiv-7"
+          class="StackCard-statusDiv-52"
         >
           <div>
-            StackStatus mock 
+            StackStatus mock
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"rstudio","status":"ready","shared":"private","accessTime":1556863200000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
     <div
-      class="SuspendWarning-message-12"
+      class="SuspendWarning-message-57"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium SuspendWarning-icon-14 css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium SuspendWarning-icon-59 css-i4bv87-MuiSvgIcon-root"
         data-testid="ErrorOutlineIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -227,7 +227,7 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
         />
       </svg>
       <div
-        class="SuspendWarning-text-13"
+        class="SuspendWarning-text-58"
       >
         <p>
           This notebook was opened 2 hours ago and may still be in use.  Please be aware that opening
@@ -235,7 +235,7 @@ it will close it for the other user.
         </p>
       </div>
       <div
-        class="SuspendWarning-info-15"
+        class="SuspendWarning-info-60"
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-1lwtx1x-MuiButtonBase-root-MuiButton-root"
@@ -349,13 +349,13 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
         class="StackCard-actionsDiv-17"
       >
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"zeppelin","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
-    
+
   </div>
 </div>
 `;
@@ -407,9 +407,9 @@ exports[`StackCard creates correct snapshot for glusterfs stack type 1`] = `
         class="StackCard-actionsDiv-28"
       >
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"GLUSTERFS","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
@@ -459,18 +459,18 @@ exports[`StackCard should show status ad buttons when status is ready 1`] = `
           class="StackCard-statusDiv-41"
         >
           <div>
-            StackStatus mock 
+            StackStatus mock
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock 
+          StackCardActions mock
           {"stack":{"id":"100","displayName":"name1","type":"jupyter","status":"ready","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-           
+
         </div>
       </div>
     </div>
-    
+
   </div>
 </div>
 `;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -163,25 +163,25 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
 <div>
   <div>
     <div
-      class="StackCard-cardDiv-46"
+      class="StackCard-cardDiv-1"
     >
       <div
-        class="StackCard-imageDiv-47"
+        class="StackCard-imageDiv-2"
       >
         <img
           alt="rstudio logo"
-          class="StackCard-cardImage-53"
+          class="StackCard-cardImage-8"
           src="rstudio-logo.png"
         />
       </div>
       <div
-        class="StackCard-textDiv-48"
+        class="StackCard-textDiv-3"
       >
         <div
-          class="StackCard-displayNameContainer-50"
+          class="StackCard-displayNameContainer-5"
         >
           <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap StackCard-displayName-49 css-ltmxt9-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap StackCard-displayName-4 css-ltmxt9-MuiTypography-root"
           >
             name1
           </h5>
@@ -195,10 +195,10 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
         </p>
       </div>
       <div
-        class="StackCard-actionsDiv-51"
+        class="StackCard-actionsDiv-6"
       >
         <div
-          class="StackCard-statusDiv-52"
+          class="StackCard-statusDiv-7"
         >
           <div>
             StackStatus mock 
@@ -213,11 +213,11 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
       </div>
     </div>
     <div
-      class="SuspendWarning-message-57"
+      class="SuspendWarning-message-12"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium SuspendWarning-icon-59 css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium SuspendWarning-icon-14 css-i4bv87-MuiSvgIcon-root"
         data-testid="ErrorOutlineIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -227,7 +227,7 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
         />
       </svg>
       <div
-        class="SuspendWarning-text-58"
+        class="SuspendWarning-text-13"
       >
         <p>
           This notebook was opened 2 hours ago and may still be in use.  Please be aware that opening
@@ -235,7 +235,7 @@ it will close it for the other user.
         </p>
       </div>
       <div
-        class="SuspendWarning-info-60"
+        class="SuspendWarning-info-15"
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit css-1lwtx1x-MuiButtonBase-root-MuiButton-root"
@@ -244,7 +244,7 @@ it will close it for the other user.
         >
           <a
             class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xdxgn1-MuiTypography-root-MuiLink-root"
-            href="http://localhost:undefined/howto/suspend-and-restart-resources"
+            href="http://localhost:undefined/howto/rstudio-single-user-explanation"
             style="text-decoration: none;"
             target="_blank"
           >

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -42,18 +42,18 @@ exports[`StackCard a recently opened vscode notebook that should NOT have a RECE
           class="StackCard-statusDiv-82"
         >
           <div>
-            StackStatus mock
+            StackStatus mock 
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"vscode","status":"ready","shared":"private","accessTime":1556863200000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
-
+    
   </div>
 </div>
 `;
@@ -100,14 +100,14 @@ exports[`StackCard an rstudio notebook that should only have a NOT ACCESSED warn
           class="StackCard-statusDiv-67"
         >
           <div>
-            StackStatus mock
+            StackStatus mock 
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"rstudio","status":"ready","shared":"private","accessTime":1555142400000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
@@ -201,14 +201,14 @@ exports[`StackCard an rstudio notebook that should only have a RECENTLY OPENED w
           class="StackCard-statusDiv-52"
         >
           <div>
-            StackStatus mock
+            StackStatus mock 
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"rstudio","status":"ready","shared":"private","accessTime":1556863200000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
@@ -349,13 +349,13 @@ exports[`StackCard creates correct snapshot for Zeppelin stack type 1`] = `
         class="StackCard-actionsDiv-17"
       >
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"zeppelin","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
-
+    
   </div>
 </div>
 `;
@@ -407,9 +407,9 @@ exports[`StackCard creates correct snapshot for glusterfs stack type 1`] = `
         class="StackCard-actionsDiv-28"
       >
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"GLUSTERFS","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
@@ -459,18 +459,18 @@ exports[`StackCard should show status ad buttons when status is ready 1`] = `
           class="StackCard-statusDiv-41"
         >
           <div>
-            StackStatus mock
+            StackStatus mock 
             {"status":"ready"}
           </div>
         </div>
         <div>
-          StackCardActions mock
+          StackCardActions mock 
           {"stack":{"id":"100","displayName":"name1","type":"jupyter","status":"ready","shared":"private"},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
-
+           
         </div>
       </div>
     </div>
-
+    
   </div>
 </div>
 `;


### PR DESCRIPTION
When an rstudio notebook has recently been opened, a warning message is displayed when viewing notebooks in a project to alert the user to potentially interrupting the current user's access.  This message has a link on the 'more' button pointing to a docs page explaining more about it.  But the link was pointing to the wrong how-to doc, which (as you'll see when you review it) is because it was implemented as a change to the SuspendWarning component and only the message had been made dynamic, not the link.

This pull request corrects it.