### PR TITLE
Rstudio notebook warning and Requested state

### DIFF
--- a/code/workspaces/web-app/src/components/stacks/StackCard.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { stackTypes } from 'common';
+import { stackTypes, statusTypes } from 'common';
 import ResourceInfoSpan from '../common/typography/ResourceInfoSpan';
 import StackCardActions from './StackCardActions/StackCardActions';
 import stackDescriptions from './stackDescriptions';
@@ -117,7 +117,7 @@ const StackCard = ({ classes, stack, openStack, deleteStack, editStack, restartS
       const daysSinceAccess = daysSinceCreation(stack.accessTime);
       const hoursSinceAccess = hoursSinceCreation(stack.accessTime);
       const warn = (daysSinceAccess > accessTimeWarning);
-      const inUseWarn = (hoursSinceAccess < inUseTimeWarning) && (stackTypes.RSTUDIO === stack.type);
+      const inUseWarn = (stackTypes.RSTUDIO === stack.type) && (statusTypes.READY === stack.status) && (hoursSinceAccess < inUseTimeWarning);
       if (!warn) {
         if (inUseWarn) {
           warning.message = `This notebook was opened ${hoursSinceAccess} hours ago and may still be in use.  Please be aware that opening

--- a/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
+++ b/code/workspaces/web-app/src/components/stacks/StackCard.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
+import { statusTypes } from 'common';
 import { render } from '../../testUtils/renderTests';
 import StackCard from './StackCard';
 import { storageDescription, storageDisplayValue } from '../../config/storage';
@@ -101,7 +102,7 @@ describe('StackCard', () => {
 
   it('should show status ad buttons when status is ready', () => {
     // Arrange
-    const props = generateProps('jupyter', 'ready');
+    const props = generateProps('jupyter', statusTypes.READY);
 
     // Act
     const output = render(<StackCard {...props} />).container;
@@ -114,7 +115,7 @@ describe('StackCard', () => {
     // Arrange
     const hoursSinceLastAccessed = 2;
     const lastAccessTime = Date.now() - (1000 * 60 * 60 * hoursSinceLastAccessed);
-    const props = generateProps('rstudio', 'ready', lastAccessTime);
+    const props = generateProps('rstudio', statusTypes.READY, lastAccessTime);
 
     // Act
     const output = render(<StackCard {...props} />).container;
@@ -127,7 +128,7 @@ describe('StackCard', () => {
     // Arrange
     const daysSinceLastAccessed = 20;
     const lastAccessTime = Date.now() - (1000 * 60 * 60 * 24 * daysSinceLastAccessed);
-    const props = generateProps('rstudio', 'ready', lastAccessTime);
+    const props = generateProps('rstudio', statusTypes.READY, lastAccessTime);
 
     // Act
     const output = render(<StackCard {...props} />).container;
@@ -140,7 +141,20 @@ describe('StackCard', () => {
     // Arrange
     const hoursSinceLastAccessed = 2;
     const lastAccessTime = Date.now() - (1000 * 60 * 60 * hoursSinceLastAccessed);
-    const props = generateProps('vscode', 'ready', lastAccessTime);
+    const props = generateProps('vscode', statusTypes.READY, lastAccessTime);
+
+    // Act
+    const output = render(<StackCard {...props} />).container;
+
+    // Assert
+    expect(output).toMatchSnapshot();
+  });
+
+  it('an rstudio notebook in "requested" state should NOT  have a RECENTLY OPENED warning', async () => {
+    // Arrange
+    const hoursSinceLastAccessed = 2;
+    const lastAccessTime = Date.now() - (1000 * 60 * 60 * hoursSinceLastAccessed);
+    const props = generateProps('rstudio', statusTypes.REQUESTED, lastAccessTime);
 
     // Act
     const output = render(<StackCard {...props} />).container;

--- a/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
+++ b/code/workspaces/web-app/src/components/stacks/__snapshots__/StackCard.spec.js.snap
@@ -58,6 +58,64 @@ exports[`StackCard a recently opened vscode notebook that should NOT have a RECE
 </div>
 `;
 
+exports[`StackCard an rstudio notebook in "requested" state should NOT  have a RECENTLY OPENED warning 1`] = `
+<div>
+  <div>
+    <div
+      class="StackCard-cardDiv-87"
+    >
+      <div
+        class="StackCard-imageDiv-88"
+      >
+        <img
+          alt="rstudio logo"
+          class="StackCard-cardImage-94"
+          src="rstudio-logo.png"
+        />
+      </div>
+      <div
+        class="StackCard-textDiv-89"
+      >
+        <div
+          class="StackCard-displayNameContainer-91"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-noWrap StackCard-displayName-90 css-ltmxt9-MuiTypography-root"
+          >
+            name1
+          </h5>
+        </div>
+        <p
+          aria-label="RStudio is an integrated development environment (IDE) for R. It includes a console, syntax-highlighting editor that supports direct code execution, as well as tools for plotting, history, debugging and workspace management."
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-yth3u7-MuiTypography-root"
+          data-mui-internal-clone-element="true"
+        >
+          RStudio is an integrated development environment (IDE) for R. It includes a console, syntax-highlighting editor that supports direct code execution, as well as tools for plotting, history, debugging and workspace management.
+        </p>
+      </div>
+      <div
+        class="StackCard-actionsDiv-92"
+      >
+        <div
+          class="StackCard-statusDiv-93"
+        >
+          <div>
+            StackStatus mock 
+            {"status":"requested"}
+          </div>
+        </div>
+        <div>
+          StackCardActions mock 
+          {"stack":{"id":"100","displayName":"name1","type":"rstudio","status":"requested","shared":"private","accessTime":1556863200000},"copySnippets":{},"userPermissions":["open","delete","edit"],"openPermission":"open","deletePermission":"delete","editPermission":"edit"}
+           
+        </div>
+      </div>
+    </div>
+    
+  </div>
+</div>
+`;
+
 exports[`StackCard an rstudio notebook that should only have a NOT ACCESSED warning 1`] = `
 <div>
   <div>


### PR DESCRIPTION
This change prevents an Rstudio notebook's recently opened message being shown when it is in the Requested state.