### PR TITLE
Added RStudio how-to page to content page of Docs 

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -68,6 +68,7 @@
 * [How to...](howto/README.md)
   * [Use the Asset Repo](howto/use-the-asset-repo/README.md)
   * [Suspend and Restart Resources](howto/suspend-and-restart-resources/README.md)
+  * [Collaborate on an RStudio notebook](howto/rstudio-single-user-explanation/README.md)
   * [Managing packages within R](r-libs/README.md)
     * [Packrat on Spark](r-libs/packrat_on_spark.md)
     * [Packrat within RStudio](r-libs/packrat_within_rstudio.md)

--- a/docs/src/howto/rstudio-single-user-explanation/README.md
+++ b/docs/src/howto/rstudio-single-user-explanation/README.md
@@ -1,14 +1,17 @@
 
-# Single use of a project's RStudio notebook #
+# Single user restriction of an RStudio notebook #
 
-## Why is this warning displayed? ##
+An RStudio notebook can only be opened by one user at a time.  This means that
+multiple users in a project cannot work on the same notebook simultaneously.
+The consequence of opening an RStudio notebook that someone else is currently
+using is to end their session.
 
-Currently, an Rstudio notebook in DataLabs does not support being opened in multiple
-instances.  This warning is displayed if the notebook you are about to open may be
-in use by another user.  If the notebook has been opened recently (eg within the last
-8 hours) then this warning is shown.  This is important because if you proceed
-to open the notebook then the current user will have their instance closed, causing
-some disruption to them.
+## How will I know if a notebook is in use ##
+
+The link to an RStudio notebook will display a warning if it has been opened recently
+(eg within the last 8 hours).  This indicates that it may be in use by another user.
+This is important because if you proceed to open the notebook then the current user will
+have their instance closed, causing some disruption to them.
 
 ## What does this warning look like ##
 
@@ -19,4 +22,4 @@ Here is an example of what this warning looks like.
 ## What should I do? ##
 
 If you are aware of a colleague who may be using the notebook, it would be prudent to
-discuss using it with them.
+discuss the best way to work together on it.


### PR DESCRIPTION
The 'howto/rstudio-single-user-explanation' page was missing from the contents list of Summary.md.  So the user could  not use the contents page to find it.  This pull request adds it to that contents list.  It should also fix the 403 and 404 errors when navigating directly to:

  - https://testlab-docs.test-datalabs.ceh.ac.uk/howto/rstudio-single-user-explanation/   (403)
  - https://testlab-docs.test-datalabs.ceh.ac.uk/howto/rstudio-single-user-explanation/index.html   (404)

The contents of /docs/src/howto/rstudio-single-user-explanation/README.md have been updated to make them sound more like a 'how-to' document - essentially 'how to collaborate on an RStudio notebook'.  The content has been reviewed by a product owner (Mike Hollaway).

