### PR TITLE
docs: add documentation to add rwx provisioner in dev environment

### DIFF
--- a/code/development-env/README.md
+++ b/code/development-env/README.md
@@ -141,6 +141,24 @@ kubectl apply -f ./config/manifests/minikube-compute-submission-role.yml
 
 ```
 
+### Storage
+
+In order to emulate storage correctly in your development environment you can add a
+local RWX (ReadWriteMany) storage provisioner through the following. Note no data will
+be persisted in this configuration but pods should load correctly.
+
+```bash
+sudo apt install nfs-common
+
+# Deploy a local RWX (NFS Based) Storage Solution
+helm repo add nfs-ganesha-server-and-external-provisioner https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
+helm install nfs-server-provisioner nfs-ganesha-server-and-external-provisioner/nfs-server-provisioner \
+ --set storageClass.name="nfs-storage" \
+ --set storageClass.defaultClass=true \
+ --namespace nfs-server-provisioner \
+ --create-namespace
+```
+
 ### Docker Desktop
 
 If using Docker Desktop with Kubernetes instead of minikube, there are some alternative steps to the ones listed above.

--- a/code/development-env/config/local/storage_config.json
+++ b/code/development-env/config/local/storage_config.json
@@ -1,15 +1,5 @@
 {
   "types": {
-    "1": {
-      "displayValue": "GlusterFS",
-      "description": "Gluster File System (GlusterFS) volume to store data for Notebooks and Sites.",
-      "storageClass": "glusterfs-storage"
-    },
-    "GLUSTERFS": {
-      "displayValue": "GlusterFS",
-      "description": "Gluster File System (GlusterFS) volume to store data for Notebooks and Sites.",
-      "storageClass": "glusterfs-storage"
-    },
     "NFS": {
       "displayValue": "NFS",
       "description": "Network File System (NFS) volume to store data for Notebooks and Sites.",
@@ -18,9 +8,8 @@
   },
   "creationOptions": {
     "allowedTypes": [
-      "GLUSTERFS",
       "NFS"
     ],
-    "defaultType": "GLUSTERFS"
+    "defaultType": "NFS"
   }
 }


### PR DESCRIPTION
Adding documentation so developers can add a RWX storage provisioner should they wish to make sure they can make pods without manually editing resources