### PR TITLE
Add missing "1" key back to development-env's storage_config.json

### DIFF
--- a/code/development-env/config/local/storage_config.json
+++ b/code/development-env/config/local/storage_config.json
@@ -1,5 +1,10 @@
 {
   "types": {
+    "1": {
+      "displayValue": "NFS",
+      "description": "Network File System (NFS) volume to store data for Notebooks and Sites.",
+      "storageClass": "nfs-storage"
+    },
     "NFS": {
       "displayValue": "NFS",
       "description": "Network File System (NFS) volume to store data for Notebooks and Sites.",


### PR DESCRIPTION
This was preventing the admin pages from loading since it tried to look up that key.